### PR TITLE
feat(ci): Fix tools cleanup

### DIFF
--- a/.github/workflows/.tools-cleanup.yml
+++ b/.github/workflows/.tools-cleanup.yml
@@ -10,6 +10,7 @@ jobs:
     name: Cleanup tools environment
     environment: tools
     runs-on: ubuntu-24.04
+
     steps:
       - name: Scale down legacy
         continue-on-error: true
@@ -19,9 +20,16 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           oc_server: ${{ secrets.oc_server }}
           commands: |
-            # Skip scaling if deployment doesn't exist
-            if oc get deployment "nr-waste-plus-${{ github.event.number }}-legacy" -n ${{ secrets.oc_namespace }} > /dev/null 2>&1; then
-              oc scale deployment/nr-waste-plus-${{ github.event.number }}-legacy --replicas=0 -n ${{ secrets.oc_namespace }}
+            NS="${{ secrets.oc_namespace }}"
+            DEPLOYMENT="nr-waste-plus-${{ github.event.number }}-legacy"
+
+            echo "Checking for legacy deployment $DEPLOYMENT in $NS..."
+
+            if oc get deployment "$DEPLOYMENT" -n "$NS" > /dev/null 2>&1; then
+              echo "Scaling $DEPLOYMENT to 0 replicas"
+              oc scale deployment "$DEPLOYMENT" --replicas=0 -n "$NS"
+            else
+              echo "Legacy deployment not found — skipping scale down"
             fi
 
       - name: Remove PR database and Oracle service
@@ -29,25 +37,29 @@ jobs:
         run: |
           NS="${{ secrets.oc_namespace }}"
           PR_NUMBER="${{ github.event.number }}"
+
           oc project "$NS"
 
           echo "Locating Oracle DB pod..."
-          POD_NAME=$(oc get pods -n "$NS" -l app=nr-waste-plus-tools -l deployment=nr-waste-plus-tools-legacydb \
-                     -o jsonpath='{.items[0].metadata.name}')
+          POD_NAME=$(oc get pods -n "$NS" \
+            -l app=nr-waste-plus-tools \
+            -l deployment=nr-waste-plus-tools-legacydb \
+            -o jsonpath='{.items[0].metadata.name}')
 
           if [ -z "$POD_NAME" ]; then
             echo "ERROR: Oracle DB pod not found in namespace $NS"
-            oc get pods
+            oc get pods -n "$NS"
             exit 0
           fi
 
           echo "Using Oracle DB pod: $POD_NAME"
 
           echo "Dropping PDB PR_$PR_NUMBER"
-          oc exec -n "$NS" "$POD_NAME" -- /opt/oracle/removeDatabase "THE" "PR_$PR_NUMBER" || true
+          oc exec -n "$NS" "$POD_NAME" -c nr-waste-plus -- \
+            /opt/oracle/removeDatabase "THE" "PR_$PR_NUMBER" || true
 
           echo "Deleting Oracle service PR_$PR_NUMBER"
-          oc exec -n "$NS" "$POD_NAME" -- sqlplus / as sysdba <<EOF
+          oc exec -n "$NS" "$POD_NAME" -c nr-waste-plus -- sqlplus / as sysdba <<EOF
           BEGIN
             DBMS_SERVICE.DELETE_SERVICE(service_name => 'PR_$PR_NUMBER');
           EXCEPTION
@@ -59,7 +71,7 @@ jobs:
           EOF
 
           echo "Remaining PR services:"
-          oc exec -n "$NS" "$POD_NAME" -- sqlplus / as sysdba <<EOF
+          oc exec -n "$NS" "$POD_NAME" -c nr-waste-plus -- sqlplus / as sysdba <<EOF
           SELECT name FROM v\\$services WHERE name LIKE 'PR_%';
           EXIT;
           EOF
@@ -71,6 +83,8 @@ jobs:
           PR_NUMBER="${{ github.event.number }}"
           oc project "$NS"
 
-          oc delete job -l pr=$PR_NUMBER || true
-          oc delete pod -l pr=$PR_NUMBER || true
-          oc delete all,pvc,secret,cm -l pr=$PR_NUMBER || true
+          echo "Deleting PR=$PR_NUMBER resources in $NS"
+
+          oc delete job  -l pr="$PR_NUMBER" || true
+          oc delete pod  -l pr="$PR_NUMBER" || true
+          oc delete all,pvc,secret,cm -l pr="$PR_NUMBER" || true


### PR DESCRIPTION
Previous cleanup workflow failed to delete PR services because it selected frontend pods and tried to run removeDatabase and sqlplus in the wrong container. This change:

- Skips scaling if legacy deployment doesn’t exist
- Finds the real Oracle DB pod by container name
- Drops the PR pluggable database
- Deletes the PR-specific Oracle service
- Logs remaining PR services for verification

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-38-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)