### PR TITLE
fix(#770): Stabilize `user.roles` reference in AuthProvider to prevent unnecessary router recreation

### DIFF
--- a/frontend/src/context/auth/AuthProvider.tsx
+++ b/frontend/src/context/auth/AuthProvider.tsx
@@ -10,13 +10,21 @@ import { signOutUrl } from '@/config/fam/config';
 import { env } from '@/env';
 import { navigateTo } from '@/utils/navigation';
 
+/**
+ * Preserves the existing roles array reference when the next auth user has the
+ * same effective role assignments, avoiding unnecessary downstream recomputation.
+ *
+ * @param previousUser The previously cached authenticated user.
+ * @param nextUser The next authenticated user produced from token refresh.
+ * @returns The next user, reusing the previous roles reference when safe.
+ */
 export const preserveRolesReference = (
   previousUser: FamLoginUser | undefined,
   nextUser: FamLoginUser | undefined,
 ): FamLoginUser | undefined => {
   if (!previousUser || !nextUser) return nextUser;
-  if (!isEqual(previousUser.roles, nextUser.roles)) return nextUser;
   if (previousUser.roles === nextUser.roles) return nextUser;
+  if (!isEqual(previousUser.roles, nextUser.roles)) return nextUser;
 
   return {
     ...nextUser,

--- a/frontend/src/context/auth/AuthProvider.tsx
+++ b/frontend/src/context/auth/AuthProvider.tsx
@@ -10,6 +10,20 @@ import { signOutUrl } from '@/config/fam/config';
 import { env } from '@/env';
 import { navigateTo } from '@/utils/navigation';
 
+const preserveRolesReference = (
+  previousUser: FamLoginUser | undefined,
+  nextUser: FamLoginUser | undefined,
+): FamLoginUser | undefined => {
+  if (!previousUser || !nextUser) return nextUser;
+  if (!isEqual(previousUser.roles, nextUser.roles)) return nextUser;
+  if (previousUser.roles === nextUser.roles) return nextUser;
+
+  return {
+    ...nextUser,
+    roles: previousUser.roles,
+  };
+};
+
 /**
  * Provides authenticated user state and auth actions to the application tree.
  *
@@ -47,7 +61,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       try {
         const idToken = await loadUserToken();
         const newUser = idToken ? parseToken(idToken) : undefined;
-        setUser((prev) => (isEqual(prev, newUser) ? prev : newUser));
+        setUser((prev) => {
+          if (isEqual(prev, newUser)) return prev;
+          return preserveRolesReference(prev, newUser);
+        });
       } catch {
         setUser(undefined);
         if (!silent) await signOut();

--- a/frontend/src/context/auth/AuthProvider.tsx
+++ b/frontend/src/context/auth/AuthProvider.tsx
@@ -10,7 +10,7 @@ import { signOutUrl } from '@/config/fam/config';
 import { env } from '@/env';
 import { navigateTo } from '@/utils/navigation';
 
-const preserveRolesReference = (
+export const preserveRolesReference = (
   previousUser: FamLoginUser | undefined,
   nextUser: FamLoginUser | undefined,
 ): FamLoginUser | undefined => {

--- a/frontend/src/context/auth/AuthProvider.unit.test.tsx
+++ b/frontend/src/context/auth/AuthProvider.unit.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeAll } from 'vitest';
 
 import { AuthContext } from './AuthContext';
 import { AuthProvider, preserveRolesReference } from './AuthProvider';
+import { Role, type FamLoginUser, type FamRole } from './types';
 
 import { jwtfy } from '@/config/tests/auth.helper';
 import { navigateTo } from '@/utils/navigation';
@@ -168,9 +169,9 @@ describe('AuthProvider (extra coverage)', () => {
 });
 
 describe('preserveRolesReference', () => {
-  const mockRoles = [{ role: 'VIEWER', clients: ['100'] }];
-  const mockRoles2 = [{ role: 'ADMIN', clients: ['200'] }];
-  const mockUser = {
+  const mockRoles: FamRole[] = [{ role: Role.VIEWER, clients: ['100'] }];
+  const mockRoles2: FamRole[] = [{ role: Role.ADMIN, clients: ['200'] }];
+  const mockUser: FamLoginUser = {
     userName: 'testuser',
     displayName: 'Test User',
     email: 'test@example.com',
@@ -203,8 +204,8 @@ describe('preserveRolesReference', () => {
   });
 
   it('preserves previous roles reference when role content is equal but reference differs', () => {
-    const previousRoles = [{ role: 'VIEWER', clients: ['100'] }];
-    const nextRoles = [{ role: 'VIEWER', clients: ['100'] }];
+    const previousRoles: FamRole[] = [{ role: Role.VIEWER, clients: ['100'] }];
+    const nextRoles: FamRole[] = [{ role: Role.VIEWER, clients: ['100'] }];
     const previousUser = { ...mockUser, roles: previousRoles };
     const nextUser = { ...mockUser, roles: nextRoles };
 
@@ -227,7 +228,7 @@ describe('preserveRolesReference', () => {
   });
 
   it('preserves roles while updating other user fields', () => {
-    const sharedRoles = [{ role: 'SUBMITTER', clients: ['300'] }];
+    const sharedRoles: FamRole[] = [{ role: Role.SUBMITTER, clients: ['300'] }];
     const previousUser = {
       ...mockUser,
       roles: sharedRoles,

--- a/frontend/src/context/auth/AuthProvider.unit.test.tsx
+++ b/frontend/src/context/auth/AuthProvider.unit.test.tsx
@@ -3,7 +3,7 @@ import { render, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 
 import { AuthContext } from './AuthContext';
-import { AuthProvider } from './AuthProvider';
+import { AuthProvider, preserveRolesReference } from './AuthProvider';
 
 import { jwtfy } from '@/config/tests/auth.helper';
 import { navigateTo } from '@/utils/navigation';
@@ -164,5 +164,84 @@ describe('AuthProvider (extra coverage)', () => {
       expect(getUserTokenFromCookie).toHaveBeenCalled();
       expect(context.user.token.payload).toEqual(payload);
     });
+  });
+});
+
+describe('preserveRolesReference', () => {
+  const mockRoles = [{ role: 'VIEWER', clients: ['100'] }];
+  const mockRoles2 = [{ role: 'ADMIN', clients: ['200'] }];
+  const mockUser = {
+    userName: 'testuser',
+    displayName: 'Test User',
+    email: 'test@example.com',
+    roles: mockRoles,
+    privileges: {},
+  };
+
+  it('returns nextUser when previousUser is undefined', () => {
+    const nextUser = { ...mockUser, roles: mockRoles };
+    const result = preserveRolesReference(undefined, nextUser);
+    expect(result).toBe(nextUser);
+  });
+
+  it('returns nextUser when nextUser is undefined', () => {
+    const result = preserveRolesReference(mockUser, undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns nextUser when both are undefined', () => {
+    const result = preserveRolesReference(undefined, undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns nextUser when role content differs', () => {
+    const previousUser = { ...mockUser, roles: mockRoles };
+    const nextUser = { ...mockUser, roles: mockRoles2 };
+    const result = preserveRolesReference(previousUser, nextUser);
+    expect(result).toBe(nextUser);
+    expect(result?.roles).toBe(mockRoles2);
+  });
+
+  it('preserves previous roles reference when role content is equal but reference differs', () => {
+    const previousRoles = [{ role: 'VIEWER', clients: ['100'] }];
+    const nextRoles = [{ role: 'VIEWER', clients: ['100'] }];
+    const previousUser = { ...mockUser, roles: previousRoles };
+    const nextUser = { ...mockUser, roles: nextRoles };
+
+    const result = preserveRolesReference(previousUser, nextUser);
+
+    expect(result).toBeDefined();
+    expect(result?.roles).toBe(previousRoles);
+    expect(result?.roles).not.toBe(nextRoles);
+    expect(result?.userName).toBe(nextUser.userName);
+  });
+
+  it('returns nextUser unchanged when roles reference is already the same', () => {
+    const sharedRoles = mockRoles;
+    const previousUser = { ...mockUser, roles: sharedRoles };
+    const nextUser = { ...mockUser, roles: sharedRoles };
+
+    const result = preserveRolesReference(previousUser, nextUser);
+
+    expect(result).toBe(nextUser);
+  });
+
+  it('preserves roles while updating other user fields', () => {
+    const sharedRoles = [{ role: 'SUBMITTER', clients: ['300'] }];
+    const previousUser = {
+      ...mockUser,
+      roles: sharedRoles,
+      email: 'old@example.com',
+    };
+    const nextUser = {
+      ...mockUser,
+      roles: sharedRoles,
+      email: 'new@example.com',
+    };
+
+    const result = preserveRolesReference(previousUser, nextUser);
+
+    expect(result?.roles).toBe(sharedRoles);
+    expect(result?.email).toBe('new@example.com');
   });
 });

--- a/frontend/src/context/auth/AuthProvider.unit.test.tsx
+++ b/frontend/src/context/auth/AuthProvider.unit.test.tsx
@@ -113,6 +113,7 @@ describe('AuthProvider (extra coverage)', () => {
       await waitFor(() => expect(context).toBeDefined());
       expect(context.userToken()).toBe('sometoken');
     });
+
   });
 
   describe('when VITE_MOCK_AUTH is true', () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

## Description

This PR stabilizes the `user.roles` array reference in `AuthProvider` to prevent unnecessary route recomputation on silent token refresh cycles.

**Problem:** Every 3 minutes, `AuthProvider` performs a silent refresh of the user's authentication token. During this refresh, `parseToken` constructs a new `FamLoginUser` object with a new `roles` array, even when the role content is identical. In `AppRoutes.tsx`, the router is memoized with `user?.roles` as a dependency. Because the `roles` array reference changes on every refresh, `createBrowserRouter` is invoked unnecessarily, causing potential navigation state loss and subtle rendering issues.

**Solution:** Added a `preserveRolesReference` helper in `AuthProvider` that detects when role content is structurally equal but the reference has changed, and preserves the previous reference when appropriate. This prevents the `useMemo` in `AppRoutes` from invalidating on role-content-unchanged refreshes.

Fixes #770 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update 

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] New unit tests
- [x] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


This is a targeted, low-risk fix that operates entirely within the auth provider layer. The `preserveRolesReference` helper is co-located with the refresh logic and has zero impact on the public API or router behaviour when roles actually change.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-21-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)