### PR TITLE
chore(be): Replaced deprecated Spring Security permissionsPolicy configuration

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/security/HeadersSecurityCustomizer.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/security/HeadersSecurityCustomizer.java
@@ -95,7 +95,6 @@ public class HeadersSecurityCustomizer implements Customizer<HeadersConfigurer<H
         // Set the Referrer-Policy header.
         .referrerPolicy(referrerPolicySpec -> referrerPolicySpec.policy(
             ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
-        
         // Set the Permissions-Policy header.
         .addHeaderWriter(new StaticHeadersWriter(
             "Permissions-Policy",


### PR DESCRIPTION
This change replaces the deprecated `permissionsPolicyHeader` configuration in Spring Security.

`HeadersConfigurer.permissionsPolicy(...)` has been deprecated and marked for removal in newer Spring Security versions. To avoid future compatibility issues, the `Permissions-Policy` header is now added using `StaticHeadersWriter`.

The behavior of the header remains the same — the application still sends the same `Permissions-Policy` directives — but it no longer relies on the deprecated Spring Security API.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-14-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)