### PR TITLE
chore(be): Fix usage of deprecated AuthorizationManager

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/security/HeadersSecurityCustomizer.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/security/HeadersSecurityCustomizer.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.XXssConfig;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
+import org.springframework.security.web.header.writers.StaticHeadersWriter;
 import org.springframework.stereotype.Component;
 
 /**
@@ -94,14 +95,13 @@ public class HeadersSecurityCustomizer implements Customizer<HeadersConfigurer<H
         // Set the Referrer-Policy header.
         .referrerPolicy(referrerPolicySpec -> referrerPolicySpec.policy(
             ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+        
         // Set the Permissions-Policy header.
-        .permissionsPolicyHeader(permissionsPolicySpec ->
-            permissionsPolicySpec.policy(
-                PERMISSIONS
-                    .stream()
-                    .map(permission -> String.format("%s=()", permission))
-                    .collect(Collectors.joining(", "))
-            )
-        );
+        .addHeaderWriter(new StaticHeadersWriter(
+            "Permissions-Policy",
+            PERMISSIONS.stream()
+                .map(permission -> String.format("%s=()", permission))
+                .collect(Collectors.joining(", "))
+        ));
   }
 }


### PR DESCRIPTION
Address Spring Security deprecation warning.

Spring Security deprecated AuthorizationManager.check(...) in favor of authorize(...)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-17-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)