### PR TITLE
fix(#731): font size on table

### DIFF
--- a/frontend/src/components/Form/ReadonlyInput/index.scss
+++ b/frontend/src/components/Form/ReadonlyInput/index.scss
@@ -13,7 +13,7 @@
   }
 
   .card-item-content {
-    @include type.type-style('body-compact-02');
+    @include type.type-style('body-compact-01');
     width: 100%;
     word-break: break-word;
 
@@ -25,6 +25,5 @@
   .card-item-content-number {
     @extend .card-item-content;
     @include type.type-style('code-02');
-    font-size: 1rem;
   }
 }

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTableExpandContent/index.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTableExpandContent/index.tsx
@@ -252,11 +252,11 @@ const WasteSearchTableExpandContent: FC<WasteSearchTableExpandContentProps> = ({
           <EmptyValueTag value={data?.comments ?? ''} />
         </ReadonlyInput>
       </Column>
-      <Column lg={2} md={2} sm={4}>
-        <p>No. of blocks in RU: {data?.totalBlocks ?? 0}</p>
+      <Column lg={3} md={3} sm={4}>
+        <p>Blocks in the RU: {data?.totalBlocks ?? 0}</p>
       </Column>
-      <Column lg={14} md={6} sm={4}>
-        <p>No. of secondary marks in block: {data?.totalChildren ?? 0}</p>
+      <Column lg={13} md={5} sm={4}>
+        <p>Secondary marks in the block: {data?.totalChildren ?? 0}</p>
       </Column>
     </Grid>
   );

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTableExpandContent/index.unit.test.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTableExpandContent/index.unit.test.tsx
@@ -172,7 +172,7 @@ describe('WasteSearchTableExpandContent', () => {
       await renderWithProps(rowId);
 
       await waitFor(() => {
-        expect(screen.getByText('No. of blocks in RU: 5')).toBeDefined();
+        expect(screen.getByText('Blocks in the RU: 5')).toBeDefined();
       });
     });
 
@@ -331,35 +331,6 @@ describe('WasteSearchTableExpandContent', () => {
       });
     });
 
-    it('renders multi-mark as Yes when true', async () => {
-      const dataWithTrue: ReportingUnitSearchExpandedDto = {
-        ...mockExpandedData,
-        multiMark: true,
-      };
-      (APIs.search.getReportingUnitSearchExpand as Mock).mockResolvedValue(dataWithTrue);
-
-      const rowId = 'RU-4069-Block-411B-224813681';
-      await renderWithProps(rowId);
-
-      await waitFor(() => {
-        expect(APIs.search.getReportingUnitSearchExpand).toHaveBeenCalled();
-      });
-    });
-
-    it('renders multi-mark as No when false', async () => {
-      const dataWithFalse: ReportingUnitSearchExpandedDto = {
-        ...mockExpandedData,
-        multiMark: false,
-      };
-      (APIs.search.getReportingUnitSearchExpand as Mock).mockResolvedValue(dataWithFalse);
-
-      const rowId = 'RU-4069-Block-411B-224813681';
-      await renderWithProps(rowId);
-
-      await waitFor(() => {
-        expect(APIs.search.getReportingUnitSearchExpand).toHaveBeenCalled();
-      });
-    });
   });
 
   describe('attachment handling', () => {
@@ -450,7 +421,6 @@ describe('WasteSearchTableExpandContent', () => {
         expect(container.querySelector(`#${rowId}-cutting-permit`)).toBeDefined();
         expect(container.querySelector(`#${rowId}-timber-mark`)).toBeDefined();
         expect(container.querySelector(`#${rowId}-exempted`)).toBeDefined();
-        expect(container.querySelector(`#${rowId}-multi-mark`)).toBeDefined();
         expect(container.querySelector(`#${rowId}-net-area`)).toBeDefined();
         expect(container.querySelector(`#${rowId}-submitter`)).toBeDefined();
         expect(container.querySelector(`#${rowId}-attachments-comments`)).toBeDefined();
@@ -537,7 +507,7 @@ describe('WasteSearchTableExpandContent', () => {
         expect(screen.getByText('LIC-12345')).toBeDefined();
         expect(screen.getByText('Cutting Permit')).toBeDefined();
         expect(screen.getByText('CP-001')).toBeDefined();
-        expect(screen.getByText('No. of blocks in RU: 5')).toBeDefined();
+        expect(screen.getByText('Blocks in the RU: 5')).toBeDefined();
       });
     });
 
@@ -567,7 +537,7 @@ describe('WasteSearchTableExpandContent', () => {
       await renderWithProps(rowId);
 
       await waitFor(() => {
-        expect(screen.getByText('No. of blocks in RU: 0')).toBeDefined();
+        expect(screen.getByText('Blocks in the RU: 0')).toBeDefined();
       });
     });
 
@@ -623,7 +593,7 @@ describe('WasteSearchTableExpandContent', () => {
       await renderWithProps(rowId);
 
       await waitFor(() => {
-        expect(screen.getByText('No. of secondary marks in block: 3')).toBeDefined();
+        expect(screen.getByText('Secondary marks in the block: 3')).toBeDefined();
       });
     });
 

--- a/frontend/src/pages/WasteSearch/expanded-row.e2e.test.tsx
+++ b/frontend/src/pages/WasteSearch/expanded-row.e2e.test.tsx
@@ -50,7 +50,7 @@ test.describe('Waste Search - Expanded Row Content', () => {
       'Comment:This is a sample comment for the reporting unit.',
     ); // comments
     await expect(page.getByRole('link', { name: /Link/i })).toBeVisible(); // attachments and comments link
-    await expect(page.getByText('No. of blocks in RU: 15')).toBeVisible(); // totalBlocks
+    await expect(page.getByText('Blocks in the RU: 15')).toBeVisible(); // totalBlocks
   });
 
   test('handles missing attachment and comment correctly', async ({ page }) => {
@@ -89,7 +89,7 @@ test.describe('Waste Search - Expanded Row Content', () => {
       String.raw`BCEID\\BMO`,
     ); // submitter
     await expect(page.getByTestId('card-item-comment:')).toHaveText('Comment:-'); // comments
-    await expect(page.getByText('No. of blocks in RU: 2')).toBeVisible(); // totalBlocks
+    await expect(page.getByText('Blocks in the RU: 2')).toBeVisible(); // totalBlocks
 
     // Verify attachments and comments link is present
     const attachmentsCommentsLinks = page.getByRole('link', {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Updates Waste Search expanded-row display text/layout and adjusts read-only field typography so the table/expanded content renders at the intended font size, with tests updated to match.

**Changes:**
- Adjust `ReadonlyInput` content typography (and remove a hard-coded numeric font-size override).
- Update expanded-row labels/column widths for “Blocks in the RU” and “Secondary marks in the block”.
- Update unit + e2e tests to match the new UI strings and remove outdated multi-mark assertions.
- Fixes #731 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] Updated existing tests

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-38-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)