### PR TITLE
fix(ci): use needs instead of steps for vars job output

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/.deploy.yml
     with:
       environment: test
-      target: ${{ steps.vars.outputs.pr }}
+      target: ${{ needs.vars.outputs.pr }}
       zone: test
       url: nr-waste-plus-test-frontend.apps.silver.devops.gov.bc.ca
       configmap-backend: |-
@@ -53,7 +53,7 @@ jobs:
     uses: ./.github/workflows/.deploy.yml
     with:
       environment: prod
-      target: ${{ steps.vars.outputs.pr }}
+      target: ${{ needs.vars.outputs.pr }}
       zone: prod
       url: wasteplus.nrs.gov.bc.ca
       configmap-backend: |-
@@ -78,7 +78,7 @@ jobs:
         with:
           registry: ghcr.io
           repository: ${{ github.repository }}/${{ matrix.component }}
-          target: ${{ steps.vars.outputs.pr }}
+          target: ${{ needs.vars.outputs.pr }}
           tags: prod
 
   release:


### PR DESCRIPTION
## Summary
- Fix invalid workflow references in `merge.yml` — `steps.vars.outputs.pr` was used instead of `needs.vars.outputs.pr` in three places where `vars` is a dependency job, not a step
- Affects `deploy-test`, `deploy-prod`, and `images-prod` jobs

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-32-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)