### PR TITLE
feat(ci): Make PR cleanup workflow safe for merged PRs by deleting on…

### DIFF
--- a/.github/workflows/.tools-cleanup.yml
+++ b/.github/workflows/.tools-cleanup.yml
@@ -54,8 +54,24 @@ jobs:
             echo "Failed to find the pod after 5 attempts."
           fi
 
-      - name: Remove completed pods and jobs (cronjobs)
+      - name: Stop PR-specific CronJobs and clean PR resources
+        continue-on-error: true
         run: |
-          oc delete po --field-selector=status.phase==Succeeded
-          oc delete jobs --field-selector status.successful=1
-    
+          NS="${{ secrets.oc_namespace }}"
+          PR_NUMBER="${{ github.event.number }}"
+          oc project "$NS"
+
+          echo "Stopping CronJobs related to PR_$PR_NUMBER"
+          CRONJOBS=$(oc get cronjob -n "$NS" -l app=nr-waste-plus-tools \
+            -o jsonpath='{.items[?(@.metadata.name=="nr-waste-plus-tools-migratedb")].metadata.name}')
+          for CJ in $CRONJOBS; do
+            # Only stop the cronjob if it targets this PR
+            oc patch cronjob "$CJ" -p '{"spec":{"suspend":true}}'
+          done
+
+          echo "Deleting PR-specific Jobs and Pods"
+          oc delete job -l pr=$PR_NUMBER || true
+          oc delete pod -l pr=$PR_NUMBER || true
+
+          echo "Deleting PR-specific resources"
+          oc delete all,pvc,secret,cm -l pr=$PR_NUMBER || true


### PR DESCRIPTION
Update tools environment cleanup to: 
- suspend PR-specific CronJobs 
- remove only Jobs, Pods, and resources for the merged PR
- avoid affecting other PRs

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-26-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)