### PR TITLE
feat(#777): switching from id token to access token

### DIFF
--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -34,6 +34,9 @@ parameters:
   - name: COGNITO_REGION
     description: Cognito region to be used
     value: 'ca-central-1'
+  - name: COGNITO_DOMAIN
+    description: Cognito domain to be used
+    value: 'lza-prod-fam-user-pool-domain'
   - name: FRONTEND_URL
     description: Frontend URL
     required: true
@@ -111,6 +114,8 @@ objects:
                       key: cognito-user-pool
                 - name: COGNITO_REGION
                   value: ${COGNITO_REGION}
+                - name: COGNITO_DOMAIN
+                  value: ${COGNITO_DOMAIN}
                 - name: TZ
                   value: America/Vancouver
                 - name: APP_ZONE

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/configuration/GlobalConfiguration.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/configuration/GlobalConfiguration.java
@@ -7,6 +7,7 @@ import ca.bc.gov.nrs.hrs.dto.client.ForestClientDto;
 import ca.bc.gov.nrs.hrs.dto.client.ForestClientLocationDto;
 import ca.bc.gov.nrs.hrs.dto.search.ReportingUnitSearchParametersDto;
 import ca.bc.gov.nrs.hrs.dto.search.ReportingUnitSearchResultDto;
+import ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity;
 import ca.bc.gov.nrs.hrs.entity.users.UserPreferenceEntity;
 import ca.bc.gov.nrs.hrs.exception.ForestClientNotFoundException;
 import ca.bc.gov.nrs.hrs.exception.NotFoundGenericException;
@@ -48,6 +49,7 @@ import tools.jackson.databind.json.JsonMapper.Builder;
     CodeDescriptionDto.class,
     CodeNameDto.class,
     UserPreferenceEntity.class,
+    UserIdentityEntity.class,
     ForestClientNotFoundException.class,
     NotFoundGenericException.class,
     RequestException.class,
@@ -61,6 +63,31 @@ import tools.jackson.databind.json.JsonMapper.Builder;
 })
 @EnableJpaAuditing(auditorAwareRef = "databaseAuditor")
 public class GlobalConfiguration {
+
+  /**
+   * Builds a {@link RestClient} configured to call the Cognito userInfo endpoint.
+   *
+   * <p>The base URL is set to the configured Cognito userInfo URI from
+   * {@link HrsConfiguration}. B3 trace headers are forwarded to Cognito via
+   * the supplied {@link B3HeaderForwarder}. No default Authorization header is
+   * set here — each call supplies its own Bearer token.
+   * </p>
+   *
+   * @param configuration application configuration providing the Cognito userInfo URI
+   * @param b3Header      request initializer that forwards B3 trace headers
+   * @return a configured {@link RestClient} for the Cognito userInfo endpoint
+   */
+  @Bean
+  public RestClient cognitoApi(
+      HrsConfiguration configuration,
+      B3HeaderForwarder b3Header
+  ) {
+    return RestClient
+        .builder()
+        .baseUrl(configuration.getCognito().getUserinfoUri())
+        .requestInitializer(b3Header)
+        .build();
+  }
 
   /**
    * Builds a {@link RestClient} configured to call the Forest Client API.

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/configuration/HrsConfiguration.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/configuration/HrsConfiguration.java
@@ -47,6 +47,18 @@ public class HrsConfiguration {
   private FrontEndConfiguration frontend;
 
   /**
+   * Cognito-specific configuration (userInfo URI and identity TTL).
+   */
+  @NestedConfigurationProperty
+  private CognitoConfiguration cognito;
+
+  /**
+   * Identity hydration configuration (which paths trigger hydration).
+   */
+  @NestedConfigurationProperty
+  private HydrationConfiguration hydration;
+
+  /**
    * External API address configuration.
    *
    * <p>Holds the remote service base URL and an optional API key used to
@@ -130,6 +142,52 @@ public class HrsConfiguration {
      * to the configured frontend URL(s) when setting up CORS mappings for API endpoints.
      */
     private List<String> origins;
+  }
+
+  /**
+   * Cognito configuration.
+   *
+   * <p>Holds the Cognito userInfo endpoint URI and the TTL after which a
+   * persisted identity record is considered stale and must be refreshed.</p>
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class CognitoConfiguration {
+
+    /**
+     * Full URL of the Cognito {@code /oauth2/userInfo} endpoint.
+     * Defaults to the standard Cognito path derived from region and pool env vars.
+     */
+    private String userinfoUri;
+
+    /**
+     * How long a locally persisted identity is considered fresh before
+     * a Cognito refresh is triggered. Defaults to 24 hours.
+     */
+    @Builder.Default
+    private Duration identityTtl = Duration.ofHours(24);
+  }
+
+  /**
+   * Identity hydration configuration.
+   *
+   * <p>Defines the list of request paths that will trigger user identity
+   * hydration via the {@code UserIdentityHydrationFilter}.</p>
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class HydrationConfiguration {
+
+    /**
+     * List of path prefixes for which identity hydration is performed.
+     * Any request whose URI starts with one of these values will be hydrated.
+     */
+    @Builder.Default
+    private List<String> paths = List.of("/api/users/preferences");
   }
 
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/configuration/SecurityConfiguration.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/configuration/SecurityConfiguration.java
@@ -4,6 +4,7 @@ import ca.bc.gov.nrs.hrs.security.ApiAuthorizationCustomizer;
 import ca.bc.gov.nrs.hrs.security.CsrfSecurityCustomizer;
 import ca.bc.gov.nrs.hrs.security.HeadersSecurityCustomizer;
 import ca.bc.gov.nrs.hrs.security.Oauth2SecurityCustomizer;
+import ca.bc.gov.nrs.hrs.security.UserIdentityHydrationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -34,14 +36,21 @@ public class SecurityConfiguration {
    *
    * <p>The supplied customizers are applied in the following logical order:
    * headers -> CSRF -> CORS defaults -> authorization rules -> disable HTTP Basic and form login ->
-   * OAuth2 resource server. Each argument is a Spring-managed component that encapsulates the
-   * configuration for the corresponding concern.</p>
+   * OAuth2 resource server -> identity hydration filter. Each argument is a Spring-managed
+   * component that encapsulates the configuration for the corresponding concern.</p>
+   *
+   * <p>The {@link UserIdentityHydrationFilter} is inserted immediately after the
+   * {@code BearerTokenAuthenticationFilter} so that the JWT is already validated and the
+   * {@code SecurityContext} is populated before identity hydration runs. This guarantees that
+   * role-based authorization decisions in {@link ApiAuthorizationCustomizer} always see a
+   * fully enriched principal on hydrated paths.</p>
    *
    * @param http              the {@link HttpSecurity} builder provided by Spring Security
    * @param headersCustomizer customizer used to configure security-related HTTP headers
    * @param csrfCustomizer    customizer used to configure CSRF protection
    * @param apiCustomizer     customizer used to configure authorization rules for HTTP endpoints
    * @param oauth2Customizer  customizer used to configure OAuth2 resource server support
+   * @param hydrationFilter   filter that enriches the security context with persisted identity data
    * @return the configured {@link SecurityFilterChain}
    * @throws Exception if an error occurs while configuring {@code HttpSecurity}
    */
@@ -51,7 +60,8 @@ public class SecurityConfiguration {
       HeadersSecurityCustomizer headersCustomizer,
       CsrfSecurityCustomizer csrfCustomizer,
       ApiAuthorizationCustomizer apiCustomizer,
-      Oauth2SecurityCustomizer oauth2Customizer
+      Oauth2SecurityCustomizer oauth2Customizer,
+      UserIdentityHydrationFilter hydrationFilter
   ) throws Exception {
     http
         .headers(headersCustomizer)
@@ -60,7 +70,8 @@ public class SecurityConfiguration {
         .authorizeHttpRequests(apiCustomizer)
         .httpBasic(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
-        .oauth2ResourceServer(oauth2Customizer);
+        .oauth2ResourceServer(oauth2Customizer)
+        .addFilterAfter(hydrationFilter, BearerTokenAuthenticationFilter.class);
 
     return http.build();
   }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/dto/base/FeatureFlag.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/dto/base/FeatureFlag.java
@@ -31,7 +31,16 @@ package ca.bc.gov.nrs.hrs.dto.base;
  */
 public enum FeatureFlag {
 
-  OFFLINE_MODE_ENABLED("offline-mode-enabled");
+  OFFLINE_MODE_ENABLED("offline-mode-enabled"),
+
+  /**
+   * Controls whether hydrated user identity attributes are persisted locally.
+   *
+   * <p>When disabled, the application still calls Cognito {@code /oauth2/userInfo}
+   * for request-time hydration but does not write/read identity data from the database.
+   * This allows privacy-first rollout while keeping the hydration pipeline active.</p>
+   */
+  USER_IDENTITY_PERSISTENCE_ENABLED("user-identity-persistence-enabled");
 
   private final String key;
 

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/entity/users/UserIdentityEntity.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/entity/users/UserIdentityEntity.java
@@ -1,0 +1,122 @@
+package ca.bc.gov.nrs.hrs.entity.users;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.With;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * JPA entity that caches a user's identity attributes retrieved from Cognito.
+ *
+ * <p>Maps to the {@code hrs.user_identity} table. Each row represents a single
+ * user identified by their Cognito {@code sub} claim. Identity data is persisted
+ * locally so that async workflows (email notifications, scheduled jobs) can access
+ * user attributes without requiring a live Cognito call.
+ * </p>
+ *
+ * <p>The {@link #lastSyncedAt} field is used to determine whether the record is
+ * stale and needs refreshing from Cognito. The staleness threshold is configurable
+ * via {@code ca.bc.gov.nrs.cognito.identity-ttl} (default 24 h).
+ * </p>
+ */
+@Entity
+@Table(name = "user_identity", schema = "hrs")
+@Data
+@Builder
+@With
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class UserIdentityEntity {
+
+  /**
+   * Cognito subject identifier — the user's unique, immutable UUID assigned by Cognito.
+   * Used as the primary key for this entity.
+   */
+  @Id
+  @EqualsAndHashCode.Include
+  private String sub;
+
+  /**
+   * The user's email address as returned by the Cognito {@code /oauth2/userInfo} endpoint.
+   */
+  private String email;
+
+  /**
+   * The user's full display name.
+   */
+  private String name;
+
+  /**
+   * The user's given (first) name.
+   */
+  @Column(name = "given_name")
+  private String givenName;
+
+  /**
+   * The user's family (last) name.
+   */
+  @Column(name = "family_name")
+  private String familyName;
+
+  /**
+   * The identity provider name from {@code custom:idp_name} (e.g. {@code idir},
+   * {@code bceidbusiness}). Used by {@link ca.bc.gov.nrs.hrs.util.JwtPrincipalUtil}
+   * to resolve the {@link ca.bc.gov.nrs.hrs.dto.base.IdentityProvider}.
+   */
+  @Column(name = "idp_name")
+  private String idpName;
+
+  /**
+   * The user's identifier within their identity provider, from {@code custom:idp_user_id}.
+   */
+  @Column(name = "idp_user_id")
+  private String idpUserId;
+
+  /**
+   * The user's username within their identity provider, from {@code custom:idp_username}.
+   */
+  @Column(name = "idp_username")
+  private String idpUsername;
+
+  /**
+   * The user's display name as set by their identity provider,
+   * from {@code custom:idp_display_name} (e.g. {@code Cruz, Paulo WLRS:EX}).
+   */
+  @Column(name = "idp_display_name")
+  private String idpDisplayName;
+
+  /**
+   * The BCeID business identifier from {@code custom:idp_business_id}.
+   * Only populated for users authenticating via BCeID Business; {@code null} for IDIR users.
+   */
+  @Column(name = "idp_business_id")
+  private String businessId;
+
+  /**
+   * The complete raw attribute map returned by the Cognito userInfo endpoint,
+   * stored as JSONB so that custom or future Cognito attributes are not lost.
+   */
+  @Column(name = "raw_attributes", columnDefinition = "jsonb")
+  @JdbcTypeCode(SqlTypes.JSON)
+  private Map<String, Object> rawAttributes;
+
+  /**
+   * Timestamp of the last successful sync with Cognito.
+   * Used to determine whether the record is stale and must be refreshed.
+   */
+  @Column(name = "last_synced_at", nullable = false)
+  private Instant lastSyncedAt;
+
+}
+

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/provider/cognito/CognitoUserInfoClient.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/provider/cognito/CognitoUserInfoClient.java
@@ -1,0 +1,110 @@
+package ca.bc.gov.nrs.hrs.provider.cognito;
+
+import io.micrometer.observation.annotation.Observed;
+import io.micrometer.tracing.annotation.NewSpan;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Client that calls the Cognito {@code /oauth2/userInfo} endpoint to retrieve
+ * identity attributes for the currently authenticated user.
+ *
+ * <p>Uses Spring's {@link RestClient} following the same provider pattern as
+ * other API clients in the application. The Bearer access token from the
+ * incoming request is forwarded as the {@code Authorization} header so
+ * Cognito can resolve the user's identity.
+ * </p>
+ *
+ * <p>All errors are caught and logged; the method returns
+ * {@link Optional#empty()} rather than propagating exceptions so callers
+ * can apply safe fallback behaviour.
+ * </p>
+ */
+@Slf4j
+@Component
+@Observed
+public class CognitoUserInfoClient {
+
+  private static final String PROVIDER = "Cognito UserInfo";
+
+  private final RestClient restClient;
+
+  /**
+   * Construct the client using the pre-configured {@code cognitoApi} REST client bean.
+   *
+   * @param cognitoApi the {@link RestClient} pre-configured with the Cognito userInfo base URL
+   */
+  public CognitoUserInfoClient(@Qualifier("cognitoApi") RestClient cognitoApi) {
+    this.restClient = cognitoApi;
+  }
+
+  /**
+   * Fetch user identity attributes from the Cognito userInfo endpoint.
+   *
+   * <p>The supplied {@code accessToken} is forwarded as a Bearer token.
+   * On any error the method logs a warning and returns {@link Optional#empty()}.
+   * </p>
+   *
+   * @param accessToken the raw OAuth2 access token value for the current request
+   * @return an {@link Optional} containing a {@link CognitoUserInfoResponse} when
+   *         the call succeeds, or empty on any failure
+   */
+  @NewSpan
+  public Optional<CognitoUserInfoResponse> fetchUserInfo(String accessToken) {
+    log.debug("Calling {} endpoint to retrieve user identity", PROVIDER);
+
+    try {
+      Map<String, Object> body = restClient
+          .get()
+          .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+          .retrieve()
+          .body(new ParameterizedTypeReference<>() {
+          });
+
+      if (body == null) {
+        log.warn("{} returned an empty response body", PROVIDER);
+        return Optional.empty();
+      }
+
+      return Optional.of(mapResponse(body));
+
+    } catch (RestClientException ex) {
+      log.warn("Failed to fetch user info from {}: {}", PROVIDER, ex.getMessage());
+      return Optional.empty();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private CognitoUserInfoResponse mapResponse(Map<String, Object> body) {
+    List<String> groups = body.get("cognito:groups") instanceof List<?> rawList
+        ? rawList.stream()
+            .filter(String.class::isInstance)
+            .map(String.class::cast)
+            .toList()
+        : List.of();
+
+    return new CognitoUserInfoResponse(
+        (String) body.get("sub"),
+        (String) body.get("email"),
+        (String) body.get("name"),
+        (String) body.get("given_name"),
+        (String) body.get("family_name"),
+        (String) body.get("custom:idp_name"),
+        (String) body.get("custom:idp_user_id"),
+        (String) body.get("custom:idp_username"),
+        (String) body.get("custom:idp_display_name"),
+        (String) body.get("custom:idp_business_id"),
+        groups,
+        body
+    );
+  }
+}
+

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/provider/cognito/CognitoUserInfoResponse.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/provider/cognito/CognitoUserInfoResponse.java
@@ -1,0 +1,44 @@
+package ca.bc.gov.nrs.hrs.provider.cognito;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Immutable response DTO for the Cognito {@code /oauth2/userInfo} endpoint.
+ *
+ * <p>Holds standard OIDC identity claims as well as Cognito custom attributes
+ * ({@code custom:idp_*}) that are present in the userInfo response but absent
+ * from access tokens. The {@code groups} field maps to {@code cognito:groups}
+ * which Cognito may or may not include depending on pool configuration.
+ * </p>
+ *
+ * @param sub            the subject identifier (user's unique Cognito UUID)
+ * @param email          the user's email address, or {@code null} if not present
+ * @param name           the user's full display name, or {@code null} if not present
+ * @param givenName      the user's given (first) name, or {@code null} if not present
+ * @param familyName     the user's family (last) name, or {@code null} if not present
+ * @param idpName        value of {@code custom:idp_name} (e.g. {@code idir})
+ * @param idpUserId      value of {@code custom:idp_user_id}
+ * @param idpUsername    value of {@code custom:idp_username}
+ * @param idpDisplayName value of {@code custom:idp_display_name}
+ * @param businessId     value of {@code custom:idp_business_id} (BCeID Business users only)
+ * @param groups         list of Cognito group names from {@code cognito:groups}; may be empty
+ * @param rawAttributes  the complete raw attribute map returned by the endpoint
+ */
+public record CognitoUserInfoResponse(
+    String sub,
+    String email,
+    String name,
+    String givenName,
+    String familyName,
+    String idpName,
+    String idpUserId,
+    String idpUsername,
+    String idpDisplayName,
+    String businessId,
+    List<String> groups,
+    Map<String, Object> rawAttributes
+) {
+
+}
+

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/UserIdentityRepository.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/UserIdentityRepository.java
@@ -1,0 +1,30 @@
+package ca.bc.gov.nrs.hrs.repository;
+
+import ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity;
+import java.util.Optional;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository for accessing {@link UserIdentityEntity} records.
+ *
+ * <p>Provides CRUD operations for persisted Cognito user identity data.
+ * The primary key is the user's Cognito {@code sub} (subject) identifier.
+ * </p>
+ */
+@Repository
+public interface UserIdentityRepository extends CrudRepository<UserIdentityEntity, String> {
+
+  /**
+   * Find a {@link UserIdentityEntity} by its Cognito subject identifier.
+   *
+   * @param sub the Cognito subject identifier
+   * @return an {@link Optional} containing the entity if found
+   */
+  @Override
+  @NonNull
+  Optional<UserIdentityEntity> findById(@NonNull String sub);
+
+}
+

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/security/DatabaseAuditor.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/security/DatabaseAuditor.java
@@ -31,7 +31,7 @@ public class DatabaseAuditor implements AuditorAware<String> {
    */
   @Override
   public Optional<String> getCurrentAuditor() {
-    return Optional.ofNullable(SecurityContextHolder.getContext())
+    return Optional.of(SecurityContextHolder.getContext())
         .map(SecurityContext::getAuthentication)
         .filter(Authentication::isAuthenticated)
         .map(Authentication::getPrincipal)

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/security/DatabaseAuditor.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/security/DatabaseAuditor.java
@@ -2,6 +2,7 @@ package ca.bc.gov.nrs.hrs.security;
 
 import ca.bc.gov.nrs.hrs.util.JwtPrincipalUtil;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -13,9 +14,11 @@ import org.springframework.stereotype.Component;
  * AuditorAware implementation that resolves the current user id from the
  * active JWT principal for Spring Data auditing.
  *
- * <p>
- * When present the authenticated JWT's subject (user id) will be used as
- * the auditor value for created/modified auditing fields.
+ * When the JWT is an ID token the structured user id from
+ * {@link JwtPrincipalUtil#getUserId(Jwt)} (e.g. {@code IDIR/username}) is used.
+ * When the JWT is an access token those claims may be absent, so the auditor
+ * falls back to the raw Cognito {@code sub} claim to ensure audit columns are
+ * always populated.
  * </p>
  */
 @Component
@@ -33,6 +36,10 @@ public class DatabaseAuditor implements AuditorAware<String> {
         .filter(Authentication::isAuthenticated)
         .map(Authentication::getPrincipal)
         .map(Jwt.class::cast)
-        .map(JwtPrincipalUtil::getUserId);
+        .map(jwt -> {
+          String userId = JwtPrincipalUtil.getUserId(jwt);
+          return StringUtils.isNotBlank(userId) ? userId : jwt.getSubject();
+        });
   }
 }
+

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/security/Oauth2SecurityCustomizer.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/security/Oauth2SecurityCustomizer.java
@@ -53,7 +53,7 @@ public class Oauth2SecurityCustomizer implements
     return jwt -> {
       Collection<GrantedAuthority> authorities = authConverter.convert(jwt);
 
-      if (authorities == null || authorities.isEmpty()) {
+      if (authorities.isEmpty()) {
         authorities = fetchAuthoritiesFromUserInfo(jwt.getTokenValue());
       }
 

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/security/Oauth2SecurityCustomizer.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/security/Oauth2SecurityCustomizer.java
@@ -1,13 +1,19 @@
 package ca.bc.gov.nrs.hrs.security;
 
+import ca.bc.gov.nrs.hrs.provider.cognito.CognitoUserInfoClient;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.stereotype.Component;
 
@@ -15,14 +21,20 @@ import org.springframework.stereotype.Component;
  * Customize OAuth2 resource server configuration to extract authorities
  * from the JWT's {@code cognito:groups} claim and to configure the JWK set URI.
  *
- * <p>The customizer sets a JwtAuthenticationConverter that uses the
- * {@code cognito:groups} claim as the source of granted authorities and
- * removes any prefix from authority names to match application roles.
+ * <p>The customizer sets a {@link Converter} that uses the {@code cognito:groups}
+ * claim as the primary source of granted authorities. When the access token carries
+ * no groups (which can happen when an access token rather than an ID token is used),
+ * the converter falls back to calling the Cognito {@code /oauth2/userInfo} endpoint
+ * to retrieve the groups from there. This guarantees that role-based authorization
+ * decisions in {@link ApiAuthorizationCustomizer} always have authorities available.
  * </p>
  */
 @Component
+@RequiredArgsConstructor
 public class Oauth2SecurityCustomizer implements
     Customizer<OAuth2ResourceServerConfigurer<HttpSecurity>> {
+
+  private final CognitoUserInfoClient cognitoUserInfoClient;
 
   @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}")
   String jwkSetUri;
@@ -38,9 +50,24 @@ public class Oauth2SecurityCustomizer implements
     authConverter.setAuthoritiesClaimName("cognito:groups");
     authConverter.setAuthorityPrefix("");
 
-    JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
-    converter.setJwtGrantedAuthoritiesConverter(authConverter);
-    return converter;
+    return jwt -> {
+      Collection<GrantedAuthority> authorities = authConverter.convert(jwt);
+
+      if (authorities == null || authorities.isEmpty()) {
+        authorities = fetchAuthoritiesFromUserInfo(jwt.getTokenValue());
+      }
+
+      return new JwtAuthenticationToken(jwt, authorities);
+    };
   }
 
+  private Collection<GrantedAuthority> fetchAuthoritiesFromUserInfo(String accessToken) {
+    return cognitoUserInfoClient
+        .fetchUserInfo(accessToken)
+        .map(response -> response.groups()
+            .stream()
+            .<GrantedAuthority>map(SimpleGrantedAuthority::new)
+            .toList())
+        .orElse(List.of());
+  }
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/security/UserIdentityAuthentication.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/security/UserIdentityAuthentication.java
@@ -1,0 +1,46 @@
+package ca.bc.gov.nrs.hrs.security;
+
+import ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity;
+import java.util.Collection;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Custom {@link JwtAuthenticationToken} that carries a fully hydrated
+ * {@link UserIdentityEntity} alongside the original JWT.
+ *
+ * <p>Placed into the {@code SecurityContext} by {@link UserIdentityHydrationFilter}
+ * for requests that trigger identity hydration. Because this class extends
+ * {@link JwtAuthenticationToken}, all existing code that reads authorities,
+ * the JWT, or the principal directly continues to work without modification.</p>
+ */
+public class UserIdentityAuthentication extends JwtAuthenticationToken {
+
+  private final UserIdentityEntity identity;
+
+  /**
+   * Construct a hydrated authentication token.
+   *
+   * @param jwt         the validated JWT from the current request
+   * @param authorities the granted authorities resolved for this user
+   * @param identity    the hydrated {@link UserIdentityEntity} for this user
+   */
+  public UserIdentityAuthentication(
+      Jwt jwt,
+      Collection<? extends GrantedAuthority> authorities,
+      UserIdentityEntity identity
+  ) {
+    super(jwt, authorities);
+    this.identity = identity;
+  }
+
+  /**
+   * Return the hydrated identity entity for this user.
+   *
+   * @return the {@link UserIdentityEntity} carrying Cognito identity attributes
+   */
+  public UserIdentityEntity getIdentity() {
+    return identity;
+  }
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/security/UserIdentityHydrationFilter.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/security/UserIdentityHydrationFilter.java
@@ -22,10 +22,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity} for configured paths.
  *
  * <p>Runs after JWT validation. For matching paths it extracts the Cognito
- * {@code sub} and access token, delegates to {@link UserIdentityService} (DB first,
- * Cognito fallback) and replaces the principal with a
- * {@link UserIdentityAuthentication}. If lookup fails the original principal
- * is preserved so the request proceeds normally.</p>
+ * {@code sub} and access token, delegates to {@link UserIdentityService} to
+ * retrieve or refresh the identity from Cognito (optionally persisting it),
+ * and replaces the principal with a {@link UserIdentityAuthentication}. If
+ * lookup fails the original principal is preserved so the request proceeds
+ * normally.</p>
  *
  * <p>Hydrated paths are configurable via
  * {@code ca.bc.gov.nrs.hydration.paths} in {@code application.yml}.</p>

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/security/UserIdentityHydrationFilter.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/security/UserIdentityHydrationFilter.java
@@ -1,0 +1,78 @@
+package ca.bc.gov.nrs.hrs.security;
+
+import ca.bc.gov.nrs.hrs.configuration.HrsConfiguration;
+import ca.bc.gov.nrs.hrs.service.UserIdentityService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Servlet filter that hydrates the Spring Security context with a persisted
+ * {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity} for configured paths.
+ *
+ * <p>Runs after JWT validation. For matching paths it extracts the Cognito
+ * {@code sub} and access token, delegates to {@link UserIdentityService} (DB first,
+ * Cognito fallback) and replaces the principal with a
+ * {@link UserIdentityAuthentication}. If lookup fails the original principal
+ * is preserved so the request proceeds normally.</p>
+ *
+ * <p>Hydrated paths are configurable via
+ * {@code ca.bc.gov.nrs.hydration.paths} in {@code application.yml}.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserIdentityHydrationFilter extends OncePerRequestFilter {
+
+  private final UserIdentityService userIdentityService;
+  private final HrsConfiguration configuration;
+
+  @Override
+  protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
+    String path = request.getRequestURI();
+    List<String> hydratedPaths = configuration.getHydration().getPaths();
+    return hydratedPaths.stream().noneMatch(path::startsWith);
+  }
+
+  @Override
+  protected void doFilterInternal(
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain chain
+  ) throws IOException, ServletException {
+
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+    if (auth instanceof JwtAuthenticationToken jwtAuth) {
+      String sub = jwtAuth.getToken().getSubject();
+      String accessToken = jwtAuth.getToken().getTokenValue();
+
+      userIdentityService.getOrRefreshBySub(sub, accessToken)
+          .ifPresentOrElse(
+              identity -> {
+                log.debug("Identity hydrated for sub={}", sub);
+                UserIdentityAuthentication enriched = new UserIdentityAuthentication(
+                    jwtAuth.getToken(),
+                    jwtAuth.getAuthorities(),
+                    identity
+                );
+                SecurityContextHolder.getContext().setAuthentication(enriched);
+              },
+              () -> log.warn("Could not hydrate identity for sub={}, proceeding without it", sub)
+          );
+    }
+
+    chain.doFilter(request, response);
+  }
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/UserIdentityPersistenceService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/UserIdentityPersistenceService.java
@@ -1,0 +1,33 @@
+package ca.bc.gov.nrs.hrs.service;
+
+import ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity;
+import ca.bc.gov.nrs.hrs.repository.UserIdentityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Persistence boundary for user identity writes.
+ *
+ * <p>Keeps database transactions scoped only to repository save operations so
+ * upstream network calls can run outside any open transaction.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+public class UserIdentityPersistenceService {
+
+  private final UserIdentityRepository repository;
+
+  /**
+   * Persist hydrated identity in a short transaction.
+   *
+   * @param hydratedIdentity identity populated from Cognito userInfo
+   * @return persisted entity
+   */
+  @Transactional
+  public UserIdentityEntity saveHydratedIdentity(UserIdentityEntity hydratedIdentity) {
+    return repository.save(hydratedIdentity);
+  }
+}
+

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/UserIdentityService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/UserIdentityService.java
@@ -1,0 +1,104 @@
+package ca.bc.gov.nrs.hrs.service;
+
+import ca.bc.gov.nrs.hrs.configuration.FeatureFlagsConfiguration;
+import ca.bc.gov.nrs.hrs.dto.base.FeatureFlag;
+import ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity;
+import ca.bc.gov.nrs.hrs.provider.cognito.CognitoUserInfoClient;
+import ca.bc.gov.nrs.hrs.provider.cognito.CognitoUserInfoResponse;
+import ca.bc.gov.nrs.hrs.repository.UserIdentityRepository;
+import io.micrometer.observation.annotation.Observed;
+import io.micrometer.tracing.annotation.NewSpan;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service responsible for hydrating user identity data from Cognito's
+ * {@code /oauth2/userInfo} endpoint and optionally persisting it.
+ *
+ * <p>Hydration always calls Cognito on each request so identity attributes are
+ * current at request time. Database persistence is controlled by
+ * {@link FeatureFlag#USER_IDENTITY_PERSISTENCE_ENABLED} to support privacy-first
+ * rollout: when disabled, no user identity data is written to or read from the
+ * local database.</p>
+ */
+@Slf4j
+@Service
+@Observed
+@RequiredArgsConstructor
+public class UserIdentityService {
+
+  private final UserIdentityRepository repository;
+  private final CognitoUserInfoClient cognitoClient;
+  private final FeatureFlagsConfiguration featureFlagsConfiguration;
+
+  /**
+   * Hydrate identity from Cognito for the given user on every call.
+   *
+   * <p>If {@link FeatureFlag#USER_IDENTITY_PERSISTENCE_ENABLED} is enabled,
+   * the hydrated entity is also saved and the persisted instance is returned.
+   * When disabled, the hydrated entity is returned without persistence.</p>
+   *
+   * @param sub the Cognito subject identifier from the access token
+   * @param accessToken the raw access token forwarded to Cognito userInfo
+   * @return hydrated identity if Cognito call succeeds; otherwise empty
+   */
+  @NewSpan
+  @Transactional
+  public Optional<UserIdentityEntity> getOrRefreshBySub(String sub, String accessToken) {
+    return cognitoClient.fetchUserInfo(accessToken)
+        .map(info -> maybePersist(toEntity(sub, info)));
+  }
+
+  /**
+   * Retrieve a previously persisted identity for async workflows.
+   *
+   * <p>When persistence is disabled via
+   * {@link FeatureFlag#USER_IDENTITY_PERSISTENCE_ENABLED}, this method returns
+   * {@link Optional#empty()} by design.</p>
+   *
+   * @param sub the Cognito subject identifier
+   * @return optional persisted entity if persistence is enabled and record exists
+   */
+  @NewSpan
+  public Optional<UserIdentityEntity> findPersistedBySub(String sub) {
+    if (isPersistenceEnabled()) {
+      return repository.findById(sub);
+    }
+    return Optional.empty();
+  }
+
+  private UserIdentityEntity maybePersist(UserIdentityEntity hydratedIdentity) {
+    if (isPersistenceEnabled()) {
+      log.debug("Persisting hydrated identity for sub={}", hydratedIdentity.getSub());
+      return repository.save(hydratedIdentity);
+    }
+    return hydratedIdentity;
+  }
+
+  private boolean isPersistenceEnabled() {
+    return featureFlagsConfiguration.isEnabled(FeatureFlag.USER_IDENTITY_PERSISTENCE_ENABLED);
+  }
+
+  private UserIdentityEntity toEntity(String fallbackSub, CognitoUserInfoResponse info) {
+    String resolvedSub = info.sub() == null || info.sub().isBlank() ? fallbackSub : info.sub();
+
+    return UserIdentityEntity.builder()
+        .sub(resolvedSub)
+        .email(info.email())
+        .name(info.name())
+        .givenName(info.givenName())
+        .familyName(info.familyName())
+        .idpName(info.idpName())
+        .idpUserId(info.idpUserId())
+        .idpUsername(info.idpUsername())
+        .idpDisplayName(info.idpDisplayName())
+        .businessId(info.businessId())
+        .rawAttributes(info.rawAttributes())
+        .lastSyncedAt(Instant.now())
+        .build();
+  }
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/UserIdentityService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/UserIdentityService.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Service responsible for hydrating user identity data from Cognito's
@@ -32,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserIdentityService {
 
   private final UserIdentityRepository repository;
+  private final UserIdentityPersistenceService userIdentityPersistenceService;
   private final CognitoUserInfoClient cognitoClient;
   private final FeatureFlagsConfiguration featureFlagsConfiguration;
 
@@ -47,7 +47,6 @@ public class UserIdentityService {
    * @return hydrated identity if Cognito call succeeds; otherwise empty
    */
   @NewSpan
-  @Transactional
   public Optional<UserIdentityEntity> getOrRefreshBySub(String sub, String accessToken) {
     return cognitoClient.fetchUserInfo(accessToken)
         .map(info -> maybePersist(toEntity(sub, info)));
@@ -74,7 +73,7 @@ public class UserIdentityService {
   private UserIdentityEntity maybePersist(UserIdentityEntity hydratedIdentity) {
     if (isPersistenceEnabled()) {
       log.debug("Persisting hydrated identity for sub={}", hydratedIdentity.getSub());
-      return repository.save(hydratedIdentity);
+      return userIdentityPersistenceService.saveHydratedIdentity(hydratedIdentity);
     }
     return hydratedIdentity;
   }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/util/JwtPrincipalUtil.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/util/JwtPrincipalUtil.java
@@ -24,6 +24,17 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
  *    and {@link Jwt} instances. Methods include retrieval of provider, user id, business
  *    identifiers, names, groups and role/client mappings. The class is non-instantiable.
  * </p>
+ *
+ * <p><strong>Access-token migration note:</strong> The application now validates Cognito
+ * <em>access tokens</em> instead of ID tokens. Several claims that were present in the
+ * ID token are absent from the access token and can only be retrieved via the Cognito
+ * {@code /oauth2/userInfo} endpoint (persisted in
+ * {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity}). Methods that read such
+ * claims are marked {@link Deprecated} and will return an empty string when called
+ * against an access token. They should be replaced with reads from
+ * {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity} via
+ * {@link ca.bc.gov.nrs.hrs.security.UserIdentityAuthentication#getIdentity()}.
+ * </p>
  */
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class JwtPrincipalUtil {
@@ -98,7 +109,11 @@ public class JwtPrincipalUtil {
    *
    * @param principal JwtAuthenticationToken object from which the business ID is to be extracted.
    * @return The business ID, or an empty string if the business ID is blank.
+   * @deprecated {@code custom:idp_business_id} is not present in Cognito access tokens.
+   *     Use {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity#getBusinessId()} obtained
+   *     from {@link ca.bc.gov.nrs.hrs.security.UserIdentityAuthentication#getIdentity()} instead.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getBusinessId(JwtAuthenticationToken principal) {
     return getBusinessIdValue(principal.getTokenAttributes());
   }
@@ -110,7 +125,11 @@ public class JwtPrincipalUtil {
    *
    * @param principal Jwt object from which the business ID is to be extracted.
    * @return The business ID, or an empty string if the business ID is blank.
+   * @deprecated {@code custom:idp_business_id} is not present in Cognito access tokens.
+   *     Use {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity#getBusinessId()} obtained
+   *     from {@link ca.bc.gov.nrs.hrs.security.UserIdentityAuthentication#getIdentity()} instead.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getBusinessId(Jwt principal) {
     return getBusinessIdValue(principal.getClaims());
   }
@@ -123,7 +142,11 @@ public class JwtPrincipalUtil {
    * @param principal JwtAuthenticationToken object from which the business name is to be
    *        extracted.
    * @return The business name, or an empty string if the business name is blank.
+   * @deprecated {@code custom:idp_business_name} is not present in Cognito access tokens or in
+   *     the Cognito {@code /oauth2/userInfo} response. This method will always return an empty
+   *     string when called against an access token. Schedule for removal after callers are audited.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getBusinessName(JwtAuthenticationToken principal) {
     return getBusinessNameValue(principal.getTokenAttributes());
   }
@@ -135,161 +158,157 @@ public class JwtPrincipalUtil {
    *
    * @param principal Jwt object from which the business name is to be extracted.
    * @return The business name, or an empty string if the business name is blank.
+   * @deprecated {@code custom:idp_business_name} is not present in Cognito access tokens or in
+   *     the Cognito {@code /oauth2/userInfo} response. This method will always return an empty
+   *     string when called against an access token. Schedule for removal after callers are audited.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getBusinessName(Jwt principal) {
     return getBusinessNameValue(principal.getClaims());
   }
 
   /**
-   * Retrieves the business name from the given JwtAuthenticationToken principal. The business name
-   * is extracted from the token attributes under the key "custom:idp_business_name". If the
-   * business name is blank, an empty string is returned.
+   * Retrieves the email address from the given JwtAuthenticationToken principal.
    *
-   * @param principal JwtAuthenticationToken object from which the business name is to be
-   *        extracted.
-   * @return The business name, or an empty string if the business name is blank.
+   * @param principal JwtAuthenticationToken object from which the email is to be extracted.
+   * @return The email, or an empty string if the claim is blank.
+   * @deprecated {@code email} is not present in Cognito access tokens.
+   *     Use {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity#getEmail()} obtained
+   *     from {@link ca.bc.gov.nrs.hrs.security.UserIdentityAuthentication#getIdentity()} instead.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getEmail(JwtAuthenticationToken principal) {
     return getEmailValue(principal.getTokenAttributes());
   }
 
   /**
-   * Retrieves the business name from the given Jwt principal. The business name is extracted from
-   * the token attributes under the key "custom:idp_business_name". If the business name is blank,
-   * an empty string is returned.
+   * Retrieves the email address from the given Jwt principal.
    *
-   * @param principal Jwt object from which the business name is to be extracted.
-   * @return The business name, or an empty string if the business name is blank.
+   * @param principal Jwt object from which the email is to be extracted.
+   * @return The email, or an empty string if the claim is blank.
+   * @deprecated {@code email} is not present in Cognito access tokens.
+   *     Use {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity#getEmail()} obtained
+   *     from {@link ca.bc.gov.nrs.hrs.security.UserIdentityAuthentication#getIdentity()} instead.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getEmail(Jwt principal) {
     return getEmailValue(principal.getClaims());
   }
 
   /**
-   * Retrieves the display name from the given JwtAuthenticationToken principal. The display name is
-   * extracted from the token attributes under the key "custom:idp_display_name". If the display
-   * name is blank, the first and last names are extracted and concatenated. If both the first and
-   * last names are blank, an empty string is returned.
+   * Retrieves the display name from the given JwtAuthenticationToken principal.
    *
    * @param principal JwtAuthenticationToken object from which the display name is to be extracted.
-   * @return The display name, or the concatenated first and last names, or an empty string if both
-   *        the display name and the first and last names are blank.
+   * @return The display name, or concatenated first/last names, or an empty string.
+   * @deprecated {@code custom:idp_display_name}, {@code given_name} and {@code family_name} are
+   *     not present in Cognito access tokens — this method will always return an empty string.
+   *     Use {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity#getIdpDisplayName()} obtained
+   *     from {@link ca.bc.gov.nrs.hrs.security.UserIdentityAuthentication#getIdentity()} instead.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getName(JwtAuthenticationToken principal) {
     return getNameValue(principal.getTokenAttributes());
   }
 
   /**
-   * Retrieves the display name from the given Jwt principal. The display name is extracted from the
-   * token attributes under the key "custom:idp_display_name". If the display name is blank, the
-   * first and last names are extracted and concatenated. If both the first and last names are
-   * blank, an empty string is returned.
+   * Retrieves the display name from the given Jwt principal.
    *
    * @param principal Jwt object from which the display name is to be extracted.
-   * @return The display name, or the concatenated first and last names, or an empty string if both
-   *        the display name and the first and last names are blank.
+   * @return The display name, or concatenated first/last names, or an empty string.
+   * @deprecated {@code custom:idp_display_name}, {@code given_name} and {@code family_name} are
+   *     not present in Cognito access tokens — this method will always return an empty string.
+   *     Use {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity#getIdpDisplayName()} obtained
+   *     from {@link ca.bc.gov.nrs.hrs.security.UserIdentityAuthentication#getIdentity()} instead.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getName(Jwt principal) {
     return getNameValue(principal.getClaims());
   }
 
   /**
-   * Retrieves the first name from the given JwtAuthenticationToken principal. The first name is
-   * extracted from the token attributes under the key "given_name". If the first name is blank, an
-   * empty string is returned.
+   * Retrieves the first name from the given JwtAuthenticationToken principal.
    *
    * @param principal JwtAuthenticationToken object from which the first name is to be extracted.
    * @return The first name or an empty string if the first name is blank.
+   * @deprecated {@code given_name} is not present in Cognito access tokens or in the
+   *     {@code /oauth2/userInfo} response for any known identity provider. This method will
+   *     always return an empty string. Schedule for removal after callers are audited.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getFirstName(JwtAuthenticationToken principal) {
     return getFirstNameValue(principal.getTokenAttributes());
   }
 
   /**
-   * Retrieves the first name from the given Jwt principal. The first name is extracted from the
-   * token attributes under the key "given_name". If the first name is blank, an empty string is
-   * returned.
+   * Retrieves the first name from the given Jwt principal.
    *
    * @param principal Jwt object from which the first name is to be extracted.
    * @return The first name or an empty string if the first name is blank.
+   * @deprecated {@code given_name} is not present in Cognito access tokens or in the
+   *     {@code /oauth2/userInfo} response for any known identity provider. This method will
+   *     always return an empty string. Schedule for removal after callers are audited.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getFirstName(Jwt principal) {
     return getFirstNameValue(principal.getClaims());
   }
 
   /**
-   * Retrieves the last name from the given JwtAuthenticationToken principal. The last name is
-   * extracted from the token attributes under the key "family_name". If the last name is blank, an
-   * empty string is returned.
+   * Retrieves the last name from the given JwtAuthenticationToken principal.
    *
    * @param principal JwtAuthenticationToken object from which the last name is to be extracted.
    * @return The last name or an empty string if the last name is blank.
+   * @deprecated {@code family_name} is not present in Cognito access tokens or in the
+   *     {@code /oauth2/userInfo} response for any known identity provider. This method will
+   *     always return an empty string. Schedule for removal after callers are audited.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getLastName(JwtAuthenticationToken principal) {
     return getLastNameValue(principal.getTokenAttributes());
   }
 
   /**
-   * Retrieves the last name from the given Jwt principal. The last name is extracted from the token
-   * attributes under the key "family_name". If the last name is blank, an empty string is
-   * returned.
+   * Retrieves the last name from the given Jwt principal.
    *
    * @param principal Jwt object from which the last name is to be extracted.
    * @return The last name or an empty string if the last name is blank.
+   * @deprecated {@code family_name} is not present in Cognito access tokens or in the
+   *     {@code /oauth2/userInfo} response for any known identity provider. This method will
+   *     always return an empty string. Schedule for removal after callers are audited.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getLastName(Jwt principal) {
     return getLastNameValue(principal.getClaims());
   }
 
   /**
-   * Retrieves the display name from the given JwtAuthenticationToken principal. The display name is
-   * extracted from the token attributes under the key "custom:idp_display_name". If the display
-   * name is blank, an empty string is returned.
+   * Retrieves the display name from the given JwtAuthenticationToken principal.
    *
    * @param principal JwtAuthenticationToken object from which the display name is to be extracted.
    * @return The display name or an empty string if the display name is blank.
+   * @deprecated {@code custom:idp_display_name} is not present in Cognito access tokens.
+   *     Use {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity#getIdpDisplayName()} obtained
+   *     from {@link ca.bc.gov.nrs.hrs.security.UserIdentityAuthentication#getIdentity()} instead.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getDisplayName(JwtAuthenticationToken principal) {
     return getDisplayNameValue(principal.getTokenAttributes());
   }
 
   /**
-   * Retrieves the display name from the given Jwt principal. The display name is extracted from the
-   * token attributes under the key "custom:idp_display_name". If the display name is blank, an
-   * empty string is returned.
+   * Retrieves the display name from the given Jwt principal.
    *
    * @param principal Jwt object from which the display name is to be extracted.
    * @return The display name or an empty string if the display name is blank.
+   * @deprecated {@code custom:idp_display_name} is not present in Cognito access tokens.
+   *     Use {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity#getIdpDisplayName()} obtained
+   *     from {@link ca.bc.gov.nrs.hrs.security.UserIdentityAuthentication#getIdentity()} instead.
    */
+  @Deprecated(since = "access-token-migration", forRemoval = true)
   public static String getDisplayName(Jwt principal) {
     return getDisplayNameValue(principal.getClaims());
   }
 
-  /**
-   * Retrieves the IDP username from the given JwtAuthenticationToken principal. The IDP username is
-   * extracted from the token attributes under the key "custom:idp_username". If the IDP username is
-   * blank, the value under the key "custom:idp_user_id" is used. If both values are blank, an empty
-   * string is returned.
-   *
-   * @param principal JwtAuthenticationToken object from which the IDP username is to be extracted.
-   * @return The IDP username or an empty string if both values are blank.
-   */
-  public static String getIdpUsername(JwtAuthenticationToken principal) {
-    return getIdpUsernameValue(principal.getTokenAttributes());
-  }
-
-  /**
-   * Retrieves the IDP username from the given Jwt principal. The IDP username is extracted from the
-   * token attributes under the key "custom:idp_username". If the IDP username is blank, the value
-   * under the key "custom:idp_user_id" is used. If both values are blank, an empty string is
-   * returned.
-   *
-   * @param principal Jwt object from which the IDP username is to be extracted.
-   * @return The IDP username or an empty string if both values are blank.
-   */
-  public static String getIdpUsername(Jwt principal) {
-    return getIdpUsernameValue(principal.getClaims());
-  }
 
   /**
    * Retrieves a list of groups from the given JwtPrincipal. This method extracts the token
@@ -576,6 +595,32 @@ public class JwtPrincipalUtil {
         .map(userId -> getProviderValue(claims) + "\\" + userId)
         .findFirst()
         .orElse(StringUtils.EMPTY);
+  }
+
+  /**
+   * Retrieves the IDP username from the given JwtAuthenticationToken principal.
+   *
+   * <p>The IDP username is extracted from {@code custom:idp_username}. If absent,
+   * {@code custom:idp_user_id} is used as a fallback.</p>
+   *
+   * @param principal JwtAuthenticationToken object from which the IDP username is extracted
+   * @return the IDP username or an empty string when both claims are absent
+   */
+  public static String getIdpUsername(JwtAuthenticationToken principal) {
+    return getIdpUsernameValue(principal.getTokenAttributes());
+  }
+
+  /**
+   * Retrieves the IDP username from the given Jwt principal.
+   *
+   * <p>The IDP username is extracted from {@code custom:idp_username}. If absent,
+   * {@code custom:idp_user_id} is used as a fallback.</p>
+   *
+   * @param principal Jwt object from which the IDP username is extracted
+   * @return the IDP username or an empty string when both claims are absent
+   */
+  public static String getIdpUsername(Jwt principal) {
+    return getIdpUsernameValue(principal.getClaims());
   }
 
   private static String getIdpUsernameValue(Map<String, Object> claims) {

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/util/JwtPrincipalUtil.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/util/JwtPrincipalUtil.java
@@ -30,8 +30,8 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
  * ID token are absent from the access token and can only be retrieved via the Cognito
  * {@code /oauth2/userInfo} endpoint (persisted in
  * {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity}). Methods that read such
- * claims are marked {@link Deprecated} and will return an empty string when called
- * against an access token. They should be replaced with reads from
+ * claims are marked {@link Deprecated}; when called against an access token, they may
+ * return an empty string. They should be replaced with reads from
  * {@link ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity} via
  * {@link ca.bc.gov.nrs.hrs.security.UserIdentityAuthentication#getIdentity()}.
  * </p>

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -167,6 +167,12 @@ ca:
           key: ${FORESTCLIENTAPI_KEY:placeholder-api-key}
         legacy-api:
           address: ${LEGACY_URL:http://127.0.0.1:9090}
+        cognito:
+          userinfo-uri: https://${COGNITO_DOMAIN:pool-domain}.auth.${COGNITO_REGION:region}.amazoncognito.com/oauth2/userInfo
+          identity-ttl: ${COGNITO_IDENTITY_TTL:24h}
+        hydration:
+          paths:
+            - /api/users/preferences
         frontend:
           url: ${FRONTEND_URL:http://localhost:3000}
           cors:

--- a/backend/src/main/resources/db/migration/V1.0.1__user_identity.sql
+++ b/backend/src/main/resources/db/migration/V1.0.1__user_identity.sql
@@ -1,3 +1,6 @@
+-- Ensure schema exists for multi-schema deployments
+create schema if not exists hrs;
+
 create table if not exists hrs.user_identity (
     sub              varchar(128)    not null,
     email            varchar(255),
@@ -27,4 +30,12 @@ comment on column hrs.user_identity.idp_display_name is 'Display name from the i
 comment on column hrs.user_identity.idp_business_id is 'BCeID business identifier from custom:idp_business_id; null for IDIR users';
 comment on column hrs.user_identity.raw_attributes is 'Full raw attribute map returned by Cognito userInfo, stored for future use';
 comment on column hrs.user_identity.last_synced_at is 'Timestamp of the last successful sync with Cognito; used for staleness checks';
+
+-- Performance indexes on frequently queried columns
+create index if not exists idx_user_identity_email on hrs.user_identity (email);
+create index if not exists idx_user_identity_idp_name on hrs.user_identity (idp_name);
+
+-- GIN index for JSONB queries on raw_attributes
+create index if not exists idx_user_identity_raw_attributes_gin on hrs.user_identity using gin (raw_attributes);
+
 

--- a/backend/src/main/resources/db/migration/V1.0.1__user_identity.sql
+++ b/backend/src/main/resources/db/migration/V1.0.1__user_identity.sql
@@ -1,0 +1,30 @@
+create table if not exists hrs.user_identity (
+    sub              varchar(128)    not null,
+    email            varchar(255),
+    name             varchar(255),
+    given_name       varchar(128),
+    family_name      varchar(128),
+    idp_name         varchar(64),
+    idp_user_id      varchar(128),
+    idp_username     varchar(128),
+    idp_display_name varchar(255),
+    idp_business_id  varchar(128),
+    raw_attributes   jsonb           not null default '{}'::jsonb,
+    last_synced_at   timestamptz     not null default current_timestamp,
+    constraint user_identity_pk primary key (sub)
+);
+
+comment on table hrs.user_identity is 'Cached Cognito user identity attributes, used to avoid repeated userInfo calls';
+comment on column hrs.user_identity.sub is 'Cognito subject identifier — unique, immutable UUID for the user';
+comment on column hrs.user_identity.email is 'User email address as returned by Cognito userInfo';
+comment on column hrs.user_identity.name is 'User full display name as returned by Cognito userInfo';
+comment on column hrs.user_identity.given_name is 'User given (first) name as returned by Cognito userInfo';
+comment on column hrs.user_identity.family_name is 'User family (last) name as returned by Cognito userInfo';
+comment on column hrs.user_identity.idp_name is 'Identity provider name from custom:idp_name (e.g. idir, bceidbusiness)';
+comment on column hrs.user_identity.idp_user_id is 'User identifier within the identity provider from custom:idp_user_id';
+comment on column hrs.user_identity.idp_username is 'Username within the identity provider from custom:idp_username';
+comment on column hrs.user_identity.idp_display_name is 'Display name from the identity provider from custom:idp_display_name';
+comment on column hrs.user_identity.idp_business_id is 'BCeID business identifier from custom:idp_business_id; null for IDIR users';
+comment on column hrs.user_identity.raw_attributes is 'Full raw attribute map returned by Cognito userInfo, stored for future use';
+comment on column hrs.user_identity.last_synced_at is 'Timestamp of the last successful sync with Cognito; used for staleness checks';
+

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/provider/cognito/CognitoUserInfoClientTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/provider/cognito/CognitoUserInfoClientTest.java
@@ -1,0 +1,110 @@
+package ca.bc.gov.nrs.hrs.provider.cognito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@DisplayName("Unit Test | CognitoUserInfoClient")
+class CognitoUserInfoClientTest {
+
+  private final RestClient restClient = mock(RestClient.class);
+  private final RestClient.RequestHeadersUriSpec<?> requestHeadersUriSpec =
+      mock(RestClient.RequestHeadersUriSpec.class);
+  private final RestClient.RequestHeadersSpec<?> requestHeadersSpec =
+      mock(RestClient.RequestHeadersSpec.class);
+  private final RestClient.ResponseSpec responseSpec = mock(RestClient.ResponseSpec.class);
+
+  private final CognitoUserInfoClient client = new CognitoUserInfoClient(restClient);
+
+  @Test
+  @DisplayName("maps user info response including custom attributes and groups")
+  void shouldMapUserInfoResponse() {
+    Map<String, Object> body = new HashMap<>();
+    body.put("sub", "sub-123");
+    body.put("email", "user@example.com");
+    body.put("name", "Jane Doe");
+    body.put("given_name", "Jane");
+    body.put("family_name", "Doe");
+    body.put("custom:idp_name", "idir");
+    body.put("custom:idp_user_id", "JD123");
+    body.put("custom:idp_username", "jdoe");
+    body.put("custom:idp_display_name", "Doe, Jane");
+    body.put("custom:idp_business_id", "BUS-1");
+    body.put("cognito:groups", Arrays.asList("group-a", 10, "group-b", null));
+    mockRestChain("access-token", body);
+
+    Optional<CognitoUserInfoResponse> result = client.fetchUserInfo("access-token");
+
+    assertThat(result).isPresent();
+    assertThat(result.orElseThrow().sub()).isEqualTo("sub-123");
+    assertThat(result.orElseThrow().email()).isEqualTo("user@example.com");
+    assertThat(result.orElseThrow().idpName()).isEqualTo("idir");
+    assertThat(result.orElseThrow().groups()).containsExactly("group-a", "group-b");
+    assertThat(result.orElseThrow().rawAttributes()).containsEntry("sub", "sub-123");
+  }
+
+  @Test
+  @DisplayName("returns empty when Cognito returns null body")
+  void shouldReturnEmptyWhenBodyIsNull() {
+    mockRestChain("access-token", null);
+
+    Optional<CognitoUserInfoResponse> result = client.fetchUserInfo("access-token");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("returns empty when Cognito request throws RestClientException")
+  void shouldReturnEmptyOnRestClientException() {
+    doReturn(requestHeadersUriSpec).when(restClient).get();
+    doReturn(requestHeadersSpec)
+        .when(requestHeadersUriSpec)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer access-token");
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.body(any(ParameterizedTypeReference.class)))
+        .thenThrow(new RestClientException("boom"));
+
+    Optional<CognitoUserInfoResponse> result = client.fetchUserInfo("access-token");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("uses empty groups when cognito:groups is not a list")
+  void shouldUseEmptyGroupsWhenClaimIsNotAList() {
+    Map<String, Object> body = Map.of(
+        "sub", "sub-123",
+        "cognito:groups", "not-a-list"
+    );
+    mockRestChain("access-token", body);
+
+    Optional<CognitoUserInfoResponse> result = client.fetchUserInfo("access-token");
+
+    assertThat(result).isPresent();
+    assertThat(result.orElseThrow().groups()).isEmpty();
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private void mockRestChain(String accessToken, Map<String, Object> body) {
+    doReturn(requestHeadersUriSpec).when(restClient).get();
+    doReturn(requestHeadersSpec)
+        .when(requestHeadersUriSpec)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.body(any(ParameterizedTypeReference.class))).thenReturn(body);
+  }
+}
+

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/security/DatabaseAuditorTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/security/DatabaseAuditorTest.java
@@ -1,0 +1,88 @@
+package ca.bc.gov.nrs.hrs.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+@DisplayName("Unit Test | DatabaseAuditor")
+class DatabaseAuditorTest {
+
+  private final DatabaseAuditor databaseAuditor = new DatabaseAuditor();
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  @DisplayName("returns structured user id when ID token claims are present")
+  void shouldReturnStructuredUserIdWhenClaimsPresent() {
+    Jwt jwt = jwt(Map.of(
+        "sub", "sub-123",
+        "custom:idp_name", "idir",
+        "custom:idp_username", "jdoe",
+        "custom:idp_user_id", "jdoe-id"
+    ));
+    SecurityContextHolder.getContext().setAuthentication(
+        new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList("ROLE_USER")));
+
+    Optional<String> auditor = databaseAuditor.getCurrentAuditor();
+
+    assertThat(auditor).contains("IDIR\\jdoe");
+  }
+
+  @Test
+  @DisplayName("falls back to sub when custom idp claims are absent")
+  void shouldFallbackToSubWhenIdpClaimsMissing() {
+    Jwt jwt = jwt(Map.of("sub", "sub-from-access-token"));
+    SecurityContextHolder.getContext().setAuthentication(
+        new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList("ROLE_USER")));
+
+    Optional<String> auditor = databaseAuditor.getCurrentAuditor();
+
+    assertThat(auditor).contains("sub-from-access-token");
+  }
+
+  @Test
+  @DisplayName("returns empty when authentication is missing")
+  void shouldReturnEmptyWhenAuthenticationMissing() {
+    SecurityContextHolder.clearContext();
+
+    Optional<String> auditor = databaseAuditor.getCurrentAuditor();
+
+    assertThat(auditor).isEmpty();
+  }
+
+  @Test
+  @DisplayName("returns empty when authentication is not authenticated")
+  void shouldReturnEmptyWhenNotAuthenticated() {
+    TestingAuthenticationToken authentication = new TestingAuthenticationToken("principal",
+        "credentials");
+    authentication.setAuthenticated(false);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    Optional<String> auditor = databaseAuditor.getCurrentAuditor();
+
+    assertThat(auditor).isEmpty();
+  }
+
+  private Jwt jwt(Map<String, Object> claims) {
+    return Jwt.withTokenValue("token")
+        .issuedAt(Instant.parse("2026-01-01T00:00:00Z"))
+        .expiresAt(Instant.parse("2026-01-01T01:00:00Z"))
+        .header("alg", "none")
+        .claims(existing -> existing.putAll(claims))
+        .build();
+  }
+}
+

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/UserIdentityServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/UserIdentityServiceTest.java
@@ -1,0 +1,117 @@
+package ca.bc.gov.nrs.hrs.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ca.bc.gov.nrs.hrs.configuration.FeatureFlagsConfiguration;
+import ca.bc.gov.nrs.hrs.dto.base.FeatureFlag;
+import ca.bc.gov.nrs.hrs.entity.users.UserIdentityEntity;
+import ca.bc.gov.nrs.hrs.provider.cognito.CognitoUserInfoClient;
+import ca.bc.gov.nrs.hrs.provider.cognito.CognitoUserInfoResponse;
+import ca.bc.gov.nrs.hrs.repository.UserIdentityRepository;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("Unit Test | UserIdentityService")
+@ExtendWith(MockitoExtension.class)
+class UserIdentityServiceTest {
+
+  @Mock
+  private UserIdentityRepository repository;
+
+  @Mock
+  private CognitoUserInfoClient cognitoClient;
+
+  @Mock
+  private FeatureFlagsConfiguration featureFlagsConfiguration;
+
+  @InjectMocks
+  private UserIdentityService service;
+
+  @Test
+  @DisplayName("should always call userInfo and skip persistence when flag is disabled")
+  void shouldHydrateWithoutPersistenceWhenFlagDisabled() {
+    when(featureFlagsConfiguration.isEnabled(FeatureFlag.USER_IDENTITY_PERSISTENCE_ENABLED))
+        .thenReturn(false);
+    when(cognitoClient.fetchUserInfo("token"))
+        .thenReturn(Optional.of(sampleResponse("sub-from-user-info")));
+
+    Optional<UserIdentityEntity> result = service.getOrRefreshBySub("sub-from-jwt", "token");
+
+    assertThat(result).isPresent();
+    assertThat(result.orElseThrow().getSub()).isEqualTo("sub-from-user-info");
+    verify(cognitoClient).fetchUserInfo("token");
+    verify(repository, never()).save(org.mockito.ArgumentMatchers.any(UserIdentityEntity.class));
+    verify(repository, never()).findById(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  @DisplayName("should persist hydrated identity when flag is enabled")
+  void shouldPersistWhenFlagEnabled() {
+    when(featureFlagsConfiguration.isEnabled(FeatureFlag.USER_IDENTITY_PERSISTENCE_ENABLED))
+        .thenReturn(true);
+    when(cognitoClient.fetchUserInfo("token"))
+        .thenReturn(Optional.of(sampleResponse("sub-from-user-info")));
+    when(repository.save(org.mockito.ArgumentMatchers.any(UserIdentityEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    Optional<UserIdentityEntity> result = service.getOrRefreshBySub("sub-from-jwt", "token");
+
+    assertThat(result).isPresent();
+    verify(cognitoClient).fetchUserInfo("token");
+    verify(repository).save(org.mockito.ArgumentMatchers.any(UserIdentityEntity.class));
+    verify(repository, never()).findById(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  @DisplayName("should return empty persisted identity when persistence flag is disabled")
+  void shouldReturnEmptyPersistedIdentityWhenFlagDisabled() {
+    when(featureFlagsConfiguration.isEnabled(FeatureFlag.USER_IDENTITY_PERSISTENCE_ENABLED))
+        .thenReturn(false);
+
+    Optional<UserIdentityEntity> result = service.findPersistedBySub("sub");
+
+    assertThat(result).isEmpty();
+    verify(repository, never()).findById(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  @DisplayName("should delegate persisted identity lookup when persistence flag is enabled")
+  void shouldReadPersistedIdentityWhenFlagEnabled() {
+    UserIdentityEntity persisted = UserIdentityEntity.builder().sub("sub").build();
+    when(featureFlagsConfiguration.isEnabled(FeatureFlag.USER_IDENTITY_PERSISTENCE_ENABLED))
+        .thenReturn(true);
+    when(repository.findById("sub")).thenReturn(Optional.of(persisted));
+
+    Optional<UserIdentityEntity> result = service.findPersistedBySub("sub");
+
+    assertThat(result).contains(persisted);
+    verify(repository).findById("sub");
+  }
+
+  private CognitoUserInfoResponse sampleResponse(String sub) {
+    return new CognitoUserInfoResponse(
+        sub,
+        "user@example.com",
+        "John Doe",
+        null,
+        null,
+        "idir",
+        "idp-user-id",
+        "idp-user",
+        "Doe, John",
+        null,
+        java.util.List.of(),
+        Map.of("sub", sub)
+    );
+  }
+}
+

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/UserIdentityServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/UserIdentityServiceTest.java
@@ -28,6 +28,9 @@ class UserIdentityServiceTest {
   private UserIdentityRepository repository;
 
   @Mock
+  private UserIdentityPersistenceService userIdentityPersistenceService;
+
+  @Mock
   private CognitoUserInfoClient cognitoClient;
 
   @Mock
@@ -60,14 +63,16 @@ class UserIdentityServiceTest {
         .thenReturn(true);
     when(cognitoClient.fetchUserInfo("token"))
         .thenReturn(Optional.of(sampleResponse("sub-from-user-info")));
-    when(repository.save(org.mockito.ArgumentMatchers.any(UserIdentityEntity.class)))
+    when(userIdentityPersistenceService.saveHydratedIdentity(
+        org.mockito.ArgumentMatchers.any(UserIdentityEntity.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
 
     Optional<UserIdentityEntity> result = service.getOrRefreshBySub("sub-from-jwt", "token");
 
     assertThat(result).isPresent();
     verify(cognitoClient).fetchUserInfo("token");
-    verify(repository).save(org.mockito.ArgumentMatchers.any(UserIdentityEntity.class));
+    verify(userIdentityPersistenceService)
+        .saveHydratedIdentity(org.mockito.ArgumentMatchers.any(UserIdentityEntity.class));
     verify(repository, never()).findById(org.mockito.ArgumentMatchers.anyString());
   }
 

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTableExpandContent/index.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTableExpandContent/index.tsx
@@ -247,10 +247,24 @@ const WasteSearchTableExpandContent: FC<WasteSearchTableExpandContentProps> = ({
         </ReadonlyInput>
       </Column>
       <Column lg={3} md={3} sm={4}>
-        <p>Blocks in the RU: {data?.totalBlocks ?? 0}</p>
+        <ReadonlyInput
+          label=""
+          id={`${rowId}-block-count`}
+          isNumber={false}
+          showSkeleton={isLoading}
+        >
+          Blocks in the RU: {data?.totalBlocks ?? 0}
+        </ReadonlyInput>
       </Column>
       <Column lg={13} md={5} sm={4}>
-        <p>Secondary marks in the block: {data?.totalChildren ?? 0}</p>
+        <ReadonlyInput
+          label=""
+          id={`${rowId}-secondary-marks-count`}
+          isNumber={false}
+          showSkeleton={isLoading}
+        >
+          Secondary marks in the block: {data?.totalChildren ?? 0}
+        </ReadonlyInput>
       </Column>
     </Grid>
   );

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTableExpandContent/index.unit.test.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTableExpandContent/index.unit.test.tsx
@@ -424,6 +424,8 @@ describe('WasteSearchTableExpandContent', () => {
         expect(container.querySelector(`#${rowId}-submitter`)).toBeDefined();
         expect(container.querySelector(`#${rowId}-attachments-comments`)).toBeDefined();
         expect(container.querySelector(`#${rowId}-comment`)).toBeDefined();
+        expect(container.querySelector(`#${rowId}-block-count`)).toBeDefined();
+        expect(container.querySelector(`#${rowId}-secondary-marks-count`)).toBeDefined();
       });
     });
   });

--- a/frontend/src/config/tests/auth.helper.ts
+++ b/frontend/src/config/tests/auth.helper.ts
@@ -8,6 +8,7 @@ import type { Page } from '@playwright/test';
 interface CookieData {
   lastAuthUser: string;
   idToken: string;
+  accessToken: string;
 }
 
 const defaultGroups = {
@@ -59,6 +60,9 @@ const setupCustomClaims = (
     idToken: jwtfy(
       userType === 'idir' ? { ...idir, ...claimOverrides } : { ...bceid, ...claimOverrides },
     ),
+    accessToken: jwtfy(
+      userType === 'idir' ? { ...idir, ...claimOverrides } : { ...bceid, ...claimOverrides },
+    ),
   };
 };
 
@@ -69,7 +73,7 @@ export async function mockJwt(
 ) {
   const cookieData = setupCustomClaims(metadata.userType.toLowerCase(), claimOverrides);
 
-  const { lastAuthUser, idToken } = cookieData;
+  const { lastAuthUser, idToken, accessToken } = cookieData;
 
   const clientId = metadata.userPoolsClientId ?? process.env.VITE_USER_POOLS_WEB_CLIENT_ID;
   if (!clientId) {
@@ -81,6 +85,9 @@ export async function mockJwt(
   await page
     .context()
     .clearCookies({ name: `CognitoIdentityServiceProvider.${clientId}.${lastAuthUser}.idToken` });
+  await page
+    .context()
+    .clearCookies({ name: `CognitoIdentityServiceProvider.${clientId}.${lastAuthUser}.accessToken` });
   await page.context().addCookies([
     {
       name: `CognitoIdentityServiceProvider.${clientId}.LastAuthUser`,
@@ -93,6 +100,14 @@ export async function mockJwt(
     {
       name: `CognitoIdentityServiceProvider.${clientId}.${lastAuthUser}.idToken`,
       value: idToken,
+      sameSite: 'Lax',
+      expires: 2908989880,
+      path: '/',
+      domain: 'localhost',
+    },
+    {
+      name: `CognitoIdentityServiceProvider.${clientId}.${lastAuthUser}.accessToken`,
+      value: accessToken,
       sameSite: 'Lax',
       expires: 2908989880,
       path: '/',

--- a/frontend/src/context/auth/AuthProvider.tsx
+++ b/frontend/src/context/auth/AuthProvider.tsx
@@ -3,7 +3,7 @@ import isEqual from 'lodash/isEqual';
 import { useEffect, useMemo, useState, useCallback, type ReactNode } from 'react';
 
 import { AuthContext, type AuthContextType } from './AuthContext';
-import { parseToken, getUserTokenFromCookie } from './authUtils';
+import { parseToken, getUserAccessTokenFromCookie, getUserIdTokenFromCookie } from './authUtils';
 import { type FamLoginUser, type IdpProviderType, type JWT } from './types';
 
 import { signOutUrl } from '@/config/fam/config';
@@ -46,10 +46,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const appEnv = Number.isNaN(Number(env.VITE_ZONE)) ? (env.VITE_ZONE ?? 'TEST') : 'TEST';
   const isMock = env.VITE_MOCK_AUTH === 'true';
 
-  const loadUserToken = useCallback(async (): Promise<JWT | undefined> => {
+  const loadUserIdToken = useCallback(async (): Promise<JWT | undefined> => {
     if (isMock) {
       // This is for test only
-      const idToken = getUserTokenFromCookie();
+      const idToken = getUserIdTokenFromCookie();
       const payload = idToken ? JSON.parse(atob(idToken.split('.')[1])) : null;
       return payload ? { payload } : undefined;
     }
@@ -67,7 +67,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     async (silent = false) => {
       if (!silent) setIsLoading(true);
       try {
-        const idToken = await loadUserToken();
+        const idToken = await loadUserIdToken();
         const newUser = idToken ? parseToken(idToken) : undefined;
         setUser((prev) => {
           if (isEqual(prev, newUser)) return prev;
@@ -80,7 +80,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         if (!silent) setIsLoading(false);
       }
     },
-    [loadUserToken],
+    [loadUserIdToken],
   );
 
   useEffect(() => {
@@ -118,9 +118,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     navigateTo(signOutUrl);
   };
 
-  // Memoized function to get the current user's idToken from localStorage (via getUserTokenFromCookie)
+  // Memoized function to get the current user's access token from cookies.
   const userToken = useCallback(() => {
-    return getUserTokenFromCookie();
+    return getUserAccessTokenFromCookie();
   }, []);
 
   const contextValue: AuthContextType = useMemo(

--- a/frontend/src/context/auth/AuthProvider.unit.test.tsx
+++ b/frontend/src/context/auth/AuthProvider.unit.test.tsx
@@ -18,7 +18,8 @@ vi.mock('aws-amplify/auth', () => ({
 
 vi.mock('./authUtils', () => ({
   parseToken: vi.fn((token) => ({ id: 'user', name: 'Test User', token })),
-  getUserTokenFromCookie: vi.fn(() => undefined),
+  getUserAccessTokenFromCookie: vi.fn(() => undefined),
+  getUserIdTokenFromCookie: vi.fn(() => undefined),
 }));
 
 vi.mock('@/utils/navigation', () => ({
@@ -98,8 +99,8 @@ describe('AuthProvider (extra coverage)', () => {
     });
 
     it('calls userToken and returns value', async () => {
-      const { getUserTokenFromCookie } = await import('./authUtils');
-      (getUserTokenFromCookie as any).mockReturnValue('sometoken');
+      const { getUserAccessTokenFromCookie } = await import('./authUtils');
+      (getUserAccessTokenFromCookie as any).mockReturnValue('sometoken');
       let context: any;
       render(
         <AuthProvider>
@@ -140,8 +141,8 @@ describe('AuthProvider (extra coverage)', () => {
       expect(fetchAuthSession).not.toHaveBeenCalled();
     });
 
-    it("calls getUserTokenFromCookie and sets the user token payload to the cookie's decoded value", async () => {
-      const { getUserTokenFromCookie } = await import('./authUtils');
+    it("calls getUserIdTokenFromCookie and sets the user token payload to the cookie's decoded value", async () => {
+      const { getUserIdTokenFromCookie } = await import('./authUtils');
 
       const payload = {
         testKey: 'testValue',
@@ -149,7 +150,7 @@ describe('AuthProvider (extra coverage)', () => {
 
       const jwt = jwtfy(payload);
 
-      (getUserTokenFromCookie as any).mockReturnValue(jwt);
+      (getUserIdTokenFromCookie as any).mockReturnValue(jwt);
       let context: any;
       render(
         <AuthProvider>
@@ -162,7 +163,7 @@ describe('AuthProvider (extra coverage)', () => {
         </AuthProvider>,
       );
       await waitFor(() => expect(context).toBeDefined());
-      expect(getUserTokenFromCookie).toHaveBeenCalled();
+      expect(getUserIdTokenFromCookie).toHaveBeenCalled();
       expect(context.user.token.payload).toEqual(payload);
     });
   });

--- a/frontend/src/context/auth/authUtils.ts
+++ b/frontend/src/context/auth/authUtils.ts
@@ -24,10 +24,24 @@ export const getCookie = (name: string): string => {
 };
 
 /**
+ * Retrieves the Cognito accessToken for the current user from cookies.
+ * @returns {string | undefined} The accessToken string, or undefined if not found.
+ */
+export const getUserAccessTokenFromCookie = (): string | undefined => {
+  const baseCookieName = `CognitoIdentityServiceProvider.${env.VITE_USER_POOLS_WEB_CLIENT_ID}`;
+  const userId = encodeURIComponent(getCookie(`${baseCookieName}.LastAuthUser`));
+  if (userId) {
+    return getCookie(`${baseCookieName}.${userId}.accessToken`);
+  } else {
+    return undefined;
+  }
+};
+
+/**
  * Retrieves the Cognito idToken for the current user from cookies.
  * @returns {string | undefined} The idToken string, or undefined if not found.
  */
-export const getUserTokenFromCookie = (): string | undefined => {
+export const getUserIdTokenFromCookie = (): string | undefined => {
   const baseCookieName = `CognitoIdentityServiceProvider.${env.VITE_USER_POOLS_WEB_CLIENT_ID}`;
   const userId = encodeURIComponent(getCookie(`${baseCookieName}.LastAuthUser`));
   if (userId) {
@@ -36,6 +50,12 @@ export const getUserTokenFromCookie = (): string | undefined => {
     return undefined;
   }
 };
+
+/**
+ * Backward-compatible alias for existing call sites.
+ * Uses the access token because API authorization depends on it.
+ */
+export const getUserTokenFromCookie = getUserAccessTokenFromCookie;
 
 /**
  * Parses a JWT token and returns a FamLoginUser object if valid.

--- a/frontend/src/context/auth/authUtils.unit.test.ts
+++ b/frontend/src/context/auth/authUtils.unit.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { getCookie, getUserTokenFromCookie, parseToken } from './authUtils';
+import {
+  getCookie,
+  getUserAccessTokenFromCookie,
+  getUserIdTokenFromCookie,
+  getUserTokenFromCookie,
+  parseToken,
+} from './authUtils';
 
 // Mock env
 vi.mock(import('@/env'), async (importOriginal) => {
@@ -24,7 +30,7 @@ describe('authUtils', () => {
         writable: true,
         configurable: true,
         value:
-          'foo=bar; CognitoIdentityServiceProvider.test-client-id.LastAuthUser=theuser; CognitoIdentityServiceProvider.test-client-id.theuser.idToken=thetoken',
+          'foo=bar; CognitoIdentityServiceProvider.test-client-id.LastAuthUser=theuser; CognitoIdentityServiceProvider.test-client-id.theuser.idToken=idtoken; CognitoIdentityServiceProvider.test-client-id.theuser.accessToken=accesstoken',
       });
     });
     afterEach(() => {
@@ -45,27 +51,35 @@ describe('authUtils', () => {
     });
   });
 
-  describe('getUserTokenFromCookie', () => {
+  describe('token getters', () => {
     beforeEach(() => {
       Object.defineProperty(document, 'cookie', {
         writable: true,
         configurable: true,
         value:
-          'CognitoIdentityServiceProvider.test-client-id.LastAuthUser=theuser; CognitoIdentityServiceProvider.test-client-id.theuser.idToken=thetoken',
+          'CognitoIdentityServiceProvider.test-client-id.LastAuthUser=theuser; CognitoIdentityServiceProvider.test-client-id.theuser.idToken=idtoken; CognitoIdentityServiceProvider.test-client-id.theuser.accessToken=accesstoken',
       });
     });
     afterEach(() => {
       vi.clearAllMocks();
     });
-    it('returns the idToken from cookies', () => {
-      expect(getUserTokenFromCookie()).toBe('thetoken');
+    it('returns the accessToken from cookies', () => {
+      expect(getUserAccessTokenFromCookie()).toBe('accesstoken');
+      expect(getUserTokenFromCookie()).toBe('accesstoken');
     });
+
+    it('returns the idToken from cookies', () => {
+      expect(getUserIdTokenFromCookie()).toBe('idtoken');
+    });
+
     it('returns undefined if no userId', () => {
       Object.defineProperty(document, 'cookie', {
         writable: true,
         configurable: true,
         value: '',
       });
+      expect(getUserAccessTokenFromCookie()).toBeUndefined();
+      expect(getUserIdTokenFromCookie()).toBeUndefined();
       expect(getUserTokenFromCookie()).toBeUndefined();
     });
   });

--- a/frontend/src/pages/WasteSearch/expanded-row.e2e.test.tsx
+++ b/frontend/src/pages/WasteSearch/expanded-row.e2e.test.tsx
@@ -51,6 +51,13 @@ test.describe('Waste Search - Expanded Row Content', () => {
     ); // comments
     await expect(page.getByRole('link', { name: /Link/i })).toBeVisible(); // attachments and comments link
     await expect(page.getByText('Blocks in the RU: 15')).toBeVisible(); // totalBlocks
+    await expect(page.getByText('Secondary marks in the block: 0')).toBeVisible(); // totalChildren (defaults to 0)
+
+    // The last two values are rendered via ReadonlyInput card items.
+    await expect(page.locator('dl.card-item').filter({ hasText: 'Blocks in the RU: 15' })).toHaveCount(1);
+    await expect(
+      page.locator('dl.card-item').filter({ hasText: 'Secondary marks in the block: 0' }),
+    ).toHaveCount(1);
   });
 
   test('handles missing attachment and comment correctly', async ({ page }) => {
@@ -90,6 +97,7 @@ test.describe('Waste Search - Expanded Row Content', () => {
     ); // submitter
     await expect(page.getByTestId('card-item-comment:')).toHaveText('Comment:-'); // comments
     await expect(page.getByText('Blocks in the RU: 2')).toBeVisible(); // totalBlocks
+    await expect(page.getByText('Secondary marks in the block: 0')).toBeVisible(); // totalChildren (defaults to 0)
 
     // Verify attachments and comments link is present
     const attachmentsCommentsLinks = page.getByRole('link', {

--- a/frontend/src/services/APIs.ts
+++ b/frontend/src/services/APIs.ts
@@ -5,7 +5,7 @@ import type { APIConfig } from '@/config/api/types';
 
 import { failureNotificationMiddleware } from '@/config/api/failureNotificationMiddleware';
 import { problemDetailsMiddleware } from '@/config/api/problemDetailsMiddleware';
-import { getUserTokenFromCookie } from '@/context/auth/authUtils';
+import { getUserAccessTokenFromCookie } from '@/context/auth/authUtils';
 import { env } from '@/env';
 import { SearchService } from '@/services//search.service';
 import { ForestClientService } from '@/services/forestclient.service';
@@ -28,7 +28,7 @@ export const BackendApiConfig: APIConfig = {
 };
 
 BackendApiConfig.TOKEN = async () => {
-  return getUserTokenFromCookie() ?? '';
+  return getUserAccessTokenFromCookie() ?? '';
 };
 
 BackendApiConfig.HEADERS = async () => {

--- a/frontend/src/services/APIs.unit.test.ts
+++ b/frontend/src/services/APIs.unit.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('BackendApiConfig.TOKEN', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns access token from cookie helper', async () => {
+    const getUserAccessTokenFromCookie = vi.fn(() => 'access-token');
+    vi.doMock('@/context/auth/authUtils', () => ({
+      getUserAccessTokenFromCookie,
+    }));
+
+    const { BackendApiConfig } = await vi.importActual<typeof import('./APIs')>('./APIs');
+    const tokenResolver = BackendApiConfig.TOKEN as (() => Promise<string>) | undefined;
+
+    expect(tokenResolver).toBeTypeOf('function');
+    await expect(tokenResolver?.()).resolves.toBe('access-token');
+    expect(getUserAccessTokenFromCookie).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty string when access token cookie is unavailable', async () => {
+    const getUserAccessTokenFromCookie = vi.fn(() => undefined);
+    vi.doMock('@/context/auth/authUtils', () => ({
+      getUserAccessTokenFromCookie,
+    }));
+
+    const { BackendApiConfig } = await vi.importActual<typeof import('./APIs')>('./APIs');
+    const tokenResolver = BackendApiConfig.TOKEN as (() => Promise<string>) | undefined;
+
+    expect(tokenResolver).toBeTypeOf('function');
+    await expect(tokenResolver?.()).resolves.toBe('');
+    expect(getUserAccessTokenFromCookie).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This PR delivers a cross-stack authentication and identity-hydration update, including backend user identity persistence support and frontend token-source correction.

Summary of what changed:
- Backend identity hydration and persistence pipeline:
  - Added identity domain model and persistence: UserIdentityEntity, UserIdentityRepository, migration V1.0.1__user_identity.sql.
  - Added Cognito userInfo integration: CognitoUserInfoClient and CognitoUserInfoResponse.
  - Added runtime hydration/auth wiring: UserIdentityHydrationFilter, UserIdentityAuthentication, UserIdentityService.
  - Updated security/configuration wiring to install hydration after bearer token auth and register supporting configuration.
- Backend behavioural/security updates:
  - Updated JwtPrincipalUtil, Oauth2SecurityCustomizer, DatabaseAuditor, HrsConfiguration, GlobalConfiguration, SecurityConfiguration.
  - Updated deployment/config surfaces: backend/openshift.deploy.yml and backend/src/main/resources/application.yml.
- Frontend token-source split fix:
  - Frontend user loading/parsing now uses idToken.
  - Backend API authorization now uses accessToken.
  - Added explicit token helpers and updated AuthProvider/API wiring.
- Test/mocking updates:
  - Updated Playwright mock auth helper to set both Cognito cookies (idToken and accessToken).
  - Added/updated frontend unit tests, including APIs.unit.test.ts and auth provider/utils tests.
  - Added backend unit tests for Cognito user info client, database auditor, and user identity service.
- Fixes #777 


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] New unit tests
- [x] New integrated tests
- [x] New end-to-end tests
- [x] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

If this PR adds, changes, or removes behaviour behind a feature flag, this section is required.
Use the architecture checklist in the Feature Flags page as the source of truth.

- [x] Canonical key follows `<domain>-<capability>-enabled`


Feature flag included in this change:
- Enum constant: USER_IDENTITY_PERSISTENCE_ENABLED
- Canonical key: user-identity-persistence-enabled
- Current backend behaviour: identity hydration always calls Cognito userInfo; this flag gates database persistence.
- Current automated coverage includes enabled and disabled paths in UserIdentityServiceTest.

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


Risk and rollout notes:
- Primary risk is auth/token-source regression between frontend and backend (idToken vs accessToken split).
- Primary backend risk is identity hydration filter behaviour and persistence gating by feature flag on protected paths.
- Mitigations in this PR:
  - Explicit token helper split on frontend.
  - Updated E2E mock cookies to include both tokens.
  - Added service-level feature-flag tests for enabled and disabled persistence behaviour.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-28-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)