### PR TITLE
feat(#733): update MyClientListing to use RedirectLinkTag for client …

### DIFF
--- a/frontend/src/components/waste/MyClientListing/constants.tsx
+++ b/frontend/src/components/waste/MyClientListing/constants.tsx
@@ -2,9 +2,7 @@ import type { TableHeaderType } from '@/components/Form/TableResource/types';
 import type { MyForestClientDto } from '@/services/types';
 
 import DateTag from '@/components/core/Tags/DateTag';
-import RoleBasedRedirectLinkTag from '@/components/waste/RoleBasedRedirectLinkTag';
-import { Role } from '@/context/auth/types';
-import { env } from '@/env';
+import RedirectLinkTag from '@/components/waste/RedirectLinkTag';
 
 export const headers: TableHeaderType<MyForestClientDto>[] = [
   {
@@ -13,11 +11,7 @@ export const headers: TableHeaderType<MyForestClientDto>[] = [
     sortable: true,
     selected: true,
     renderAs: (value) => (
-      <RoleBasedRedirectLinkTag
-        text={value as string}
-        url={`${env.VITE_CLIENT_BASE_URL}/clients/details/${value}`}
-        allowedRoles={[Role.IDIR]}
-      />
+      <RedirectLinkTag text={value as string} url={`/search?clientNumbers=${value}`} sameTab />
     ),
   },
   { key: 'client.description', header: 'Client name', sortable: true, selected: true },

--- a/frontend/src/components/waste/MyClientListing/index.unit.test.tsx
+++ b/frontend/src/components/waste/MyClientListing/index.unit.test.tsx
@@ -2,6 +2,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 import MyClientListing from './index';
@@ -36,6 +37,11 @@ vi.mock('@/components/Form/TableResource', () => ({
         <div>Nothing to show yet!</div>
       );
     }
+
+    const getCellValue = (row: any, key: string): any => {
+      return key.split('.').reduce((obj, k) => obj?.[k], row);
+    };
+
     return (
       <div data-testid={id}>
         <table>
@@ -49,10 +55,10 @@ vi.mock('@/components/Form/TableResource', () => ({
           <tbody>
             {content.content.map((row: any) => (
               <tr key={row.id}>
-                <td>{row.client.code}</td>
-                <td>{row.client.description}</td>
-                <td>{row.submissionsCount}</td>
-                <td>{row.blocksCount}</td>
+                {headers.map((h: any) => {
+                  const value = getCellValue(row, h.key);
+                  return <td key={h.key}>{h.renderAs ? h.renderAs(value) : value}</td>;
+                })}
               </tr>
             ))}
           </tbody>
@@ -129,11 +135,13 @@ const renderWithProps = async () => {
   });
   await act(async () => {
     render(
-      <QueryClientProvider client={qc}>
-        <PreferenceProvider>
-          <MyClientListing />
-        </PreferenceProvider>
-      </QueryClientProvider>,
+      <MemoryRouter>
+        <QueryClientProvider client={qc}>
+          <PreferenceProvider>
+            <MyClientListing />
+          </PreferenceProvider>
+        </QueryClientProvider>
+      </MemoryRouter>,
     );
   });
 };
@@ -452,6 +460,29 @@ describe('MyClientListing', () => {
         // The component transforms data to add id from client.code
         expect(screen.getByText('00001001')).toBeDefined();
         expect(screen.getByText('00001002')).toBeDefined();
+      });
+    });
+
+    it('renders client code as a link to search page with client filter', async () => {
+      (APIs.forestclient.searchMyForestClients as Mock).mockResolvedValue(mockSearchResults);
+      await renderWithProps();
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: '00001001' });
+        expect(link).toBeDefined();
+        expect(link.getAttribute('href')).toBe('/search?clientNumbers=00001001');
+      });
+    });
+
+    it('renders all client codes as search links', async () => {
+      (APIs.forestclient.searchMyForestClients as Mock).mockResolvedValue(mockSearchResults);
+      await renderWithProps();
+
+      await waitFor(() => {
+        const link1 = screen.getByRole('link', { name: '00001001' });
+        const link2 = screen.getByRole('link', { name: '00001002' });
+        expect(link1.getAttribute('href')).toBe('/search?clientNumbers=00001001');
+        expect(link2.getAttribute('href')).toBe('/search?clientNumbers=00001002');
       });
     });
   });

--- a/frontend/src/components/waste/MyClientListing/index.unit.test.tsx
+++ b/frontend/src/components/waste/MyClientListing/index.unit.test.tsx
@@ -12,6 +12,7 @@ import type { MyForestClientDto } from '@/services/types';
 
 import { PreferenceProvider } from '@/context/preference/PreferenceProvider';
 import APIs from '@/services/APIs';
+import { renderCell } from '@/components/Form/TableResource/types';
 
 vi.mock('@/services/APIs');
 vi.mock('@/hooks/useSendEvent', () => ({
@@ -38,10 +39,6 @@ vi.mock('@/components/Form/TableResource', () => ({
       );
     }
 
-    const getCellValue = (row: any, key: string): any => {
-      return key.split('.').reduce((obj, k) => obj?.[k], row);
-    };
-
     return (
       <div data-testid={id}>
         <table>
@@ -55,10 +52,9 @@ vi.mock('@/components/Form/TableResource', () => ({
           <tbody>
             {content.content.map((row: any) => (
               <tr key={row.id}>
-                {headers.map((h: any) => {
-                  const value = getCellValue(row, h.key);
-                  return <td key={h.key}>{h.renderAs ? h.renderAs(value) : value}</td>;
-                })}
+                {headers.map((h: any) => (
+                  <td key={h.key}>{renderCell(row, h)}</td>
+                ))}
               </tr>
             ))}
           </tbody>

--- a/frontend/src/components/waste/RedirectLinkTag/index.tsx
+++ b/frontend/src/components/waste/RedirectLinkTag/index.tsx
@@ -1,4 +1,5 @@
 import { type FC } from 'react';
+import { Link } from 'react-router-dom';
 
 import EmptyValueTag from '@/components/core/Tags/EmptyValueTag';
 
@@ -9,15 +10,55 @@ type RedirectLinkTagProps = {
 };
 
 /**
- * Renders a link-like value, falling back to the shared empty-value presentation when needed.
+ * Determines whether a given URL should be treated as an internal application route.
+ *
+ * Internal links in this application are expected to be **path‑only** URLs,
+ * such as `/search?param=value` or `/details/1`. These URLs do not include a
+ * protocol or domain and should be handled by React Router to preserve SPA navigation.
+ *
+ * External links include a full domain (e.g., `https://google.com`) and should
+ * be rendered using a standard `<a>` element.
+ *
+ * @param url The URL to evaluate.
+ * @returns `true` if the URL is internal (path‑only), otherwise `false`.
+ */
+const isInternal = (url: string): boolean => {
+  try {
+    const parsed = new URL(url, globalThis.location.origin);
+    return parsed.origin === globalThis.location.origin;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Renders a link-like value that intelligently chooses between React Router's
+ * `<Link>` component for internal navigation and a standard `<a>` element for
+ * external URLs.
+ *
+ * Rules:
+ * - Internal URLs (path‑only, e.g., `/details/1`) use `<Link>` when `sameTab` is true.
+ * - External URLs (full domain, e.g., `https://example.com`) always use `<a>`.
+ * - `sameTab` controls whether the link opens in the current tab (`_self`)
+ *   or a new tab (`_blank`), regardless of internal/external.
  *
  * @param props The redirect link props.
- * @param props.text The link text to display.
+ * @param props.text The text to display inside the link.
  * @param props.url The target URL.
- * @param props.sameTab When true, opens the URL in the current tab.
- * @returns The rendered anchor element.
+ * @param props.sameTab When true, opens the link in the current tab.
+ * @returns The rendered link element.
  */
 const RedirectLinkTag: FC<RedirectLinkTagProps> = ({ text, url, sameTab }) => {
+  const internal = isInternal(url);
+
+  if (internal && sameTab) {
+    return (
+      <Link to={url}>
+        <EmptyValueTag value={text} />
+      </Link>
+    );
+  }
+
   return (
     <a
       href={url}

--- a/frontend/src/components/waste/RedirectLinkTag/index.tsx
+++ b/frontend/src/components/waste/RedirectLinkTag/index.tsx
@@ -23,12 +23,8 @@ type RedirectLinkTagProps = {
  * @returns `true` if the URL is internal (path‑only), otherwise `false`.
  */
 const isInternal = (url: string): boolean => {
-  try {
-    const parsed = new URL(url, globalThis.location.origin);
-    return parsed.origin === globalThis.location.origin;
-  } catch {
-    return false;
-  }
+  // Internal URLs are path-only: start with / but not // (protocol-relative)
+  return url.startsWith('/') && !url.startsWith('//');
 };
 
 /**

--- a/frontend/src/components/waste/RedirectLinkTag/index.unit.test.tsx
+++ b/frontend/src/components/waste/RedirectLinkTag/index.unit.test.tsx
@@ -34,4 +34,36 @@ describe('RedirectLinkTag', () => {
     expect(link.getAttribute('target')).toBe('_self');
     expect(link.getAttribute('rel')).toBe(null);
   });
+
+  it('treats absolute same-origin URLs as external (not path-only)', () => {
+    render(
+      <RedirectLinkTag
+        text="Absolute URL"
+        url="https://localhost:5173/details/1"
+        sameTab
+      />,
+    );
+    const link = screen.getByRole('link');
+    // Should render as anchor with _self, not as React Router Link
+    expect(link.getAttribute('href')).toBe('https://localhost:5173/details/1');
+    expect(link.getAttribute('target')).toBe('_self');
+    expect(link.getAttribute('rel')).toBe(null);
+  });
+
+  it('treats protocol-relative URLs as external', () => {
+    render(
+      <RedirectLinkTag text="Protocol-relative" url="//example.com/path" sameTab />,
+    );
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('href')).toBe('//example.com/path');
+    expect(link.getAttribute('target')).toBe('_self');
+  });
+
+  it('renders internal path-only URL in new tab as anchor with _blank', () => {
+    render(<RedirectLinkTag text="Internal Default" url="/search?term=wood" />);
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('href')).toBe('/search?term=wood');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
 });

--- a/frontend/src/components/waste/RedirectLinkTag/index.unit.test.tsx
+++ b/frontend/src/components/waste/RedirectLinkTag/index.unit.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect } from 'vitest';
 
 import RedirectLinkTag from './index';
@@ -13,12 +14,24 @@ describe('RedirectLinkTag', () => {
     expect(screen.getByText('Go')).toBeDefined();
   });
 
-  it('renders link with text and opens in same tab if sameTab is true', () => {
-    render(<RedirectLinkTag text="Stay" url="/local" sameTab />);
+  it('renders a React Router link for internal URL in same tab', () => {
+    render(
+      <MemoryRouter>
+        <RedirectLinkTag text="Stay" url="/local" sameTab />
+      </MemoryRouter>,
+    );
     const link = screen.getByRole('link');
     expect(link.getAttribute('href')).toBe('/local');
-    expect(link.getAttribute('target')).toBe('_self');
+    expect(link.getAttribute('target')).toBe(null);
     expect(link.getAttribute('rel')).toBe(null);
     expect(screen.getByText('Stay')).toBeDefined();
+  });
+
+  it('renders external URL in same tab as anchor with _self target', () => {
+    render(<RedirectLinkTag text="External" url="https://example.com/path" sameTab />);
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('href')).toBe('https://example.com/path');
+    expect(link.getAttribute('target')).toBe('_self');
+    expect(link.getAttribute('rel')).toBe(null);
   });
 });

--- a/frontend/src/pages/MyClientList/index.e2e.test.tsx
+++ b/frontend/src/pages/MyClientList/index.e2e.test.tsx
@@ -168,9 +168,8 @@ test.describe('My Client List Page', () => {
     await expect(page.getByRole('heading', { name: 'My clients' })).toBeVisible();
   });
 
-  test('should render a link to the client details page on the Client application', async ({
+  test('should navigate to search page with selected client number in same tab', async ({
     page,
-    context,
   }, testInfo) => {
     test.skip(testInfo.project.metadata.userType !== 'idir', 'Only runs for IDIR project');
     test.skip(!canOverrideClaims(), 'Per-test role override requires VITE_MOCK_AUTH=true.');
@@ -190,12 +189,8 @@ test.describe('My Client List Page', () => {
     const href = await clientLink.getAttribute('href');
     expect(href).toContain('/search?clientNumbers=90000001');
 
-    const [newPage] = await Promise.all([context.waitForEvent('page'), clientLink.click()]);
+    await clientLink.click();
 
-    await newPage.waitForLoadState();
-
-    await expect(
-      newPage.getByRole('heading', { name: 'Forests Client Management System' }),
-    ).toBeVisible();
+    await expect(page).toHaveURL(/\/search\?clientNumbers=90000001/);
   });
 });

--- a/frontend/src/pages/MyClientList/index.e2e.test.tsx
+++ b/frontend/src/pages/MyClientList/index.e2e.test.tsx
@@ -49,17 +49,20 @@ test.describe('My Client List Page', () => {
     await expect(page.getByRole('cell', { name: 'CANADIAN SAMPLE CO.' }).first()).toBeVisible();
   });
 
-  test('should not render the client number as a link', async ({ page }) => {
+  test('should render the client number as a link to search with client filter', async ({
+    page,
+  }) => {
     test.skip(
       !hasClientAccessRole(test.info().project.metadata.userType),
       'Only runs for users with Viewer/Submitter access',
     );
 
-    // The client number is rendered on the table
-    await expect(page.getByRole('cell', { name: '90000001' })).toBeVisible();
+    // The client number should be rendered as a link
+    const clientLink = page.getByRole('link', { name: '90000001' });
+    await expect(clientLink).toBeVisible();
 
-    // But it's not a link
-    await expect(page.getByRole('link', { name: '90000001' })).toHaveCount(0);
+    // The link should navigate to search page with client number filter
+    await expect(clientLink).toHaveAttribute('href', '/search?clientNumbers=90000001');
   });
 
   test('should allow column selection', async ({ page }) => {

--- a/frontend/src/pages/MyClientList/index.e2e.test.tsx
+++ b/frontend/src/pages/MyClientList/index.e2e.test.tsx
@@ -188,7 +188,7 @@ test.describe('My Client List Page', () => {
     await expect(clientLink).toBeVisible();
 
     const href = await clientLink.getAttribute('href');
-    expect(href).toContain('/clients/details/90000001');
+    expect(href).toContain('/search?clientNumbers=90000001');
 
     const [newPage] = await Promise.all([context.waitForEvent('page'), clientLink.click()]);
 


### PR DESCRIPTION
…links and enhance tests

<!-- Provide a general summary of your changes in the Title above -->

# Description


Updates client-number links in **MyClientListing** to navigate internally via React Router (to Waste Search with a prefilled `clientNumbers` filter), and expands unit tests accordingly.

**Changes:**
- Update `RedirectLinkTag` to render a React Router `<Link>` for internal URLs when `sameTab` is enabled.
- Change `MyClientListing` client code column to link to `/search?clientNumbers=...` using `RedirectLinkTag`.
- Enhance unit tests for `RedirectLinkTag` and `MyClientListing` (including router context in renders).
- Fixes #733 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-37-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)