### PR TITLE
feat(#779): add bookmarking support for Reporting units

### DIFF
--- a/.github/workflows/reusable-tests-fe.yml
+++ b/.github/workflows/reusable-tests-fe.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       VITE_APP_NAME: Waste Plus
-      VITE_FEATURE_FLAGS: '{"offline-mode-enabled":true}'
+      VITE_FEATURE_FLAGS: '{"offline-mode-enabled":false,"bookmark-ru-enabled":true}'
       VITE_ZONE: TEST
       VITE_MOCK_AUTH: true
       VITE_USER_POOLS_ID: ${{ secrets.COGNITO_USER_POOL }}
@@ -43,7 +43,7 @@ jobs:
         id: tests
         env:
           VITE_APP_NAME: Waste Plus
-          VITE_FEATURE_FLAGS: '{"offline-mode-enabled":true}'
+          VITE_FEATURE_FLAGS: '{"offline-mode-enabled":false,"bookmark-ru-enabled":true}'
           VITE_ZONE: TEST
           VITE_MOCK_AUTH: true
           VITE_USER_POOLS_ID: ${{ secrets.COGNITO_USER_POOL }}

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/SearchController.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/SearchController.java
@@ -89,7 +89,7 @@ public class SearchController {
     }
 
     log.info("Searching waste entries with filters: {}, pageable: {}", filters, pageable);
-    return service.search(filters, pageable);
+    return service.search(JwtPrincipalUtil.getUserId(jwt), filters, pageable);
 
   }
 

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/UserController.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/UserController.java
@@ -3,7 +3,6 @@ package ca.bc.gov.nrs.hrs.controller;
 import ca.bc.gov.nrs.hrs.service.UserService;
 import ca.bc.gov.nrs.hrs.util.JwtPrincipalUtil;
 import io.micrometer.observation.annotation.Observed;
-import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -113,20 +112,5 @@ public class UserController {
     log.info("Removing bookmark for user: {} and reporting unit: {}",
         JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
     userService.deleteUserBookmark(JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
-  }
-
-  /**
-   * Retrieve all bookmarked reporting unit IDs for the authenticated user.
-   *
-   * <p>Delegates to {@link UserService#getUserBookmarks(String)} and returns the list of
-   * reporting unit IDs the user has bookmarked.</p>
-   *
-   * @param jwt the authenticated user's JWT principal (injected by Spring)
-   * @return list of bookmarked reporting unit IDs
-   */
-  @GetMapping("/bookmarks")
-  public List<Long> getBookmarkedReportingUnitIds(@AuthenticationPrincipal Jwt jwt) {
-    log.info("Retrieving bookmarks for user: {}", JwtPrincipalUtil.getUserId(jwt));
-    return userService.getUserBookmarks(JwtPrincipalUtil.getUserId(jwt));
   }
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/UserController.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/UserController.java
@@ -1,5 +1,7 @@
 package ca.bc.gov.nrs.hrs.controller;
 
+import ca.bc.gov.nrs.hrs.configuration.FeatureFlagsConfiguration;
+import ca.bc.gov.nrs.hrs.dto.base.FeatureFlag;
 import ca.bc.gov.nrs.hrs.service.UserService;
 import ca.bc.gov.nrs.hrs.util.JwtPrincipalUtil;
 import io.micrometer.observation.annotation.Observed;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * REST endpoints for user-specific operations such as reading and updating user preferences.
@@ -34,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
   private final UserService userService;
+  private final FeatureFlagsConfiguration featureFlagsConfiguration;
 
   /**
    * Retrieve the preferences for the authenticated user.
@@ -89,9 +93,15 @@ public class UserController {
       @AuthenticationPrincipal Jwt jwt,
       @PathVariable Long reportingUnitId
   ) {
-    log.info("Adding bookmark for user: {} and reporting unit: {}",
-        JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
-    userService.addUserBookmark(JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
+
+    if (featureFlagsConfiguration.isEnabled(FeatureFlag.BOOKMARK_REPORTING_UNIT_ENABLED)) {
+      log.info("Adding bookmark for user: {} and reporting unit: {}",
+          JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
+      userService.addUserBookmark(JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
+    } else {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+          "The requested resource is not available");
+    }
   }
 
   /**
@@ -109,8 +119,13 @@ public class UserController {
       @AuthenticationPrincipal Jwt jwt,
       @PathVariable Long reportingUnitId
   ) {
-    log.info("Removing bookmark for user: {} and reporting unit: {}",
-        JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
-    userService.deleteUserBookmark(JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
+    if (featureFlagsConfiguration.isEnabled(FeatureFlag.BOOKMARK_REPORTING_UNIT_ENABLED)) {
+      log.info("Removing bookmark for user: {} and reporting unit: {}",
+          JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
+      userService.deleteUserBookmark(JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
+    } else {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+          "The requested resource is not available");
+    }
   }
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/UserController.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/UserController.java
@@ -3,13 +3,16 @@ package ca.bc.gov.nrs.hrs.controller;
 import ca.bc.gov.nrs.hrs.service.UserService;
 import ca.bc.gov.nrs.hrs.util.JwtPrincipalUtil;
 import io.micrometer.observation.annotation.Observed;
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -72,4 +75,58 @@ public class UserController {
     );
   }
 
+  /**
+   * Bookmark a reporting unit for the authenticated user.
+   *
+   * <p>Delegates to {@link UserService#addUserBookmark(String, Long)}. The operation is
+   * idempotent: bookmarking an already-bookmarked reporting unit is a safe no-op.</p>
+   *
+   * @param jwt             the authenticated user's JWT principal (injected by Spring)
+   * @param reportingUnitId the reporting unit to bookmark
+   */
+  @PutMapping("/bookmarks/{reportingUnitId}")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public void addBookmarkedReportingUnit(
+      @AuthenticationPrincipal Jwt jwt,
+      @PathVariable Long reportingUnitId
+  ) {
+    log.info("Adding bookmark for user: {} and reporting unit: {}",
+        JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
+    userService.addUserBookmark(JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
+  }
+
+  /**
+   * Remove a bookmarked reporting unit for the authenticated user.
+   *
+   * <p>Delegates to {@link UserService#deleteUserBookmark(String, Long)}. The operation is
+   * idempotent: removing a bookmark that does not exist is a safe no-op.</p>
+   *
+   * @param jwt             the authenticated user's JWT principal (injected by Spring)
+   * @param reportingUnitId the reporting unit to un-bookmark
+   */
+  @DeleteMapping("/bookmarks/{reportingUnitId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void removeBookmarkedReportingUnit(
+      @AuthenticationPrincipal Jwt jwt,
+      @PathVariable Long reportingUnitId
+  ) {
+    log.info("Removing bookmark for user: {} and reporting unit: {}",
+        JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
+    userService.deleteUserBookmark(JwtPrincipalUtil.getUserId(jwt), reportingUnitId);
+  }
+
+  /**
+   * Retrieve all bookmarked reporting unit IDs for the authenticated user.
+   *
+   * <p>Delegates to {@link UserService#getUserBookmarks(String)} and returns the list of
+   * reporting unit IDs the user has bookmarked.</p>
+   *
+   * @param jwt the authenticated user's JWT principal (injected by Spring)
+   * @return list of bookmarked reporting unit IDs
+   */
+  @GetMapping("/bookmarks")
+  public List<Long> getBookmarkedReportingUnitIds(@AuthenticationPrincipal Jwt jwt) {
+    log.info("Retrieving bookmarks for user: {}", JwtPrincipalUtil.getUserId(jwt));
+    return userService.getUserBookmarks(JwtPrincipalUtil.getUserId(jwt));
+  }
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/dto/base/FeatureFlag.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/dto/base/FeatureFlag.java
@@ -1,5 +1,7 @@
 package ca.bc.gov.nrs.hrs.dto.base;
 
+import lombok.Getter;
+
 /**
  * Known feature flag keys for compile-time discoverability.
  *
@@ -29,6 +31,7 @@ package ca.bc.gov.nrs.hrs.dto.base;
  *
  * @since 1.0.0
  */
+@Getter
 public enum FeatureFlag {
 
   OFFLINE_MODE_ENABLED("offline-mode-enabled"),
@@ -40,24 +43,18 @@ public enum FeatureFlag {
    * for request-time hydration but does not write/read identity data from the database.
    * This allows privacy-first rollout while keeping the hydration pipeline active.</p>
    */
-  USER_IDENTITY_PERSISTENCE_ENABLED("user-identity-persistence-enabled");
+  USER_IDENTITY_PERSISTENCE_ENABLED("user-identity-persistence-enabled"),
+
+  /**
+   * Controls whether the reporting unit bookmark feature is enabled.
+   * <p>When enabled, users can bookmark a reporting unit, and see their bookmarked values as
+   * part of the search result</p>
+   */
+  BOOKMARK_REPORTING_UNIT_ENABLED("bookmark-ru-enabled");
 
   private final String key;
 
   FeatureFlag(String key) {
     this.key = key;
-  }
-
-  /**
-   * Returns the YAML configuration key for this flag.
-   *
-   * <p>This is the string used as the key under {@code features.flags} in
-   * {@code application.yml}, and must match the canonical cross-stack key
-   * format {@code <domain>-<capability>-enabled}.
-   *
-   * @return the configuration key string
-   */
-  public String getKey() {
-    return key;
   }
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchParametersDto.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchParametersDto.java
@@ -40,6 +40,7 @@ public class ReportingUnitSearchParametersDto {
   private List<String> status;
   private boolean requestByMe;
   private boolean multiMark;
+  private boolean bookmarked;
   private String requestUserId;
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
   private LocalDate updateDateStart;
@@ -49,6 +50,7 @@ public class ReportingUnitSearchParametersDto {
   private String cuttingPermitId;
   private String timberMark;
   private List<String> clientNumbers;
+  private List<Long> reportingUnitIds;
 
   /**
    * Convert the populated search parameters into a {@link MultiValueMap} of query parameters
@@ -109,6 +111,10 @@ public class ReportingUnitSearchParametersDto {
       multiValueMap.add("updateDateEnd", updateDateEnd.format(DateTimeFormatter.ISO_LOCAL_DATE));
     }
 
+    if (!CollectionUtils.isEmpty(reportingUnitIds)) {
+      reportingUnitIds.forEach(value -> multiValueMap.add("reportingUnitIds", value.toString()));
+    }
+
     multiValueMap.addAll(UriUtils.buildPageableQueryParam(page));
 
     return multiValueMap;
@@ -136,6 +142,7 @@ public class ReportingUnitSearchParametersDto {
            && CollectionUtils.isEmpty(status)
            && !requestByMe
            && !multiMark
+           && !bookmarked
            && StringUtils.isBlank(requestUserId)
            && updateDateStart == null
            && updateDateEnd == null

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchResultDto.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchResultDto.java
@@ -37,6 +37,7 @@ public record ReportingUnitSearchResultDto(
     CodeDescriptionDto sampling,
     CodeDescriptionDto district,
     CodeDescriptionDto status,
-    LocalDateTime lastUpdated
+    LocalDateTime lastUpdated,
+    boolean bookmarked
 ) {
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/entity/users/UserBookmarkEntity.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/entity/users/UserBookmarkEntity.java
@@ -1,0 +1,56 @@
+package ca.bc.gov.nrs.hrs.entity.users;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.With;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * JPA entity that stores bookmarked reporting units for users.
+ *
+ * <p>
+ * Maps to {@code hrs.user_bookmarks}. The table uses a composite primary key
+ * made of {@link #userId} and {@link #reportingUnitId}, allowing each user to
+ * bookmark multiple reporting units while preventing duplicate bookmarks for
+ * the same user/reporting-unit pair.
+ * </p>
+ */
+@Entity
+@Table(name = "user_bookmarks", schema = "hrs")
+@IdClass(UserBookmarkEntityId.class)
+@Data
+@Builder
+@With
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EntityListeners(AuditingEntityListener.class)
+public class UserBookmarkEntity {
+
+  /**
+   * Unique identifier for the user who owns the bookmark.
+   * Part of the composite primary key.
+   */
+  @Id
+  @Column(name = "user_id", nullable = false, length = 70)
+  @EqualsAndHashCode.Include
+  private String userId;
+
+  /**
+   * Identifier of the bookmarked reporting unit.
+   * Part of the composite primary key.
+   */
+  @Id
+  @Column(name = "reporting_unit_id", nullable = false)
+  @EqualsAndHashCode.Include
+  private Long reportingUnitId;
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/entity/users/UserBookmarkEntityId.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/entity/users/UserBookmarkEntityId.java
@@ -1,0 +1,28 @@
+package ca.bc.gov.nrs.hrs.entity.users;
+
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Composite identifier for {@link UserBookmarkEntity}.
+ *
+ * <p>
+ * The fields and types must match the {@code @Id} fields declared in
+ * {@link UserBookmarkEntity}.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserBookmarkEntityId implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = -54654686531L;
+
+  private String userId;
+  private Long reportingUnitId;
+}
+

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/UserBookmarkRepository.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/UserBookmarkRepository.java
@@ -1,0 +1,23 @@
+package ca.bc.gov.nrs.hrs.repository;
+
+import ca.bc.gov.nrs.hrs.entity.users.UserBookmarkEntity;
+import ca.bc.gov.nrs.hrs.entity.users.UserBookmarkEntityId;
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserBookmarkRepository
+    extends PagingAndSortingRepository<UserBookmarkEntity, UserBookmarkEntityId>,
+        CrudRepository<UserBookmarkEntity, UserBookmarkEntityId> {
+
+  /**
+   * Returns all bookmarks belonging to a given user.
+   *
+   * @param userId the user's identifier
+   * @return list of bookmarked reporting units for that user
+   */
+  List<UserBookmarkEntity> findByUserId(String userId);
+
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/UserBookmarkRepository.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/UserBookmarkRepository.java
@@ -20,4 +20,15 @@ public interface UserBookmarkRepository
    */
   List<UserBookmarkEntity> findByUserId(String userId);
 
+  /**
+   * Returns all bookmarks belonging to a user that are included in the list of RUs.
+   *
+   * @param userId the user's identifier
+   * @param reportingUnitIds a reference list of RU identifiers to filter the user's bookmarks by.
+   * @return list of bookmarked reporting units for the selected filters
+   */
+  List<UserBookmarkEntity> findByUserIdAndReportingUnitIdIn(
+      String userId, List<Long> reportingUnitIds
+  );
+
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/security/ApiAuthorizationCustomizer.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/security/ApiAuthorizationCustomizer.java
@@ -54,8 +54,8 @@ public class ApiAuthorizationCustomizer implements
         .requestMatchers(HttpMethod.OPTIONS, "/**")
         .authenticated()
 
-        // User Preferences can be accessed by authenticated users
-        .requestMatchers("/api/users/preferences")
+        // User endpoints (preferences and bookmarks) can be accessed by authenticated users
+        .requestMatchers("/api/users/**")
         .authenticated()
 
         // Codes can be accessed by authenticated users

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/SearchService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/SearchService.java
@@ -2,7 +2,9 @@ package ca.bc.gov.nrs.hrs.service;
 
 import static java.util.stream.Collectors.toMap;
 
+import ca.bc.gov.nrs.hrs.configuration.FeatureFlagsConfiguration;
 import ca.bc.gov.nrs.hrs.dto.base.CodeDescriptionDto;
+import ca.bc.gov.nrs.hrs.dto.base.FeatureFlag;
 import ca.bc.gov.nrs.hrs.dto.search.MyForestClientSearchResultDto;
 import ca.bc.gov.nrs.hrs.dto.search.ReportingUnitSearchExpandedDto;
 import ca.bc.gov.nrs.hrs.dto.search.ReportingUnitSearchParametersDto;
@@ -41,6 +43,7 @@ public class SearchService {
   private final LegacyApiProvider legacyApiProvider;
   private final ForestClientService forestClientService;
   private final UserService userService;
+  private final FeatureFlagsConfiguration featureFlagsConfiguration;
 
   /**
    * Search reporting units using the supplied filters and pageable settings.
@@ -61,7 +64,8 @@ public class SearchService {
       Pageable pageable
   ) {
 
-    if (filters != null && filters.isBookmarked()) {
+    if (filters != null && filters.isBookmarked() && featureFlagsConfiguration.isEnabled(
+        FeatureFlag.BOOKMARK_REPORTING_UNIT_ENABLED)) {
       filters.setReportingUnitIds(userService.getUserBookmarksInList(userId, List.of()));
     }
 
@@ -87,7 +91,10 @@ public class SearchService {
         .map(ReportingUnitSearchResultDto::ruNumber)
         .toList();
 
-    var bookmarkedEntries = userService.getUserBookmarksInList(userId, reportingUnitsInPage);
+    var bookmarkedEntries =
+        featureFlagsConfiguration.isEnabled(FeatureFlag.BOOKMARK_REPORTING_UNIT_ENABLED)
+            ? userService.getUserBookmarksInList(userId, reportingUnitsInPage)
+            : List.of();
 
     //Enrich the results with client and location details
     return result

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/SearchService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/SearchService.java
@@ -40,6 +40,7 @@ public class SearchService {
 
   private final LegacyApiProvider legacyApiProvider;
   private final ForestClientService forestClientService;
+  private final UserService userService;
 
   /**
    * Search reporting units using the supplied filters and pageable settings.
@@ -48,15 +49,21 @@ public class SearchService {
    * calling the Forest Client service.
    * </p>
    *
+   * @param userId the current user
    * @param filters  search filters
    * @param pageable paging parameters
    * @return a page of {@link ReportingUnitSearchResultDto} enriched with client info
    */
   @NewSpan
   public Page<ReportingUnitSearchResultDto> search(
+      String userId,
       ReportingUnitSearchParametersDto filters,
       Pageable pageable
   ) {
+
+    if (filters != null && filters.isBookmarked()) {
+      filters.setReportingUnitIds(userService.getUserBookmarksInList(userId, List.of()));
+    }
 
     //Search the legacy API for reporting units
     var result = legacyApiProvider.searchReportingUnit(filters, pageable);
@@ -67,13 +74,20 @@ public class SearchService {
             .stream()
             .map(ReportingUnitSearchResultDto::client)
             .distinct()
-            .map(client -> 
+            .map(client ->
                 forestClientService
                     .getClientByNumber(client.code())
                     .map(forestClientDto -> client.withDescription(forestClientDto.name()))
                     .orElse(client)
             )
             .collect(toMap(CodeDescriptionDto::code, client -> client));
+
+    var reportingUnitsInPage = result
+        .stream()
+        .map(ReportingUnitSearchResultDto::ruNumber)
+        .toList();
+
+    var bookmarkedEntries = userService.getUserBookmarksInList(userId, reportingUnitsInPage);
 
     //Enrich the results with client and location details
     return result
@@ -86,13 +100,14 @@ public class SearchService {
                 )
             )
         )
-        .map(entry -> entry.withClient(clients.get(entry.client().code())));
+        .map(entry -> entry.withClient(clients.get(entry.client().code())))
+        .map(entry -> entry.withBookmarked(bookmarkedEntries.contains(entry.ruNumber())));
   }
 
   /**
    * Get expanded search details for a specific reporting unit and block.
    *
-   * @param ruId the reporting unit id
+   * @param ruId                  the reporting unit id
    * @param wasteAssessmentAreaId the waste assessment area ID
    * @return the expanded reporting unit search details
    */
@@ -101,7 +116,7 @@ public class SearchService {
       Long ruId, Long wasteAssessmentAreaId
   ) {
     log.info(
-        "Loading expanded search for ruId: {}, wasteAssessmentAreaId: {}", 
+        "Loading expanded search for ruId: {}, wasteAssessmentAreaId: {}",
         ruId,
         wasteAssessmentAreaId);
     return legacyApiProvider.getSearchExpanded(ruId, wasteAssessmentAreaId);

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/UserService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/UserService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Service responsible for reading and persisting user preference data.
@@ -120,8 +121,13 @@ public class UserService {
   }
 
   @NewSpan
-  public List<Long> getUserBookmarks(String userId) {
-    return bookmarkRepository.findByUserId(userId)
+  public List<Long> getUserBookmarksInList(String userId, List<Long> reportingUnitIds) {
+    List<UserBookmarkEntity> bookmarkEntities =
+      (CollectionUtils.isEmpty(reportingUnitIds))
+          ? bookmarkRepository.findByUserId(userId)
+          : bookmarkRepository.findByUserIdAndReportingUnitIdIn(userId, reportingUnitIds);
+
+    return bookmarkEntities
         .stream()
         .map(UserBookmarkEntity::getReportingUnitId)
         .toList();

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/UserService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/UserService.java
@@ -1,20 +1,26 @@
 package ca.bc.gov.nrs.hrs.service;
 
+import ca.bc.gov.nrs.hrs.entity.users.UserBookmarkEntity;
+import ca.bc.gov.nrs.hrs.entity.users.UserBookmarkEntityId;
 import ca.bc.gov.nrs.hrs.entity.users.UserPreferenceEntity;
+import ca.bc.gov.nrs.hrs.repository.UserBookmarkRepository;
 import ca.bc.gov.nrs.hrs.repository.UserPreferenceRepository;
 import io.micrometer.observation.annotation.Observed;
 import io.micrometer.tracing.annotation.NewSpan;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Service responsible for reading and persisting user preference data.
  *
  * <p>Provides methods to retrieve a user's preferences as a {@link Map} and to
- * save updated preferences. Preferences are stored in the {@link
- * UserPreferenceEntity} and accessed via {@link UserPreferenceRepository}.
+ * save updated preferences. Preferences are stored in the {@link UserPreferenceEntity} and accessed
+ * via {@link UserPreferenceRepository}.
  * </p>
  */
 @Slf4j
@@ -24,6 +30,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
   private final UserPreferenceRepository preferenceRepository;
+  private final UserBookmarkRepository bookmarkRepository;
 
   /**
    * Retrieve preferences for a given user id.
@@ -47,16 +54,15 @@ public class UserService {
    * Persist or update preferences for a given user.
    *
    * <p>If a preferences record already exists for the user it will be updated
-   * with the provided values; otherwise a new {@link UserPreferenceEntity}
-   * will be created and saved.
+   * with the provided values; otherwise a new {@link UserPreferenceEntity} will be created and
+   * saved.
    * </p>
    *
-   * @param userId the id of the user
+   * @param userId      the id of the user
    * @param preferences the preferences to save
    */
   @NewSpan
   public void saveUserPreferences(String userId, Map<String, Object> preferences) {
-
 
     log.info("Saving preferences for user: {}", userId);
 
@@ -73,5 +79,51 @@ public class UserService {
             );
 
     preferenceRepository.save(preferenceEntity);
+  }
+
+  /**
+   * Adds a bookmark for the given user and reporting unit.
+   *
+   * <p>This method is idempotent: calling it multiple times with the same arguments
+   * has the same effect as calling it once. If the bookmark already exists, the
+   * {@code save} call becomes a no-op merge (no extra columns to update), so no
+   * separate existence check is needed and no race condition can occur.</p>
+   *
+   * @param userId          the user's identifier
+   * @param reportingUnitId the reporting unit to bookmark
+   */
+  @NewSpan
+  @Transactional
+  public void addUserBookmark(String userId, Long reportingUnitId) {
+    log.info("Adding bookmark for user: {} and reporting unit: {}", userId, reportingUnitId);
+    bookmarkRepository.save(new UserBookmarkEntity(userId, reportingUnitId));
+  }
+
+  /**
+   * Removes a bookmark for the given user and reporting unit.
+   *
+   * <p>This method is idempotent: calling it when the bookmark does not exist is a
+   * safe no-op. The existence check and the delete are wrapped in a single
+   * transaction to prevent a race condition between the two operations.</p>
+   *
+   * @param userId          the user's identifier
+   * @param reportingUnitId the reporting unit to un-bookmark
+   */
+  @NewSpan
+  @Transactional
+  public void deleteUserBookmark(String userId, Long reportingUnitId) {
+    log.info("Deleting bookmark for user: {} and reporting unit: {}", userId, reportingUnitId);
+    Optional
+        .of(new UserBookmarkEntityId(userId, reportingUnitId))
+        .filter(bookmarkRepository::existsById)
+        .ifPresent(bookmarkRepository::deleteById);
+  }
+
+  @NewSpan
+  public List<Long> getUserBookmarks(String userId) {
+    return bookmarkRepository.findByUserId(userId)
+        .stream()
+        .map(UserBookmarkEntity::getReportingUnitId)
+        .toList();
   }
 }

--- a/backend/src/main/resources/db/migration/V1.0.2__bookmarks.sql
+++ b/backend/src/main/resources/db/migration/V1.0.2__bookmarks.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS hrs.user_bookmarks (
+    user_id    VARCHAR(70) NOT NULL,
+    reporting_unit_id BIGINT NOT NULL,
+    CONSTRAINT user_bookmarks_pk primary key(user_id, reporting_unit_id)
+);
+
+comment on table hrs.user_bookmarks is '
+Table to store user bookmarked reporting units.
+Users can bookmark multiple reporting units.
+Each reporting unit can be bookmarked by multiple users.
+Bookmarked reporting units are also used as reference for the offline mode.';
+comment on column hrs.user_bookmarks.user_id is 'Unique identifier for the user';
+comment on column hrs.user_bookmarks.reporting_unit_id is '
+Unique identifier for the reporting unit that the user has bookmarked.
+This is a foreign key referencing the reporting unit in the oracle database.';

--- a/backend/src/main/resources/db/migration/V1.0.2__bookmarks.sql
+++ b/backend/src/main/resources/db/migration/V1.0.2__bookmarks.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS hrs.user_bookmarks (
-    user_id    VARCHAR(70) NOT NULL,
+    user_id    VARCHAR(60) NOT NULL,
     reporting_unit_id BIGINT NOT NULL,
     CONSTRAINT user_bookmarks_pk primary key(user_id, reporting_unit_id)
 );
@@ -13,3 +13,6 @@ comment on column hrs.user_bookmarks.user_id is 'Unique identifier for the user'
 comment on column hrs.user_bookmarks.reporting_unit_id is '
 Unique identifier for the reporting unit that the user has bookmarked.
 This is a foreign key referencing the reporting unit in the oracle database.';
+
+-- add an index to speed lookups by reporting_unit_id
+create index if not exists idx_user_bookmarks_reporting_unit_id on hrs.user_bookmarks (reporting_unit_id);

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/SearchControllerIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/SearchControllerIntegrationTest.java
@@ -7,7 +7,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.unauthorized;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.springframework.boot.webmvc.test.autoconfigure.MockMvcPrint.SYSTEM_OUT;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,6 +19,7 @@ import ca.bc.gov.nrs.hrs.extensions.AbstractTestContainerIntegrationTest;
 import ca.bc.gov.nrs.hrs.extensions.WiremockLogNotifier;
 import ca.bc.gov.nrs.hrs.extensions.WithMockJwt;
 import ca.bc.gov.nrs.hrs.provider.forestclient.ForestClientApiProviderTestConstants;
+import ca.bc.gov.nrs.hrs.repository.UserBookmarkRepository;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -76,6 +79,8 @@ class SearchControllerIntegrationTest extends AbstractTestContainerIntegrationTe
   private CircuitBreakerRegistry circuitBreakerRegistry;
   @Autowired
   private RetryRegistry retryRegistry;
+  @Autowired
+  private UserBookmarkRepository bookmarkRepository;
 
   @BeforeEach
   public void setUp() {
@@ -87,6 +92,8 @@ class SearchControllerIntegrationTest extends AbstractTestContainerIntegrationTe
     RetryConfig retry = retryRegistry.retry("apiRetry").getRetryConfig();
     retryRegistry.remove("apiRetry");
     retryRegistry.retry("apiRetry", retry);
+
+    bookmarkRepository.deleteAll();
   }
 
   @ParameterizedTest
@@ -353,6 +360,131 @@ class SearchControllerIntegrationTest extends AbstractTestContainerIntegrationTe
             0L
         )
     );
+  }
+
+  @Test
+  @DisplayName("Search bookmarked reporting units with bookmarks should return bookmarked results")
+  void searchBookmarkedReportingUnits_withBookmarks_shouldReturnResults() throws Exception {
+    // First, add a bookmark for reporting unit 36834 (the one in the stub response)
+    mockMvc
+        .perform(
+            put("/api/users/bookmarks/{reportingUnitId}", 36834L)
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isAccepted());
+
+    legacyApiStub.stubFor(
+        WireMock.get(urlPathEqualTo("/api/search/reporting-units"))
+            .willReturn(okJson(ForestClientApiProviderTestConstants.REPORTING_UNITS_SEARCH_RESPONSE))
+    );
+
+    clientApiStub.stubFor(
+        WireMock.get(urlPathEqualTo("/clients/findByClientNumber/00010002"))
+            .willReturn(okJson(ForestClientApiProviderTestConstants.CLIENT_00010002))
+    );
+
+    mockMvc
+        .perform(
+            get("/api/search/reporting-units")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("bookmarked", "true")
+                .queryParam("page", "0")
+                .queryParam("size", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(jsonPath("$.content.length()").value(1))
+        .andExpect(jsonPath("$.content[0].ruNumber").value(36834))
+        .andExpect(jsonPath("$.content[0].bookmarked").value(true))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Search bookmarked reporting units with no bookmarks should return empty")
+  void searchBookmarkedReportingUnits_withNoBookmarks_shouldReturnEmpty() throws Exception {
+    legacyApiStub.stubFor(
+        WireMock.get(urlPathEqualTo("/api/search/reporting-units"))
+            .willReturn(okJson(ForestClientApiProviderTestConstants.REPORTING_UNITS_EMPTY_SEARCH_RESPONSE))
+    );
+
+    mockMvc
+        .perform(
+            get("/api/search/reporting-units")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("bookmarked", "true")
+                .queryParam("page", "0")
+                .queryParam("size", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(jsonPath("$.content.length()").value(0))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Search results should show bookmarked=false when no bookmarks exist")
+  void searchReportingUnits_withoutBookmarks_shouldShowBookmarkedFalse() throws Exception {
+    legacyApiStub.stubFor(
+        WireMock.get(urlPathEqualTo("/api/search/reporting-units"))
+            .willReturn(okJson(ForestClientApiProviderTestConstants.REPORTING_UNITS_SEARCH_RESPONSE))
+    );
+
+    clientApiStub.stubFor(
+        WireMock.get(urlPathEqualTo("/clients/findByClientNumber/00010002"))
+            .willReturn(okJson(ForestClientApiProviderTestConstants.CLIENT_00010002))
+    );
+
+    mockMvc
+        .perform(
+            get("/api/search/reporting-units")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("mainSearchTerm", "36834")
+                .queryParam("page", "0")
+                .queryParam("size", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(jsonPath("$.content.length()").value(1))
+        .andExpect(jsonPath("$.content[0].bookmarked").value(false))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Search results should show bookmarked=true when result is bookmarked")
+  void searchReportingUnits_withBookmark_shouldShowBookmarkedTrue() throws Exception {
+    // Add a bookmark for reporting unit 36834
+    mockMvc
+        .perform(
+            put("/api/users/bookmarks/{reportingUnitId}", 36834L)
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isAccepted());
+
+    legacyApiStub.stubFor(
+        WireMock.get(urlPathEqualTo("/api/search/reporting-units"))
+            .willReturn(okJson(ForestClientApiProviderTestConstants.REPORTING_UNITS_SEARCH_RESPONSE))
+    );
+
+    clientApiStub.stubFor(
+        WireMock.get(urlPathEqualTo("/clients/findByClientNumber/00010002"))
+            .willReturn(okJson(ForestClientApiProviderTestConstants.CLIENT_00010002))
+    );
+
+    mockMvc
+        .perform(
+            get("/api/search/reporting-units")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("mainSearchTerm", "36834")
+                .queryParam("page", "0")
+                .queryParam("size", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(jsonPath("$.content.length()").value(1))
+        .andExpect(jsonPath("$.content[0].bookmarked").value(true))
+        .andReturn();
   }
 
 }

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/SearchControllerIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/SearchControllerIntegrationTest.java
@@ -131,7 +131,8 @@ class SearchControllerIntegrationTest extends AbstractTestContainerIntegrationTe
       Object expectedValue
   ) throws Exception {
     legacyApiStub.stubFor(
-        WireMock.get(urlPathEqualTo("/api/search/reporting-units/ex/" + ruId + "/" + wasteAssessmentAreaId))
+        WireMock.get(
+                urlPathEqualTo("/api/search/reporting-units/ex/" + ruId + "/" + wasteAssessmentAreaId))
             .willReturn(stubResponse)
     );
 
@@ -317,7 +318,7 @@ class SearchControllerIntegrationTest extends AbstractTestContainerIntegrationTe
             0L
         ),
         Arguments.argumentSet(
-            "Search with results and no filter",
+            "Search with results and 36834 as filter ",
             ReportingUnitSearchParametersDto.builder().mainSearchTerm("36834").build(),
             PageRequest.of(0, 10),
             okJson(ForestClientApiProviderTestConstants.REPORTING_UNITS_SEARCH_RESPONSE),

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/UserBookmarkControllerIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/UserBookmarkControllerIntegrationTest.java
@@ -1,0 +1,159 @@
+package ca.bc.gov.nrs.hrs.controller;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.springframework.boot.webmvc.test.autoconfigure.MockMvcPrint.SYSTEM_OUT;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.context.TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ca.bc.gov.nrs.hrs.extensions.AbstractTestContainerIntegrationTest;
+import ca.bc.gov.nrs.hrs.extensions.WithMockJwt;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@AutoConfigureMockMvc(print = SYSTEM_OUT)
+@WithMockJwt(
+    value = "markbook"
+)
+@DisplayName("Integrated Test | User Bookmark Controller")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestExecutionListeners(
+    value = TransactionalTestExecutionListener.class,
+    mergeMode = MERGE_WITH_DEFAULTS
+)
+@Transactional
+@Rollback(value = false)
+class UserBookmarkControllerIntegrationTest extends AbstractTestContainerIntegrationTest {
+
+  private static final long REPORTING_UNIT_A = 90001L;
+  private static final long REPORTING_UNIT_B = 90002L;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("Get user bookmarks when none exist should return empty list")
+  @Order(1)
+  void getUserBookmarks_whenNoneExist_shouldReturnEmptyList() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/users/bookmarks")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(jsonPath("$.length()").value(0))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Add same bookmark twice should keep one record")
+  @Order(2)
+  void addSameBookmarkTwice_shouldKeepOneRecord() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/users/bookmarks/{reportingUnitId}", REPORTING_UNIT_A)
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isAccepted())
+        .andReturn();
+
+    mockMvc
+        .perform(
+            put("/api/users/bookmarks/{reportingUnitId}", REPORTING_UNIT_A)
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isAccepted())
+        .andReturn();
+
+    mockMvc
+        .perform(
+            get("/api/users/bookmarks")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0]").value(REPORTING_UNIT_A))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Add second bookmark should return both bookmark ids")
+  @Order(3)
+  void addSecondBookmark_shouldReturnBothBookmarkIds() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/users/bookmarks/{reportingUnitId}", REPORTING_UNIT_B)
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isAccepted())
+        .andReturn();
+
+    mockMvc
+        .perform(
+            get("/api/users/bookmarks")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$", containsInAnyOrder((int) REPORTING_UNIT_A, (int) REPORTING_UNIT_B)))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Delete same bookmark twice should be idempotent")
+  @Order(4)
+  void deleteSameBookmarkTwice_shouldBeIdempotent() throws Exception {
+    mockMvc
+        .perform(
+            delete("/api/users/bookmarks/{reportingUnitId}", REPORTING_UNIT_A)
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isNoContent())
+        .andReturn();
+
+    mockMvc
+        .perform(
+            delete("/api/users/bookmarks/{reportingUnitId}", REPORTING_UNIT_A)
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isNoContent())
+        .andReturn();
+
+    mockMvc
+        .perform(
+            get("/api/users/bookmarks")
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType("application/json;charset=UTF-8"))
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0]").value(REPORTING_UNIT_B))
+        .andReturn();
+  }
+
+}
+

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/UserBookmarkControllerIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/UserBookmarkControllerIntegrationTest.java
@@ -48,23 +48,8 @@ class UserBookmarkControllerIntegrationTest extends AbstractTestContainerIntegra
   private MockMvc mockMvc;
 
   @Test
-  @DisplayName("Get user bookmarks when none exist should return empty list")
-  @Order(1)
-  void getUserBookmarks_whenNoneExist_shouldReturnEmptyList() throws Exception {
-    mockMvc
-        .perform(
-            get("/api/users/bookmarks")
-                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType("application/json;charset=UTF-8"))
-        .andExpect(jsonPath("$.length()").value(0))
-        .andReturn();
-  }
-
-  @Test
   @DisplayName("Add same bookmark twice should keep one record")
-  @Order(2)
+  @Order(1)
   void addSameBookmarkTwice_shouldKeepOneRecord() throws Exception {
     mockMvc
         .perform(
@@ -83,22 +68,11 @@ class UserBookmarkControllerIntegrationTest extends AbstractTestContainerIntegra
                 .with(csrf()))
         .andExpect(status().isAccepted())
         .andReturn();
-
-    mockMvc
-        .perform(
-            get("/api/users/bookmarks")
-                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType("application/json;charset=UTF-8"))
-        .andExpect(jsonPath("$.length()").value(1))
-        .andExpect(jsonPath("$[0]").value(REPORTING_UNIT_A))
-        .andReturn();
   }
 
   @Test
   @DisplayName("Add second bookmark should return both bookmark ids")
-  @Order(3)
+  @Order(2)
   void addSecondBookmark_shouldReturnBothBookmarkIds() throws Exception {
     mockMvc
         .perform(
@@ -108,22 +82,11 @@ class UserBookmarkControllerIntegrationTest extends AbstractTestContainerIntegra
                 .with(csrf()))
         .andExpect(status().isAccepted())
         .andReturn();
-
-    mockMvc
-        .perform(
-            get("/api/users/bookmarks")
-                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType("application/json;charset=UTF-8"))
-        .andExpect(jsonPath("$.length()").value(2))
-        .andExpect(jsonPath("$", containsInAnyOrder((int) REPORTING_UNIT_A, (int) REPORTING_UNIT_B)))
-        .andReturn();
   }
 
   @Test
   @DisplayName("Delete same bookmark twice should be idempotent")
-  @Order(4)
+  @Order(3)
   void deleteSameBookmarkTwice_shouldBeIdempotent() throws Exception {
     mockMvc
         .perform(
@@ -141,17 +104,6 @@ class UserBookmarkControllerIntegrationTest extends AbstractTestContainerIntegra
                 .accept(MediaType.APPLICATION_JSON)
                 .with(csrf()))
         .andExpect(status().isNoContent())
-        .andReturn();
-
-    mockMvc
-        .perform(
-            get("/api/users/bookmarks")
-                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType("application/json;charset=UTF-8"))
-        .andExpect(jsonPath("$.length()").value(1))
-        .andExpect(jsonPath("$[0]").value(REPORTING_UNIT_B))
         .andReturn();
   }
 

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/UserPreferenceControllerIntegrationTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/UserPreferenceControllerIntegrationTest.java
@@ -26,10 +26,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 @AutoConfigureMockMvc(print = SYSTEM_OUT)
-@WithMockJwt(
-    value = "jakethedog"
-)
-@DisplayName("Integrated Test | User Controller")
+@WithMockJwt
+@DisplayName("Integrated Test | User Preference Controller")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestExecutionListeners(
     value = TransactionalTestExecutionListener.class,
@@ -37,7 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 )
 @Transactional
 @Rollback(value = false)
-class UserControllerIntegrationTest extends AbstractTestContainerIntegrationTest {
+class UserPreferenceControllerIntegrationTest extends AbstractTestContainerIntegrationTest {
 
   @Autowired
   private MockMvc mockMvc;

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchParametersDtoTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchParametersDtoTest.java
@@ -1,0 +1,66 @@
+package ca.bc.gov.nrs.hrs.dto.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+
+@DisplayName("Unit Test | ReportingUnitSearchParametersDto")
+class ReportingUnitSearchParametersDtoTest {
+
+  @Test
+  @DisplayName("isEmpty should return false when bookmarked is true")
+  void isEmpty_bookmarkedTrue_shouldReturnFalse() {
+    var dto = ReportingUnitSearchParametersDto.builder()
+        .bookmarked(true)
+        .build();
+
+    assertThat(dto.isEmpty()).isFalse();
+  }
+
+  @Test
+  @DisplayName("isEmpty should return true when all fields are empty/default")
+  void isEmpty_allDefaults_shouldReturnTrue() {
+    var dto = ReportingUnitSearchParametersDto.builder().build();
+
+    assertThat(dto.isEmpty()).isTrue();
+  }
+
+  @Test
+  @DisplayName("toMultiMap should include reportingUnitIds when set")
+  void toMultiMap_withReportingUnitIds_shouldIncludeThem() {
+    var dto = ReportingUnitSearchParametersDto.builder()
+        .reportingUnitIds(List.of(100L, 200L, 300L))
+        .build();
+
+    var multiMap = dto.toMultiMap(PageRequest.of(0, 10));
+
+    assertThat(multiMap.get("reportingUnitIds"))
+        .containsExactly("100", "200", "300");
+  }
+
+  @Test
+  @DisplayName("toMultiMap should not include reportingUnitIds when null")
+  void toMultiMap_withNullReportingUnitIds_shouldNotInclude() {
+    var dto = ReportingUnitSearchParametersDto.builder().build();
+
+    var multiMap = dto.toMultiMap(PageRequest.of(0, 10));
+
+    assertThat(multiMap.get("reportingUnitIds")).isNull();
+  }
+
+  @Test
+  @DisplayName("toMultiMap should not include reportingUnitIds when empty")
+  void toMultiMap_withEmptyReportingUnitIds_shouldNotInclude() {
+    var dto = ReportingUnitSearchParametersDto.builder()
+        .reportingUnitIds(List.of())
+        .build();
+
+    var multiMap = dto.toMultiMap(PageRequest.of(0, 10));
+
+    assertThat(multiMap.get("reportingUnitIds")).isNull();
+  }
+}
+

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/provider/forestclient/ForestClientApiProviderTestConstants.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/provider/forestclient/ForestClientApiProviderTestConstants.java
@@ -99,7 +99,8 @@ public class ForestClientApiProviderTestConstants {
                        "code": "DFT",
                        "description": "Draft"
                    },
-                   "lastUpdated": "2025-08-24T09:10:28"
+                   "lastUpdated": "2025-08-24T09:10:28",
+                   "bookmarked": false
                }
            ],
            "page": {

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SearchServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SearchServiceTest.java
@@ -1,0 +1,206 @@
+package ca.bc.gov.nrs.hrs.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ca.bc.gov.nrs.hrs.dto.base.CodeDescriptionDto;
+import ca.bc.gov.nrs.hrs.dto.client.ForestClientDto;
+import ca.bc.gov.nrs.hrs.dto.search.ReportingUnitSearchParametersDto;
+import ca.bc.gov.nrs.hrs.dto.search.ReportingUnitSearchResultDto;
+import ca.bc.gov.nrs.hrs.provider.legacy.LegacyApiProvider;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Unit Test | Search Service")
+class SearchServiceTest {
+
+  @Mock
+  private LegacyApiProvider legacyApiProvider;
+
+  @Mock
+  private ForestClientService forestClientService;
+
+  @Mock
+  private UserService userService;
+
+  @InjectMocks
+  private SearchService searchService;
+
+  private static final String USER_ID = "IDIR\\testuser";
+  private static final Pageable PAGEABLE = PageRequest.of(0, 10);
+
+  private ReportingUnitSearchResultDto createResult(Long ruNumber, String clientCode) {
+    return new ReportingUnitSearchResultDto(
+        null,
+        26L,
+        null,
+        ruNumber,
+        new CodeDescriptionDto(clientCode, null),
+        "LIC-123",
+        "CP-01",
+        "TM-456",
+        false,
+        false,
+        new CodeDescriptionDto("BLK", "Cutblock"),
+        new CodeDescriptionDto("DND", "Nadina Natural Resource District"),
+        new CodeDescriptionDto("DFT", "Draft"),
+        LocalDateTime.of(2025, 8, 24, 9, 10, 28),
+        false
+    );
+  }
+
+  @Test
+  @DisplayName("Search should enrich results with bookmarked=true when RU is bookmarked")
+  void search_shouldEnrichResultsWithBookmarkedTrue() {
+    var filters = ReportingUnitSearchParametersDto.builder()
+        .mainSearchTerm("36834")
+        .build();
+
+    var result = createResult(36834L, "00010002");
+    Page<ReportingUnitSearchResultDto> page = new PageImpl<>(List.of(result), PAGEABLE, 1);
+
+    when(legacyApiProvider.searchReportingUnit(any(), any())).thenReturn(page);
+    when(forestClientService.getClientByNumber("00010002"))
+        .thenReturn(Optional.of(new ForestClientDto("00010002", "WEST FRASER", null, null, null, null, null)));
+    when(userService.getUserBookmarksInList(USER_ID, List.of(36834L)))
+        .thenReturn(List.of(36834L));
+
+    Page<ReportingUnitSearchResultDto> results = searchService.search(USER_ID, filters, PAGEABLE);
+
+    assertThat(results.getContent()).hasSize(1);
+    assertThat(results.getContent().getFirst().bookmarked()).isTrue();
+    assertThat(results.getContent().getFirst().client().description()).isEqualTo("WEST FRASER");
+  }
+
+  @Test
+  @DisplayName("Search should enrich results with bookmarked=false when RU is not bookmarked")
+  void search_shouldEnrichResultsWithBookmarkedFalse() {
+    var filters = ReportingUnitSearchParametersDto.builder()
+        .mainSearchTerm("36834")
+        .build();
+
+    var result = createResult(36834L, "00010002");
+    Page<ReportingUnitSearchResultDto> page = new PageImpl<>(List.of(result), PAGEABLE, 1);
+
+    when(legacyApiProvider.searchReportingUnit(any(), any())).thenReturn(page);
+    when(forestClientService.getClientByNumber("00010002"))
+        .thenReturn(Optional.of(new ForestClientDto("00010002", "WEST FRASER", null, null, null, null, null)));
+    when(userService.getUserBookmarksInList(USER_ID, List.of(36834L)))
+        .thenReturn(List.of());
+
+    Page<ReportingUnitSearchResultDto> results = searchService.search(USER_ID, filters, PAGEABLE);
+
+    assertThat(results.getContent()).hasSize(1);
+    assertThat(results.getContent().getFirst().bookmarked()).isFalse();
+  }
+
+  @Test
+  @DisplayName("Search with bookmarked=true should fetch user bookmarks and set reportingUnitIds")
+  void search_withBookmarkedTrue_shouldSetReportingUnitIds() {
+    var filters = ReportingUnitSearchParametersDto.builder()
+        .bookmarked(true)
+        .build();
+
+    // User has bookmarks for RU 36834 and 12345
+    when(userService.getUserBookmarksInList(USER_ID, List.of()))
+        .thenReturn(List.of(36834L, 12345L));
+
+    var result = createResult(36834L, "00010002");
+    Page<ReportingUnitSearchResultDto> page = new PageImpl<>(List.of(result), PAGEABLE, 1);
+
+    when(legacyApiProvider.searchReportingUnit(any(), any())).thenReturn(page);
+    when(forestClientService.getClientByNumber("00010002"))
+        .thenReturn(Optional.of(new ForestClientDto("00010002", "WEST FRASER", null, null, null, null, null)));
+    when(userService.getUserBookmarksInList(USER_ID, List.of(36834L)))
+        .thenReturn(List.of(36834L));
+
+    Page<ReportingUnitSearchResultDto> results = searchService.search(USER_ID, filters, PAGEABLE);
+
+    assertThat(results.getContent()).hasSize(1);
+    assertThat(results.getContent().getFirst().bookmarked()).isTrue();
+    // Verify that bookmarks were fetched to set the reportingUnitIds filter
+    assertThat(filters.getReportingUnitIds()).containsExactly(36834L, 12345L);
+  }
+
+  @Test
+  @DisplayName("Search with bookmarked=false should not fetch user bookmarks for filtering")
+  void search_withBookmarkedFalse_shouldNotFetchBookmarksForFiltering() {
+    var filters = ReportingUnitSearchParametersDto.builder()
+        .mainSearchTerm("36834")
+        .bookmarked(false)
+        .build();
+
+    Page<ReportingUnitSearchResultDto> page = new PageImpl<>(List.of(), PAGEABLE, 0);
+
+    when(legacyApiProvider.searchReportingUnit(any(), any())).thenReturn(page);
+    when(userService.getUserBookmarksInList(eq(USER_ID), any())).thenReturn(List.of());
+
+    searchService.search(USER_ID, filters, PAGEABLE);
+
+    // The reportingUnitIds filter should NOT have been set (bookmarked is false)
+    assertThat(filters.getReportingUnitIds()).isNull();
+  }
+
+  @Test
+  @DisplayName("Search with empty results should return empty page with no enrichment errors")
+  void search_withEmptyResults_shouldReturnEmptyPage() {
+    var filters = ReportingUnitSearchParametersDto.builder()
+        .mainSearchTerm("99999")
+        .build();
+
+    Page<ReportingUnitSearchResultDto> page = new PageImpl<>(List.of(), PAGEABLE, 0);
+
+    when(legacyApiProvider.searchReportingUnit(any(), any())).thenReturn(page);
+    when(userService.getUserBookmarksInList(eq(USER_ID), eq(List.of()))).thenReturn(List.of());
+
+    Page<ReportingUnitSearchResultDto> results = searchService.search(USER_ID, filters, PAGEABLE);
+
+    assertThat(results.getContent()).isEmpty();
+    verify(forestClientService, never()).getClientByNumber(anyString());
+  }
+
+  @Test
+  @DisplayName("Search with multiple results should correctly flag only bookmarked ones")
+  void search_withMultipleResults_shouldFlagOnlyBookmarked() {
+    var filters = ReportingUnitSearchParametersDto.builder()
+        .mainSearchTerm("test")
+        .build();
+
+    var result1 = createResult(36834L, "00010002");
+    var result2 = createResult(12345L, "00010002");
+    Page<ReportingUnitSearchResultDto> page = new PageImpl<>(
+        List.of(result1, result2), PAGEABLE, 2
+    );
+
+    when(legacyApiProvider.searchReportingUnit(any(), any())).thenReturn(page);
+    when(forestClientService.getClientByNumber("00010002"))
+        .thenReturn(Optional.of(new ForestClientDto("00010002", "WEST FRASER", null, null, null, null, null)));
+    // Only RU 36834 is bookmarked
+    when(userService.getUserBookmarksInList(USER_ID, List.of(36834L, 12345L)))
+        .thenReturn(List.of(36834L));
+
+    Page<ReportingUnitSearchResultDto> results = searchService.search(USER_ID, filters, PAGEABLE);
+
+    assertThat(results.getContent()).hasSize(2);
+    assertThat(results.getContent().get(0).bookmarked()).isTrue();
+    assertThat(results.getContent().get(1).bookmarked()).isFalse();
+  }
+}
+

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SearchServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SearchServiceTest.java
@@ -8,7 +8,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ca.bc.gov.nrs.hrs.configuration.FeatureFlagsConfiguration;
 import ca.bc.gov.nrs.hrs.dto.base.CodeDescriptionDto;
+import ca.bc.gov.nrs.hrs.dto.base.FeatureFlag;
 import ca.bc.gov.nrs.hrs.dto.client.ForestClientDto;
 import ca.bc.gov.nrs.hrs.dto.search.ReportingUnitSearchParametersDto;
 import ca.bc.gov.nrs.hrs.dto.search.ReportingUnitSearchResultDto;
@@ -16,6 +18,7 @@ import ca.bc.gov.nrs.hrs.provider.legacy.LegacyApiProvider;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +42,9 @@ class SearchServiceTest {
 
   @Mock
   private UserService userService;
+
+  @Mock
+  private FeatureFlagsConfiguration featureFlagsConfiguration;
 
   @InjectMocks
   private SearchService searchService;
@@ -64,6 +70,12 @@ class SearchServiceTest {
         LocalDateTime.of(2025, 8, 24, 9, 10, 28),
         false
     );
+  }
+
+  @BeforeEach
+  void setUp(){
+    when(featureFlagsConfiguration.isEnabled(FeatureFlag.BOOKMARK_REPORTING_UNIT_ENABLED))
+        .thenReturn(true);
   }
 
   @Test

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/UserServiceBookmarkTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/UserServiceBookmarkTest.java
@@ -1,0 +1,107 @@
+package ca.bc.gov.nrs.hrs.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import ca.bc.gov.nrs.hrs.entity.users.UserBookmarkEntity;
+import ca.bc.gov.nrs.hrs.repository.UserBookmarkRepository;
+import ca.bc.gov.nrs.hrs.repository.UserPreferenceRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Unit Test | User Service - Bookmarks")
+class UserServiceBookmarkTest {
+
+  @SuppressWarnings("unused") // required by @InjectMocks for UserService constructor
+  @Mock
+  private UserPreferenceRepository preferenceRepository;
+
+  @Mock
+  private UserBookmarkRepository bookmarkRepository;
+
+  @InjectMocks
+  private UserService userService;
+
+  private static final String USER_ID = "IDIR\\testuser";
+
+  @Test
+  @DisplayName("getUserBookmarksInList with empty list should fetch all user bookmarks")
+  void getUserBookmarksInList_emptyList_shouldFetchAll() {
+    var bookmark1 = new UserBookmarkEntity(USER_ID, 100L);
+    var bookmark2 = new UserBookmarkEntity(USER_ID, 200L);
+
+    when(bookmarkRepository.findByUserId(USER_ID))
+        .thenReturn(List.of(bookmark1, bookmark2));
+
+    List<Long> result = userService.getUserBookmarksInList(USER_ID, List.of());
+
+    assertThat(result).containsExactly(100L, 200L);
+    verify(bookmarkRepository).findByUserId(USER_ID);
+    verifyNoMoreInteractions(bookmarkRepository);
+  }
+
+  @Test
+  @DisplayName("getUserBookmarksInList with null list should fetch all user bookmarks")
+  void getUserBookmarksInList_nullList_shouldFetchAll() {
+    var bookmark1 = new UserBookmarkEntity(USER_ID, 100L);
+
+    when(bookmarkRepository.findByUserId(USER_ID))
+        .thenReturn(List.of(bookmark1));
+
+    List<Long> result = userService.getUserBookmarksInList(USER_ID, null);
+
+    assertThat(result).containsExactly(100L);
+    verify(bookmarkRepository).findByUserId(USER_ID);
+    verifyNoMoreInteractions(bookmarkRepository);
+  }
+
+  @Test
+  @DisplayName("getUserBookmarksInList with specific IDs should filter by those IDs")
+  void getUserBookmarksInList_withIds_shouldFilterByIds() {
+    List<Long> reportingUnitIds = List.of(100L, 200L, 300L);
+    var bookmark1 = new UserBookmarkEntity(USER_ID, 100L);
+    var bookmark2 = new UserBookmarkEntity(USER_ID, 300L);
+
+    when(bookmarkRepository.findByUserIdAndReportingUnitIdIn(USER_ID, reportingUnitIds))
+        .thenReturn(List.of(bookmark1, bookmark2));
+
+    List<Long> result = userService.getUserBookmarksInList(USER_ID, reportingUnitIds);
+
+    assertThat(result).containsExactly(100L, 300L);
+    verify(bookmarkRepository).findByUserIdAndReportingUnitIdIn(USER_ID, reportingUnitIds);
+    verifyNoMoreInteractions(bookmarkRepository);
+  }
+
+  @Test
+  @DisplayName("getUserBookmarksInList should return empty when user has no bookmarks")
+  void getUserBookmarksInList_noBookmarks_shouldReturnEmpty() {
+    when(bookmarkRepository.findByUserId(USER_ID))
+        .thenReturn(List.of());
+
+    List<Long> result = userService.getUserBookmarksInList(USER_ID, List.of());
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("getUserBookmarksInList with IDs should return empty when none match")
+  void getUserBookmarksInList_withIds_noMatch_shouldReturnEmpty() {
+    List<Long> reportingUnitIds = List.of(999L, 888L);
+
+    when(bookmarkRepository.findByUserIdAndReportingUnitIdIn(USER_ID, reportingUnitIds))
+        .thenReturn(List.of());
+
+    List<Long> result = userService.getUserBookmarksInList(USER_ID, reportingUnitIds);
+
+    assertThat(result).isEmpty();
+  }
+}
+

--- a/backend/src/test/resources/application-default.yml
+++ b/backend/src/test/resources/application-default.yml
@@ -32,6 +32,7 @@ features:
   flags:
     enabled-flag: true
     disabled-flag: false
+    bookmark-ru-enabled: true
 
 logging:
   level:

--- a/frontend/src/components/waste/WasteSearch/WasteSearchFiltersActive/utils.ts
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchFiltersActive/utils.ts
@@ -18,6 +18,8 @@ export const mapDisplayFilter = (key: keyof ReportingUnitSearchParametersDto): s
       return 'Created By Me';
     case 'multiMark':
       return 'Multi-mark blocks';
+    case 'bookmarked':
+      return 'Bookmarked RUs';
     case 'requestUserId':
       return 'Submitter';
     case 'updateDateStart':

--- a/frontend/src/components/waste/WasteSearch/WasteSearchFiltersActive/utils.unit.test.ts
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchFiltersActive/utils.unit.test.ts
@@ -10,6 +10,7 @@ describe('mapDisplayFilter', () => {
     expect(mapDisplayFilter('status')).toBe('Status');
     expect(mapDisplayFilter('requestByMe')).toBe('Created By Me');
     expect(mapDisplayFilter('multiMark')).toBe('Multi-mark blocks');
+    expect(mapDisplayFilter('bookmarked')).toBe('Bookmarked RUs');
     expect(mapDisplayFilter('requestUserId')).toBe('Submitter');
     expect(mapDisplayFilter('updateDateStart')).toBe('Update Date Start');
     expect(mapDisplayFilter('updateDateEnd')).toBe('Update Date End');

--- a/frontend/src/components/waste/WasteSearch/WasteSearchFiltersAdvanced/index.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchFiltersAdvanced/index.tsx
@@ -26,6 +26,7 @@ import AutoCompleteInput from '@/components/Form/AutoCompleteInput';
 import { activeMSItemToString } from '@/components/waste/WasteSearch/WasteSearchFiltersActive/utils';
 import { useMyForestClientsQuery } from '@/config/react-query/hooks';
 import { useAuth } from '@/context/auth/useAuth';
+import { featureFlags } from '@/env';
 import APIs from '@/services/APIs';
 import { getCodeDescriptionArrayConverter } from '@/services/search.utils';
 
@@ -278,13 +279,15 @@ const WasteSearchFiltersAdvanced: FC<WasteSearchFiltersAdvancedProps> = ({
                 checked={filters.multiMark || false}
                 onChange={onCheckBoxChange('multiMark')}
               />
-              <Checkbox
-                id="as-bookmarked-checkbox"
-                data-testid="bookmarked-checkbox"
-                labelText="Bookmarked RUs only"
-                checked={filters.bookmarked || false}
-                onChange={onCheckBoxChange('bookmarked')}
-              />
+              {featureFlags['bookmark-ru-enabled'] && (
+                <Checkbox
+                  id="as-bookmarked-checkbox"
+                  data-testid="bookmarked-checkbox"
+                  labelText="Bookmarked RUs only"
+                  checked={filters.bookmarked || false}
+                  onChange={onCheckBoxChange('bookmarked')}
+                />
+              )}
             </CheckboxGroup>
           </Column>
         </Grid>

--- a/frontend/src/components/waste/WasteSearch/WasteSearchFiltersAdvanced/index.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchFiltersAdvanced/index.tsx
@@ -278,6 +278,13 @@ const WasteSearchFiltersAdvanced: FC<WasteSearchFiltersAdvancedProps> = ({
                 checked={filters.multiMark || false}
                 onChange={onCheckBoxChange('multiMark')}
               />
+              <Checkbox
+                id="as-bookmarked-checkbox"
+                data-testid="bookmarked-checkbox"
+                labelText="Bookmarked RUs only"
+                checked={filters.bookmarked || false}
+                onChange={onCheckBoxChange('bookmarked')}
+              />
             </CheckboxGroup>
           </Column>
         </Grid>

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTable/index.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTable/index.tsx
@@ -15,6 +15,7 @@ import TableResource from '@/components/Form/TableResource';
 import WasteSearchFilters from '@/components/waste/WasteSearch/WasteSearchFilters';
 import WasteSearchTableExpandContent from '@/components/waste/WasteSearch/WasteSearchTableExpandContent';
 import { useSearchReportingUnitsQuery } from '@/config/react-query/hooks';
+import { featureFlags } from '@/env';
 import useNotificationEvents from '@/hooks/useNotificationEvents';
 import { reportingUnitSearchParametersView2Plain } from '@/services/search.utils';
 import { removeEmpty } from '@/services/utils';
@@ -137,7 +138,7 @@ const WasteSearchTable: FC = () => {
           displayToolbar
           onSortChange={handleSort}
           onRowExpanded={onRowExpanded}
-          getRowActions={getRowActions}
+          getRowActions={featureFlags['bookmark-ru-enabled'] ? getRowActions : undefined}
         />
       </Column>
     </>

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTable/index.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTable/index.tsx
@@ -2,6 +2,7 @@ import { Column } from '@carbon/react';
 import { useEffect, useState, useMemo, type FC, type ReactNode } from 'react';
 
 import { headers } from './constants';
+import { useWasteSearchRowActions } from './rowActions.tsx';
 
 import type { PageableResponse } from '@/components/Form/TableResource/types';
 import type {
@@ -33,6 +34,7 @@ const WasteSearchTable: FC = () => {
   const [searchTrigger, setSearchTrigger] = useState(0);
   const { clearEvents } = useNotificationEvents();
 
+  const { sendInlineEvent } = useNotificationEvents();
   const plainFilters = useMemo(() => reportingUnitSearchParametersView2Plain(filters), [filters]);
 
   const { data, isLoading, isFetching, isError, refetch } = useSearchReportingUnitsQuery(
@@ -68,6 +70,11 @@ const WasteSearchTable: FC = () => {
       setSearchTrigger((n) => n + 1);
     }
   };
+
+  const getRowActions = useWasteSearchRowActions({
+    sendInlineEvent,
+    onToggleRefresh: () => refetch(),
+  });
 
   /**
    * Starts a new search from the first page.
@@ -130,6 +137,7 @@ const WasteSearchTable: FC = () => {
           displayToolbar
           onSortChange={handleSort}
           onRowExpanded={onRowExpanded}
+          getRowActions={getRowActions}
         />
       </Column>
     </>

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTable/index.unit.test.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTable/index.unit.test.tsx
@@ -107,6 +107,8 @@ vi.mock('@/services/APIs', () => {
       user: {
         getUserPreferences: vi.fn(),
         updateUserPreferences: vi.fn(),
+        setUserBookmarkedRu: vi.fn(),
+        deleteUserBookmarkedRu: vi.fn(),
       },
       codes: {
         getSamplingOptions: vi.fn(),
@@ -137,6 +139,7 @@ const mockSearchResults: PageableResponse<ReportingUnitSearchResultDto> = {
       district: { code: 'DCC', description: 'Cariboo-Chilcotin' },
       status: { code: 'BIS', description: 'Billing Issued' },
       lastUpdated: '2006-09-08T08:24:17',
+      bookmarked: false,
     },
     {
       id: 'RU-4070-Block-412B-224813682',
@@ -153,6 +156,7 @@ const mockSearchResults: PageableResponse<ReportingUnitSearchResultDto> = {
       district: { code: 'D2', description: 'District Two' },
       status: { code: 'SUB', description: 'Submitted' },
       lastUpdated: '2025-01-16T10:00:00',
+      bookmarked: false,
     },
   ],
   page: {
@@ -180,6 +184,7 @@ const altMockSearchResults1: PageableResponse<ReportingUnitSearchResultDto> = {
       district: { code: 'DCC', description: 'Cariboo-Chilcotin' },
       status: { code: 'BIS', description: 'Billing Issued' },
       lastUpdated: '2006-09-08T08:24:17',
+      bookmarked: false,
     },
     {
       id: 'RU-4070-Block-522B-224813684',
@@ -196,6 +201,7 @@ const altMockSearchResults1: PageableResponse<ReportingUnitSearchResultDto> = {
       district: { code: 'D2', description: 'District Two' },
       status: { code: 'SUB', description: 'Submitted' },
       lastUpdated: '2025-01-16T10:00:00',
+      bookmarked: false,
     },
   ],
   page: {
@@ -223,6 +229,7 @@ const altMockSearchResults2: PageableResponse<ReportingUnitSearchResultDto> = {
       district: { code: 'DCC', description: 'Cariboo-Chilcotin' },
       status: { code: 'BIS', description: 'Billing Issued' },
       lastUpdated: '2006-09-08T08:24:17',
+      bookmarked: false,
     },
     {
       id: 'RU-4070-Block-632B-224813682',
@@ -239,6 +246,7 @@ const altMockSearchResults2: PageableResponse<ReportingUnitSearchResultDto> = {
       district: { code: 'D2', description: 'District Two' },
       status: { code: 'SUB', description: 'Submitted' },
       lastUpdated: '2025-01-16T10:00:00',
+      bookmarked: false,
     },
   ],
   page: {

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTable/rowActions.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTable/rowActions.tsx
@@ -1,0 +1,87 @@
+import { BookmarkAdd, BookmarkFilled } from '@carbon/icons-react';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import type { PageableResponse, TableRowAction } from '@/components/Form/TableResource/types';
+import type { ReportingUnitSearchResultDto } from '@/services/search.types';
+
+import API from '@/services/APIs';
+
+type WasteSearchRow = PageableResponse<ReportingUnitSearchResultDto>['content'][number];
+
+type WasteSearchEvent = {
+  title: string;
+  description: string;
+  eventType: 'info' | 'error';
+  eventTarget: 'waste-search';
+};
+
+type WasteSearchEventSender = (event: WasteSearchEvent) => void;
+
+type UseWasteSearchRowActionsOptions = {
+  sendEvent: WasteSearchEventSender;
+  onToggleRefresh?: () => void | Promise<unknown>;
+};
+
+export const useWasteSearchRowActions = ({
+  sendEvent,
+  onToggleRefresh,
+}: UseWasteSearchRowActionsOptions) => {
+  const [pendingToggleRows, setPendingToggleRows] = useState<Set<number>>(new Set());
+
+  const toggleBookmarkApiCall = async (row: WasteSearchRow) => {
+    if (row.bookmarked) {
+      await API.user.deleteUserBookmarkedRu(row.ruNumber);
+    } else {
+      await API.user.setUserBookmarkedRu(row.ruNumber);
+    }
+    return row;
+  };
+
+  const toggleBookmarkMutation = useMutation({
+    mutationFn: toggleBookmarkApiCall,
+    onMutate: async (row) => {
+      setPendingToggleRows((prev) => {
+        const next = new Set(prev);
+        next.add(row.ruNumber);
+        return next;
+      });
+    },
+    onSuccess: (row) => {
+      sendEvent({
+        title: row.bookmarked ? 'Removed from bookmarks' : 'Added to bookmarks',
+        description: `Reporting unit ${row.ruNumber} was ${row.bookmarked ? 'removed from' : 'added to'} bookmarks successfully`,
+        eventType: 'info',
+        eventTarget: 'waste-search',
+      });
+      onToggleRefresh?.();
+    },
+    onError: (_error, row) => {
+      sendEvent({
+        title: 'Failed to toggle bookmark',
+        description: `Failed to toggle bookmark for Reporting Unit ${row.ruNumber}`,
+        eventType: 'error',
+        eventTarget: 'waste-search',
+      });
+    },
+    onSettled: (_data, _error, row) => {
+      setPendingToggleRows((prev) => {
+        const next = new Set(prev);
+        next.delete(row.ruNumber);
+        return next;
+      });
+    },
+  });
+
+  return (row: WasteSearchRow): TableRowAction<ReportingUnitSearchResultDto>[] => [
+    {
+      id: 'toggle-bookmark',
+      label: row.bookmarked ? 'Remove from bookmarked' : 'Bookmark this reporting unit',
+      icon: row.bookmarked ? <BookmarkFilled /> : <BookmarkAdd />,
+      isLoading: (selectedRow) => pendingToggleRows.has(selectedRow.ruNumber),
+      onClick: async (selectedRow) => {
+        await toggleBookmarkMutation.mutateAsync(selectedRow);
+      },
+    },
+  ];
+};

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTable/rowActions.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTable/rowActions.tsx
@@ -19,12 +19,12 @@ type WasteSearchEvent = {
 type WasteSearchEventSender = (event: WasteSearchEvent) => void;
 
 type UseWasteSearchRowActionsOptions = {
-  sendEvent: WasteSearchEventSender;
+  sendInlineEvent: WasteSearchEventSender;
   onToggleRefresh?: () => void | Promise<unknown>;
 };
 
 export const useWasteSearchRowActions = ({
-  sendEvent,
+  sendInlineEvent,
   onToggleRefresh,
 }: UseWasteSearchRowActionsOptions) => {
   const [pendingToggleRows, setPendingToggleRows] = useState<Set<number>>(new Set());
@@ -48,7 +48,7 @@ export const useWasteSearchRowActions = ({
       });
     },
     onSuccess: (row) => {
-      sendEvent({
+      sendInlineEvent({
         title: row.bookmarked ? 'Removed from bookmarks' : 'Added to bookmarks',
         description: `Reporting unit ${row.ruNumber} was ${row.bookmarked ? 'removed from' : 'added to'} bookmarks successfully`,
         eventType: 'info',
@@ -57,7 +57,7 @@ export const useWasteSearchRowActions = ({
       onToggleRefresh?.();
     },
     onError: (_error, row) => {
-      sendEvent({
+      sendInlineEvent({
         title: 'Failed to toggle bookmark',
         description: `Failed to toggle bookmark for Reporting Unit ${row.ruNumber}`,
         eventType: 'error',

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTable/rowActions.unit.test.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTable/rowActions.unit.test.tsx
@@ -1,0 +1,294 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest';
+
+import { useWasteSearchRowActions } from './rowActions';
+
+import type { PageableResponse } from '@/components/Form/TableResource/types';
+import type { ReportingUnitSearchResultDto } from '@/services/search.types';
+
+import APIs from '@/services/APIs';
+
+vi.mock('@/services/APIs', () => ({
+  default: {
+    user: {
+      setUserBookmarkedRu: vi.fn(),
+      deleteUserBookmarkedRu: vi.fn(),
+      getUserPreferences: vi.fn().mockResolvedValue({}),
+      updateUserPreferences: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+type WasteSearchRow = PageableResponse<ReportingUnitSearchResultDto>['content'][number];
+
+const makeRow = (overrides: Partial<WasteSearchRow> = {}): WasteSearchRow => ({
+  id: 'RU-100-Block-A1-999',
+  cutBlockId: 'A1',
+  wasteAssessmentAreaId: 100,
+  ruNumber: 100,
+  client: { code: '00010001', description: 'TEST CLIENT' },
+  licenseNumber: 'L001',
+  cuttingPermit: 'CP001',
+  timberMark: 'TM001',
+  multiMark: false,
+  secondaryEntry: false,
+  sampling: { code: 'OCU', description: 'Ocular' },
+  district: { code: 'DCC', description: 'Cariboo-Chilcotin' },
+  status: { code: 'SUB', description: 'Submitted' },
+  lastUpdated: '2025-01-01T00:00:00',
+  bookmarked: false,
+  ...overrides,
+});
+
+const createWrapper = () => {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+};
+
+describe('useWasteSearchRowActions', () => {
+  let sendEventMock: Mock;
+  let onToggleRefreshMock: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendEventMock = vi.fn();
+    onToggleRefreshMock = vi.fn();
+    (APIs.user.setUserBookmarkedRu as Mock).mockResolvedValue(undefined);
+    (APIs.user.deleteUserBookmarkedRu as Mock).mockResolvedValue(undefined);
+  });
+
+  const renderRowActionsHook = (onToggleRefresh?: () => void) =>
+    renderHook(
+      () =>
+        useWasteSearchRowActions({
+          sendEvent: sendEventMock,
+          onToggleRefresh: onToggleRefresh ?? onToggleRefreshMock,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+  describe('action structure', () => {
+    it('returns a single toggle-bookmark action', () => {
+      const { result } = renderRowActionsHook();
+      const actions = result.current(makeRow());
+      expect(actions).toHaveLength(1);
+      expect(actions[0].id).toBe('toggle-bookmark');
+    });
+
+    it('returns "Bookmark this reporting unit" label when not bookmarked', () => {
+      const { result } = renderRowActionsHook();
+      const actions = result.current(makeRow({ bookmarked: false }));
+      expect(actions[0].label).toBe('Bookmark this reporting unit');
+    });
+
+    it('returns "Remove from bookmarked" label when bookmarked', () => {
+      const { result } = renderRowActionsHook();
+      const actions = result.current(makeRow({ bookmarked: true }));
+      expect(actions[0].label).toBe('Remove from bookmarked');
+    });
+
+    it('isLoading returns false when no mutation is pending', () => {
+      const { result } = renderRowActionsHook();
+      const row = makeRow();
+      const actions = result.current(row);
+      const isLoading = (actions[0].isLoading as (r: any) => boolean)(row);
+      expect(isLoading).toBe(false);
+    });
+  });
+
+  describe('bookmark add (non-bookmarked row)', () => {
+    it('calls setUserBookmarkedRu with the ruNumber', async () => {
+      const { result } = renderRowActionsHook();
+      const row = makeRow({ bookmarked: false, ruNumber: 42 });
+
+      await act(async () => {
+        const actions = result.current(row);
+        await actions[0].onClick(row);
+      });
+
+      expect(APIs.user.setUserBookmarkedRu).toHaveBeenCalledWith(42);
+      expect(APIs.user.deleteUserBookmarkedRu).not.toHaveBeenCalled();
+    });
+
+    it('sends an "Added to bookmarks" event on success', async () => {
+      const { result } = renderRowActionsHook();
+      const row = makeRow({ bookmarked: false, ruNumber: 42 });
+
+      await act(async () => {
+        const actions = result.current(row);
+        await actions[0].onClick(row);
+      });
+
+      expect(sendEventMock).toHaveBeenCalledWith({
+        title: 'Added to bookmarks',
+        description: 'Reporting unit 42 was added to bookmarks successfully',
+        eventType: 'info',
+        eventTarget: 'waste-search',
+      });
+    });
+
+    it('calls onToggleRefresh on success', async () => {
+      const { result } = renderRowActionsHook();
+      const row = makeRow({ bookmarked: false });
+
+      await act(async () => {
+        const actions = result.current(row);
+        await actions[0].onClick(row);
+      });
+
+      expect(onToggleRefreshMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('bookmark remove (bookmarked row)', () => {
+    it('calls deleteUserBookmarkedRu with the ruNumber', async () => {
+      const { result } = renderRowActionsHook();
+      const row = makeRow({ bookmarked: true, ruNumber: 99 });
+
+      await act(async () => {
+        const actions = result.current(row);
+        await actions[0].onClick(row);
+      });
+
+      expect(APIs.user.deleteUserBookmarkedRu).toHaveBeenCalledWith(99);
+      expect(APIs.user.setUserBookmarkedRu).not.toHaveBeenCalled();
+    });
+
+    it('sends a "Removed from bookmarks" event on success', async () => {
+      const { result } = renderRowActionsHook();
+      const row = makeRow({ bookmarked: true, ruNumber: 99 });
+
+      await act(async () => {
+        const actions = result.current(row);
+        await actions[0].onClick(row);
+      });
+
+      expect(sendEventMock).toHaveBeenCalledWith({
+        title: 'Removed from bookmarks',
+        description: 'Reporting unit 99 was removed from bookmarks successfully',
+        eventType: 'info',
+        eventTarget: 'waste-search',
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('sends an error event when the API call fails', async () => {
+      (APIs.user.setUserBookmarkedRu as Mock).mockRejectedValue(new Error('Network error'));
+      const { result } = renderRowActionsHook();
+      const row = makeRow({ bookmarked: false, ruNumber: 77 });
+
+      await act(async () => {
+        const actions = result.current(row);
+        try {
+          await actions[0].onClick(row);
+        } catch {
+          // mutation.mutateAsync rejects; we only care about the event
+        }
+      });
+
+      expect(sendEventMock).toHaveBeenCalledWith({
+        title: 'Failed to toggle bookmark',
+        description: 'Failed to toggle bookmark for Reporting Unit 77',
+        eventType: 'error',
+        eventTarget: 'waste-search',
+      });
+    });
+
+    it('does not call onToggleRefresh when the API call fails', async () => {
+      (APIs.user.deleteUserBookmarkedRu as Mock).mockRejectedValue(new Error('fail'));
+      const { result } = renderRowActionsHook();
+      const row = makeRow({ bookmarked: true });
+
+      await act(async () => {
+        const actions = result.current(row);
+        try {
+          await actions[0].onClick(row);
+        } catch {
+          // expected
+        }
+      });
+
+      expect(onToggleRefreshMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loading state', () => {
+    it('isLoading returns true while the mutation is in flight', async () => {
+      let resolveApi!: () => void;
+      (APIs.user.setUserBookmarkedRu as Mock).mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveApi = resolve;
+        }),
+      );
+
+      const { result } = renderRowActionsHook();
+      const row = makeRow({ bookmarked: false, ruNumber: 55 });
+
+      // Start the mutation but don't await it yet
+      let mutationPromise: Promise<void>;
+      act(() => {
+        const actions = result.current(row);
+        mutationPromise = actions[0].onClick(row) as Promise<void>;
+      });
+
+      // While in flight, isLoading should be true for this row
+      await waitFor(() => {
+        const actions = result.current(row);
+        const loading = (actions[0].isLoading as (r: any) => boolean)(row);
+        expect(loading).toBe(true);
+      });
+
+      // A different row should not be loading
+      const otherRow = makeRow({ ruNumber: 999 });
+      const actionsOther = result.current(otherRow);
+      const otherLoading = (actionsOther[0].isLoading as (r: any) => boolean)(otherRow);
+      expect(otherLoading).toBe(false);
+
+      // Resolve and verify loading clears
+      await act(async () => {
+        resolveApi();
+        await mutationPromise;
+      });
+
+      await waitFor(() => {
+        const actions = result.current(row);
+        const loading = (actions[0].isLoading as (r: any) => boolean)(row);
+        expect(loading).toBe(false);
+      });
+    });
+  });
+
+  describe('optional onToggleRefresh', () => {
+    it('works without onToggleRefresh callback', async () => {
+      const row = makeRow({ bookmarked: false });
+
+      // Passing undefined for onToggleRefresh via the hook options
+      const { result: resultNoRefresh } = renderHook(
+        () =>
+          useWasteSearchRowActions({
+            sendEvent: sendEventMock,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await act(async () => {
+        const actions = resultNoRefresh.current(row);
+        await actions[0].onClick(row);
+      });
+
+      // Should complete without error even though onToggleRefresh is undefined
+      expect(sendEventMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/waste/WasteSearch/WasteSearchTable/rowActions.unit.test.tsx
+++ b/frontend/src/components/waste/WasteSearch/WasteSearchTable/rowActions.unit.test.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import type { ReactNode } from 'react';
 import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest';
 
 import { useWasteSearchRowActions } from './rowActions';
 
 import type { PageableResponse } from '@/components/Form/TableResource/types';
 import type { ReportingUnitSearchResultDto } from '@/services/search.types';
+import type { ReactNode } from 'react';
 
 import APIs from '@/services/APIs';
 
@@ -71,7 +71,7 @@ describe('useWasteSearchRowActions', () => {
     renderHook(
       () =>
         useWasteSearchRowActions({
-          sendEvent: sendEventMock,
+          sendInlineEvent: sendEventMock,
           onToggleRefresh: onToggleRefresh ?? onToggleRefreshMock,
         }),
       { wrapper: createWrapper() },
@@ -277,7 +277,7 @@ describe('useWasteSearchRowActions', () => {
       const { result: resultNoRefresh } = renderHook(
         () =>
           useWasteSearchRowActions({
-            sendEvent: sendEventMock,
+            sendInlineEvent: sendEventMock,
           }),
         { wrapper: createWrapper() },
       );

--- a/frontend/src/config/tests/setup-env.ts
+++ b/frontend/src/config/tests/setup-env.ts
@@ -14,6 +14,8 @@ vi.mock('@/services/APIs', () => ({
     user: {
       getUserPreferences: vi.fn().mockResolvedValue({}),
       updateUserPreferences: vi.fn().mockResolvedValue({}),
+      setUserBookmarkedRu: vi.fn().mockResolvedValue(undefined),
+      deleteUserBookmarkedRu: vi.fn().mockResolvedValue(undefined),
     },
     forestclient: {
       searchByClientNumbers: vi.fn().mockResolvedValue([]),

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -64,6 +64,7 @@ const appEnvSchema = z.looseObject({
 const featureFlagsSchema = z
   .object({
     'offline-mode-enabled': z.boolean(),
+    'bookmark-ru-enabled': z.boolean(),
   })
   .partial()
   .strict();

--- a/frontend/src/pages/WasteSearch/bookmark.e2e.test.tsx
+++ b/frontend/src/pages/WasteSearch/bookmark.e2e.test.tsx
@@ -1,0 +1,196 @@
+import { expect } from '@playwright/test';
+
+import { test } from '@/config/tests/coverage.setup';
+import { mockApi, mockApiResponses, mockApiResponsesWithStub } from '@/config/tests/e2e.helper';
+
+test.describe('Waste Search Bookmarks', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await mockApiResponsesWithStub(page, 'users/preferences', 'users/preferences-GET.json');
+
+    if (testInfo.project.metadata.userType === 'bceid') {
+      await mockApiResponsesWithStub(
+        page,
+        'forest-clients/searchByNumbers**',
+        'forest-clients/searchByNumbers-pg0.json',
+      );
+      await mockApiResponsesWithStub(
+        page,
+        'forest-clients/clients**',
+        'forest-clients/clients-pg0.json',
+      );
+    }
+
+    await mockApiResponsesWithStub(page, 'codes/districts', 'codes/districts.json');
+    await mockApiResponsesWithStub(page, 'codes/samplings', 'codes/samplings.json');
+    await mockApiResponsesWithStub(
+      page,
+      'codes/assess-area-statuses',
+      'codes/assess-area-statuses.json',
+    );
+
+    await page.goto('/search');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('should bookmark a reporting unit and then filter by bookmarked only', async ({ page }) => {
+    // Step 1: Search for "12345" — results come back with bookmarked: false
+    await mockApiResponsesWithStub(
+      page,
+      'search/reporting-units?mainSearchTerm=12345&size=10',
+      'search/reporting-units-with-district.json',
+    );
+
+    const searchBox = page.getByRole('searchbox');
+    await searchBox.fill('12345');
+    await searchBox.blur();
+
+    const searchButton = page.getByTestId('search-button-most');
+    await searchButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Verify both rows are shown and none are bookmarked
+    await expect(page.getByText('CANADIAN SAMPLE CO.')).toBeVisible();
+    await expect(page.getByText('JOHN WICK LOGGING LTD.')).toBeVisible();
+
+    // Every bookmark button should say "Bookmark this reporting unit"
+    const bookmarkButtons = page.getByRole('button', { name: 'Bookmark this reporting unit' });
+    await expect(bookmarkButtons.first()).toBeVisible();
+
+    // Step 2: Bookmark the first row (RU 123)
+    // Mock the PUT endpoint to return 202 with empty body
+    await mockApi(page, 'users/bookmarks/123', async (route) => {
+      if (route.request().method() === 'PUT') {
+        await route.fulfill({ status: 202, body: '' });
+      }
+    });
+
+    // After bookmarking, the table will refetch — now return results with first row bookmarked
+    await mockApiResponsesWithStub(
+      page,
+      'search/reporting-units?mainSearchTerm=12345&size=10',
+      'search/reporting-units-bookmarked.json',
+    );
+
+    // Click the bookmark button for the first row
+    await bookmarkButtons.first().click();
+
+    // Wait for the success notification
+    await expect(page.getByText('Added to bookmarks', { exact: true })).toBeVisible();
+
+    // After refetch, the first row should now show "Remove from bookmarked"
+    await expect(
+      page.getByRole('button', { name: 'Remove from bookmarked' }).first(),
+    ).toBeVisible();
+
+    // Step 3: Enable the "Bookmarked RUs only" filter and search
+    // Mock the bookmarked-only search to return just the one bookmarked row
+    await mockApiResponsesWithStub(
+      page,
+      'search/reporting-units?mainSearchTerm=12345&bookmarked=true&size=10',
+      'search/reporting-units-bookmarked-only.json',
+    );
+
+    // Open advanced search and check the bookmarked checkbox
+    const advancedSearchButton = page.getByTestId('advanced-search-button-most');
+    await advancedSearchButton.click();
+
+    const bookmarkedCheckbox = page.locator('label').filter({ hasText: 'Bookmarked RUs only' });
+    await bookmarkedCheckbox.click();
+
+    // Close advanced search
+    const closeButton = page
+      .getByTestId('advanced-search-modal')
+      .getByRole('button', { name: 'Search' });
+    await closeButton.click();
+
+    // Execute search with the bookmarked filter
+    await searchButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Only the bookmarked row should appear
+    await expect(page.getByText('CANADIAN SAMPLE CO.')).toBeVisible();
+    await expect(page.getByText('JOHN WICK LOGGING LTD.')).not.toBeVisible();
+
+    // Verify the result count
+    await expect(page.getByText('1-1 of 1 items')).toBeVisible();
+  });
+
+  test('should unbookmark a previously bookmarked reporting unit', async ({ page }) => {
+    // Start with a search where the first row is already bookmarked
+    await mockApiResponsesWithStub(
+      page,
+      'search/reporting-units?mainSearchTerm=12345&size=10',
+      'search/reporting-units-bookmarked.json',
+    );
+
+    const searchBox = page.getByRole('searchbox');
+    await searchBox.fill('12345');
+    await searchBox.blur();
+
+    const searchButton = page.getByTestId('search-button-most');
+    await searchButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // First row should show "Remove from bookmarked"
+    const removeButton = page.getByRole('button', { name: 'Remove from bookmarked' });
+    await expect(removeButton.first()).toBeVisible();
+
+    // Mock the DELETE endpoint to return 204 with empty body
+    await mockApi(page, 'users/bookmarks/123', async (route) => {
+      if (route.request().method() === 'DELETE') {
+        await route.fulfill({ status: 204, body: '' });
+      }
+    });
+
+    // After unbookmarking, the table will refetch — return results with no bookmarks
+    await mockApiResponsesWithStub(
+      page,
+      'search/reporting-units?mainSearchTerm=12345&size=10',
+      'search/reporting-units-with-district.json',
+    );
+
+    // Click the remove bookmark button
+    await removeButton.first().click();
+
+    // Wait for the success notification
+    await expect(page.getByText('Removed from bookmarks', { exact: true })).toBeVisible();
+
+    // After refetch, all rows should show "Bookmark this reporting unit"
+    await expect(
+      page.getByRole('button', { name: 'Bookmark this reporting unit' }).first(),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Remove from bookmarked' })).not.toBeVisible();
+  });
+
+  test('should display error notification when bookmark toggle fails', async ({ page }) => {
+    await mockApiResponsesWithStub(
+      page,
+      'search/reporting-units?mainSearchTerm=12345&size=10',
+      'search/reporting-units-with-district.json',
+    );
+
+    const searchBox = page.getByRole('searchbox');
+    await searchBox.fill('12345');
+    await searchBox.blur();
+
+    const searchButton = page.getByTestId('search-button-most');
+    await searchButton.click();
+    await page.waitForLoadState('networkidle');
+
+    // Mock the PUT endpoint to return 500
+    await mockApiResponses(page, 'users/bookmarks/123', 500, 'application/problem+json', {
+      detail: 'Unable to toggle bookmark.',
+      instance: '/api/users/bookmarks/123',
+      status: 500,
+      title: 'Internal Server Error',
+    });
+
+    // Click the bookmark button
+    const bookmarkButton = page.getByRole('button', { name: 'Bookmark this reporting unit' });
+    await bookmarkButton.first().click();
+
+    // Error notification should appear
+    await expect(page.getByText('Failed to toggle bookmark', { exact: true })).toBeVisible();
+    await expect(page.getByText('Failed to toggle bookmark for Reporting Unit 123')).toBeVisible();
+  });
+});

--- a/frontend/src/services/search.types.ts
+++ b/frontend/src/services/search.types.ts
@@ -19,6 +19,7 @@ export type ReportingUnitSearchResultDto = {
   district: CodeDescriptionDto;
   status: CodeDescriptionDto;
   lastUpdated: string;
+  bookmarked: boolean;
 };
 
 export type ReportingUnitSearchParametersDto = {
@@ -28,6 +29,7 @@ export type ReportingUnitSearchParametersDto = {
   status?: string[];
   requestByMe?: boolean;
   multiMark?: boolean;
+  bookmarked?: boolean;
   requestUserId?: string;
   updateDateStart?: string;
   updateDateEnd?: string;

--- a/frontend/src/services/users.service.ts
+++ b/frontend/src/services/users.service.ts
@@ -59,7 +59,6 @@ export class UserService extends HttpClient {
     return this.doRequest<void>(this.config, {
       method: 'PUT',
       url: `/api/users/bookmarks/${ruId}`,
-      middleware: [problemDetailsMiddleware()],
     });
   }
 
@@ -79,7 +78,6 @@ export class UserService extends HttpClient {
     return this.doRequest<void>(this.config, {
       method: 'DELETE',
       url: `/api/users/bookmarks/${ruId}`,
-      middleware: [problemDetailsMiddleware()],
     });
   }
 }

--- a/frontend/src/services/users.service.ts
+++ b/frontend/src/services/users.service.ts
@@ -42,4 +42,44 @@ export class UserService extends HttpClient {
       body: preferences,
     });
   }
+
+  /**
+   * Add a particular reporting unit to the user's bookmarks.
+   * This is an idempotent operation - adding a bookmark for a reporting unit that
+   * is already bookmarked will not cause an error, and will have no effect.
+   * This means the frontend can optimistically call these endpoints without
+   * needing to check the current bookmark state of the reporting unit beforehand.
+   * It also serves as an indicator to the future offline mode to keep track of this
+   * particular reporting unit, as the bookmarked reporting unit is flagged to be available offline.
+   *
+   * @param ruId The reporting unit ID.
+   * @returns A promise that resolves when added.
+   */
+  setUserBookmarkedRu(ruId: number): CancelablePromise<void> {
+    return this.doRequest<void>(this.config, {
+      method: 'PUT',
+      url: `/api/users/bookmarks/${ruId}`,
+      middleware: [problemDetailsMiddleware()],
+    });
+  }
+
+  /**
+   * Remove a particular reporting unit from the user's bookmarks.
+   * This is an idempotent operation - removing a bookmark for a reporting unit that
+   * is not currently bookmarked will not cause an error, and will have no effect.
+   * This means the frontend can optimistically call these endpoints without
+   * needing to check the current bookmark state of the reporting unit beforehand.
+   * It also serves as an indicator to the future offline mode to stop keeping track of this
+   * particular reporting unit, as the bookmarked reporting unit is flagged to be available offline.
+   *
+   * @param ruId The reporting unit ID.
+   * @returns A promise that resolves when removed.
+   */
+  deleteUserBookmarkedRu(ruId: number): CancelablePromise<void> {
+    return this.doRequest<void>(this.config, {
+      method: 'DELETE',
+      url: `/api/users/bookmarks/${ruId}`,
+      middleware: [problemDetailsMiddleware()],
+    });
+  }
 }

--- a/frontend/src/services/users.service.unit.test.ts
+++ b/frontend/src/services/users.service.unit.test.ts
@@ -45,7 +45,6 @@ describe('UserService', () => {
     expect((service as any).doRequest).toHaveBeenCalledWith(mockConfig, {
       method: 'PUT',
       url: '/api/users/bookmarks/42',
-      middleware: [expect.objectContaining({ failure: expect.any(Function) })],
     });
     expect(result).toBeUndefined();
   });
@@ -57,7 +56,6 @@ describe('UserService', () => {
     expect((service as any).doRequest).toHaveBeenCalledWith(mockConfig, {
       method: 'DELETE',
       url: '/api/users/bookmarks/42',
-      middleware: [expect.objectContaining({ failure: expect.any(Function) })],
     });
     expect(result).toBeUndefined();
   });

--- a/frontend/src/services/users.service.unit.test.ts
+++ b/frontend/src/services/users.service.unit.test.ts
@@ -37,4 +37,28 @@ describe('UserService', () => {
     });
     expect(result).toBeUndefined();
   });
+
+  it('setUserBookmarkedRu should PUT a bookmark for the given reporting unit', async () => {
+    (service as any).doRequest = vi.fn().mockResolvedValue(undefined);
+    const ruId = 42;
+    const result = await service.setUserBookmarkedRu(ruId);
+    expect((service as any).doRequest).toHaveBeenCalledWith(mockConfig, {
+      method: 'PUT',
+      url: '/api/users/bookmarks/42',
+      middleware: [expect.objectContaining({ failure: expect.any(Function) })],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('deleteUserBookmarkedRu should DELETE a bookmark for the given reporting unit', async () => {
+    (service as any).doRequest = vi.fn().mockResolvedValue(undefined);
+    const ruId = 42;
+    const result = await service.deleteUserBookmarkedRu(ruId);
+    expect((service as any).doRequest).toHaveBeenCalledWith(mockConfig, {
+      method: 'DELETE',
+      url: '/api/users/bookmarks/42',
+      middleware: [expect.objectContaining({ failure: expect.any(Function) })],
+    });
+    expect(result).toBeUndefined();
+  });
 });

--- a/frontend/stub/__files/search/reporting-units-bookmarked-only.json
+++ b/frontend/stub/__files/search/reporting-units-bookmarked-only.json
@@ -1,13 +1,12 @@
 {
   "content": [
     {
-      "id": "RU-400-Block-N/A-62371222",
-      "wasteAssessmentAreaId": null,
+      "id": "RU-123-Block-N/A-93313424",
       "cutBlockId": null,
-      "ruNumber": 400,
+      "ruNumber": 123,
       "client": {
-        "code": "91234567",
-        "description": "NORTHERN TIMBER CO"
+        "code": "90000001",
+        "description": "CANADIAN SAMPLE CO."
       },
       "licenseNumber": null,
       "cuttingPermit": null,
@@ -26,7 +25,8 @@
         "description": null
       },
       "lastUpdated": "2007-03-30T11:08:20",
-      "bookmarked": false
+      "wasteAssessmentAreaId": null,
+      "bookmarked": true
     }
   ],
   "page": {

--- a/frontend/stub/__files/search/reporting-units-bookmarked.json
+++ b/frontend/stub/__files/search/reporting-units-bookmarked.json
@@ -26,7 +26,7 @@
       },
       "lastUpdated": "2007-03-30T11:08:20",
       "wasteAssessmentAreaId": null,
-      "bookmarked": false
+      "bookmarked": true
     },
     {
       "id": "RU-321-Block-123-55437558",

--- a/frontend/stub/__files/search/reporting-units-pg0.json
+++ b/frontend/stub/__files/search/reporting-units-pg0.json
@@ -25,7 +25,8 @@
         "description": "Submitted"
       },
       "lastUpdated": "2025-08-25T10:35:06",
-      "wasteAssessmentAreaId": 102
+      "wasteAssessmentAreaId": 102,
+      "bookmarked": false
     },
     {
       "id": "RU-34906-Block-105-16777836",
@@ -52,7 +53,8 @@
         "description": "Submitted"
       },
       "lastUpdated": "2025-08-25T10:35:06",
-      "wasteAssessmentAreaId": 105
+      "wasteAssessmentAreaId": 105,
+      "bookmarked": false
     },
     {
       "id": "RU-34906-Block-571-21130094",
@@ -79,7 +81,8 @@
         "description": "Submitted"
       },
       "lastUpdated": "2025-08-25T10:35:06",
-      "wasteAssessmentAreaId": 571
+      "wasteAssessmentAreaId": 571,
+      "bookmarked": false
     },
     {
       "id": "RU-34906-Block-569-54499236",
@@ -106,7 +109,8 @@
         "description": "Submitted"
       },
       "lastUpdated": "2025-08-25T10:35:06",
-      "wasteAssessmentAreaId": 569
+      "wasteAssessmentAreaId": 569,
+      "bookmarked": false
     },
     {
       "id": "RU-34906-Block-341-94613061",
@@ -133,7 +137,8 @@
         "description": "Submitted"
       },
       "lastUpdated": "2025-08-25T10:35:06",
-      "wasteAssessmentAreaId": 341
+      "wasteAssessmentAreaId": 341,
+      "bookmarked": false
     },
     {
       "id": "RU-34906-Block-336-32570121",
@@ -160,7 +165,8 @@
         "description": "Submitted"
       },
       "lastUpdated": "2025-08-25T10:35:06",
-      "wasteAssessmentAreaId": 336
+      "wasteAssessmentAreaId": 336,
+      "bookmarked": false
     },
     {
       "id": "RU-34906-Block-274-40929234",
@@ -187,7 +193,8 @@
         "description": "Submitted"
       },
       "lastUpdated": "2025-08-25T10:35:06",
-      "wasteAssessmentAreaId": 274
+      "wasteAssessmentAreaId": 274,
+      "bookmarked": false
     },
     {
       "id": "RU-34906-Block-218-29188714",
@@ -214,7 +221,8 @@
         "description": "Submitted"
       },
       "lastUpdated": "2025-08-25T10:35:06",
-      "wasteAssessmentAreaId": 218
+      "wasteAssessmentAreaId": 218,
+      "bookmarked": false
     },
     {
       "id": "RU-36834-Block-26-84360965",
@@ -242,7 +250,8 @@
         "description": "Draft"
       },
       "lastUpdated": "2025-08-24T09:10:28",
-      "wasteAssessmentAreaId": 26
+      "wasteAssessmentAreaId": 26,
+      "bookmarked": false
     },
     {
       "id": "RU-10501-Block-2-33684183",
@@ -270,7 +279,8 @@
         "description": "Approved"
       },
       "lastUpdated": "2012-01-27T10:34:58",
-      "wasteAssessmentAreaId": 2
+      "wasteAssessmentAreaId": 2,
+      "bookmarked": false
     }
   ],
   "page": {

--- a/frontend/stub/__files/search/reporting-units-pg1.json
+++ b/frontend/stub/__files/search/reporting-units-pg1.json
@@ -25,7 +25,8 @@
         "description": "Billing Issued"
       },
       "lastUpdated": "2012-01-27T10:34:58",
-      "wasteAssessmentAreaId": 2
+      "wasteAssessmentAreaId": 2,
+      "bookmarked": false
     },
     {
       "id": "RU-2131-Block-510-61564826",
@@ -52,7 +53,8 @@
         "description": "Billing Issued"
       },
       "lastUpdated": "2009-12-02T09:06:58",
-      "wasteAssessmentAreaId": 510
+      "wasteAssessmentAreaId": 510,
+      "bookmarked": false
     }
   ],
   "page": {

--- a/frontend/stub/mappings/users.json
+++ b/frontend/stub/mappings/users.json
@@ -31,6 +31,26 @@
         "status": 200,
         "bodyFileName": "users/preferences-GET-bceid-1.json"
       }
+    },
+    {
+      "name": "Bookmark a reporting unit",
+      "request": {
+        "urlPathPattern": "/api/users/bookmarks/[0-9]+",
+        "method": "PUT"
+      },
+      "response": {
+        "status": 202
+      }
+    },
+    {
+      "name": "Remove a bookmarked reporting unit",
+      "request": {
+        "urlPathPattern": "/api/users/bookmarks/[0-9]+",
+        "method": "DELETE"
+      },
+      "response": {
+        "status": 204
+      }
     }
   ]
 }

--- a/legacy/src/main/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchParametersDto.java
+++ b/legacy/src/main/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchParametersDto.java
@@ -40,6 +40,7 @@ public class ReportingUnitSearchParametersDto {
   private String timberMark;
   private String clientLocationCode;
   private List<String> clientNumbers;
+  private List<Long> reportingUnitIds;
 
   /**
    * Returns the district filter values.
@@ -121,5 +122,12 @@ public class ReportingUnitSearchParametersDto {
   public String getDateEnd() {
     return updateDateEnd != null ? updateDateEnd.format(DateTimeFormatter.ISO_DATE)
         : LegacyConstants.NOVALUE;
+  }
+
+  public List<Long> getReportingUnitIds() {
+    if (reportingUnitIds == null || reportingUnitIds.isEmpty()) {
+      return List.of(-1L);
+    }
+    return reportingUnitIds;
   }
 }

--- a/legacy/src/main/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchResultDto.java
+++ b/legacy/src/main/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchResultDto.java
@@ -25,6 +25,7 @@ public record ReportingUnitSearchResultDto(
     CodeDescriptionDto sampling,
     CodeDescriptionDto district,
     CodeDescriptionDto status,
-    LocalDateTime lastUpdated
+    LocalDateTime lastUpdated,
+    boolean bookmarked
 ) {
 }

--- a/legacy/src/main/java/ca/bc/gov/nrs/hrs/mappers/search/ReportingUnitSearchMapper.java
+++ b/legacy/src/main/java/ca/bc/gov/nrs/hrs/mappers/search/ReportingUnitSearchMapper.java
@@ -49,6 +49,10 @@ public interface ReportingUnitSearchMapper extends
       target = "secondaryEntry",
       expression = "java(Integer.valueOf(1).equals(projection.getSecondaryEntry()))"
   )
+  @Mapping(
+      target = "bookmarked",
+      expression = "java(false)"
+  )
   ReportingUnitSearchResultDto fromProjection(ReportingUnitSearchProjection projection);
 
 }

--- a/legacy/src/main/java/ca/bc/gov/nrs/hrs/repository/ReportingUnitQueryConstants.java
+++ b/legacy/src/main/java/ca/bc/gov/nrs/hrs/repository/ReportingUnitQueryConstants.java
@@ -129,6 +129,10 @@ public final class ReportingUnitQueryConstants {
           NVL(:#{#filter.multiMark}, 0) = 0
           OR (NVL(:#{#filter.multiMark}, 0) = 1 AND waa.MULTI_MARK_IND = 'Y')
         )
+        AND (
+          -1 in (:#{#filter.reportingUnitIds})
+          OR wru.REPORTING_UNIT_ID IN (:#{#filter.reportingUnitIds})
+        )
       """;
 
   public static final String SEARCH_REPORTING_UNIT_QUERY =

--- a/legacy/src/test/java/ca/bc/gov/nrs/hrs/controller/SearchControllerReportingUnitIntegrationTest.java
+++ b/legacy/src/test/java/ca/bc/gov/nrs/hrs/controller/SearchControllerReportingUnitIntegrationTest.java
@@ -363,4 +363,74 @@ class SearchControllerReportingUnitIntegrationTest extends AbstractTestContainer
         .andReturn();
   }
 
+  @Test
+  @DisplayName("Should include bookmarked field as false in search results")
+  void shouldIncludeBookmarkedFieldAsFalse() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/search/reporting-units")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .param("page", "0")
+                .param("size", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content[0].bookmarked").value(false))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Should filter reporting units by reportingUnitIds")
+  void shouldFilterByReportingUnitIds() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/search/reporting-units")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .param("page", "0")
+                .param("size", "10")
+                .param("reportingUnitIds", "879")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content[0].ruNumber").value(879))
+        .andExpect(jsonPath("$.page.totalElements")
+            .value(org.hamcrest.Matchers.greaterThan(0)))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Should filter reporting units by multiple reportingUnitIds")
+  void shouldFilterByMultipleReportingUnitIds() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/search/reporting-units")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .param("page", "0")
+                .param("size", "10")
+                .param("reportingUnitIds", "879", "916")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.page.totalElements")
+            .value(org.hamcrest.Matchers.greaterThanOrEqualTo(2)))
+        .andReturn();
+  }
+
+  @Test
+  @DisplayName("Should return no results for non-existent reportingUnitIds")
+  void shouldReturnNoResultsForNonExistentReportingUnitIds() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/search/reporting-units")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .param("page", "0")
+                .param("size", "10")
+                .param("reportingUnitIds", "999999999")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.page.totalElements").value(0))
+        .andReturn();
+  }
+
 }

--- a/legacy/src/test/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchParametersDtoTest.java
+++ b/legacy/src/test/java/ca/bc/gov/nrs/hrs/dto/search/ReportingUnitSearchParametersDtoTest.java
@@ -1,0 +1,247 @@
+package ca.bc.gov.nrs.hrs.dto.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import ca.bc.gov.nrs.hrs.LegacyConstants;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Unit Test | ReportingUnitSearchParametersDto")
+class ReportingUnitSearchParametersDtoTest {
+
+  // -----------------------------------------------------------------------
+  // getReportingUnitIds
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("getReportingUnitIds")
+  class GetReportingUnitIds {
+
+    @Test
+    @DisplayName("should return list with -1 when reportingUnitIds is null")
+    void shouldReturnDefaultWhenNull() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      assertEquals(List.of(-1L), dto.getReportingUnitIds());
+    }
+
+    @Test
+    @DisplayName("should return list with -1 when reportingUnitIds is empty")
+    void shouldReturnDefaultWhenEmpty() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setReportingUnitIds(List.of());
+      assertEquals(List.of(-1L), dto.getReportingUnitIds());
+    }
+
+    @Test
+    @DisplayName("should return actual values when reportingUnitIds is populated")
+    void shouldReturnActualValuesWhenPopulated() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setReportingUnitIds(List.of(100L, 200L, 300L));
+      assertEquals(List.of(100L, 200L, 300L), dto.getReportingUnitIds());
+    }
+
+    @Test
+    @DisplayName("should return single value list when one id is provided")
+    void shouldReturnSingleValueList() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setReportingUnitIds(List.of(879L));
+      assertEquals(List.of(879L), dto.getReportingUnitIds());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // getDistrict
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("getDistrict")
+  class GetDistrict {
+
+    @Test
+    @DisplayName("should return NOVALUE when district is null")
+    void shouldReturnNoValueWhenNull() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      assertEquals(List.of(LegacyConstants.NOVALUE), dto.getDistrict());
+    }
+
+    @Test
+    @DisplayName("should return NOVALUE when district is empty")
+    void shouldReturnNoValueWhenEmpty() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setDistrict(List.of());
+      assertEquals(List.of(LegacyConstants.NOVALUE), dto.getDistrict());
+    }
+
+    @Test
+    @DisplayName("should return actual values when district is populated")
+    void shouldReturnActualValues() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setDistrict(List.of("DCR", "DMH"));
+      assertEquals(List.of("DCR", "DMH"), dto.getDistrict());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // getSampling
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("getSampling")
+  class GetSampling {
+
+    @Test
+    @DisplayName("should return NOVALUE when sampling is null")
+    void shouldReturnNoValueWhenNull() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      assertEquals(List.of(LegacyConstants.NOVALUE), dto.getSampling());
+    }
+
+    @Test
+    @DisplayName("should return NOVALUE when sampling is empty")
+    void shouldReturnNoValueWhenEmpty() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setSampling(List.of());
+      assertEquals(List.of(LegacyConstants.NOVALUE), dto.getSampling());
+    }
+
+    @Test
+    @DisplayName("should return actual values when sampling is populated")
+    void shouldReturnActualValues() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setSampling(List.of("S1", "S2"));
+      assertEquals(List.of("S1", "S2"), dto.getSampling());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // getStatus
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("getStatus")
+  class GetStatus {
+
+    @Test
+    @DisplayName("should return NOVALUE when status is null")
+    void shouldReturnNoValueWhenNull() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      assertEquals(List.of(LegacyConstants.NOVALUE), dto.getStatus());
+    }
+
+    @Test
+    @DisplayName("should return NOVALUE when status is empty")
+    void shouldReturnNoValueWhenEmpty() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setStatus(List.of());
+      assertEquals(List.of(LegacyConstants.NOVALUE), dto.getStatus());
+    }
+
+    @Test
+    @DisplayName("should return actual values when status is populated")
+    void shouldReturnActualValues() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setStatus(List.of("AC", "IN"));
+      assertEquals(List.of("AC", "IN"), dto.getStatus());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // getClientNumbers
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("getClientNumbers")
+  class GetClientNumbers {
+
+    @Test
+    @DisplayName("should return NOVALUE when clientNumbers is null")
+    void shouldReturnNoValueWhenNull() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      assertEquals(List.of(LegacyConstants.NOVALUE), dto.getClientNumbers());
+    }
+
+    @Test
+    @DisplayName("should return NOVALUE when clientNumbers is empty")
+    void shouldReturnNoValueWhenEmpty() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setClientNumbers(List.of());
+      assertEquals(List.of(LegacyConstants.NOVALUE), dto.getClientNumbers());
+    }
+
+    @Test
+    @DisplayName("should return actual values when clientNumbers is populated")
+    void shouldReturnActualValues() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setClientNumbers(List.of("00001271", "00010004"));
+      assertEquals(List.of("00001271", "00010004"), dto.getClientNumbers());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // getDateStart / getDateEnd
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("getDateStart and getDateEnd")
+  class GetDates {
+
+    @Test
+    @DisplayName("should return NOVALUE when updateDateStart is null")
+    void shouldReturnNoValueWhenDateStartIsNull() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      assertEquals(LegacyConstants.NOVALUE, dto.getDateStart());
+    }
+
+    @Test
+    @DisplayName("should return formatted date when updateDateStart is set")
+    void shouldReturnFormattedDateStart() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setUpdateDateStart(LocalDate.of(2025, 3, 15));
+      assertEquals("2025-03-15", dto.getDateStart());
+    }
+
+    @Test
+    @DisplayName("should return NOVALUE when updateDateEnd is null")
+    void shouldReturnNoValueWhenDateEndIsNull() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      assertEquals(LegacyConstants.NOVALUE, dto.getDateEnd());
+    }
+
+    @Test
+    @DisplayName("should return formatted date when updateDateEnd is set")
+    void shouldReturnFormattedDateEnd() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      dto.setUpdateDateEnd(LocalDate.of(2025, 12, 31));
+      assertEquals("2025-12-31", dto.getDateEnd());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Default values for simple fields
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("default field values")
+  class DefaultFieldValues {
+
+    @Test
+    @DisplayName("should have requestByMe as false by default")
+    void shouldHaveRequestByMeAsFalseByDefault() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      assertFalse(dto.isRequestByMe());
+    }
+
+    @Test
+    @DisplayName("should have multiMark as false by default")
+    void shouldHaveMultiMarkAsFalseByDefault() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      assertFalse(dto.isMultiMark());
+    }
+
+    @Test
+    @DisplayName("should have null mainSearchTerm by default")
+    void shouldHaveNullMainSearchTermByDefault() {
+      ReportingUnitSearchParametersDto dto = new ReportingUnitSearchParametersDto();
+      assertNull(dto.getMainSearchTerm());
+    }
+  }
+}
+

--- a/legacy/src/test/java/ca/bc/gov/nrs/hrs/mappers/search/ReportingUnitSearchMapperTest.java
+++ b/legacy/src/test/java/ca/bc/gov/nrs/hrs/mappers/search/ReportingUnitSearchMapperTest.java
@@ -1,0 +1,246 @@
+package ca.bc.gov.nrs.hrs.mappers.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ca.bc.gov.nrs.hrs.dto.search.ReportingUnitSearchResultDto;
+import ca.bc.gov.nrs.hrs.entity.search.ReportingUnitSearchProjection;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DisplayName("Unit Test | ReportingUnitSearchMapper")
+@SpringBootTest(classes = {ReportingUnitSearchMapperImpl.class})
+@ActiveProfiles("default")
+class ReportingUnitSearchMapperTest {
+
+  @Autowired
+  private ReportingUnitSearchMapper mapper;
+
+  private ReportingUnitSearchProjection projection;
+
+  @BeforeEach
+  void setUp() {
+    projection = mock(ReportingUnitSearchProjection.class);
+  }
+
+  private void stubFullProjection() {
+    when(projection.getWasteAssessmentAreaId()).thenReturn(100L);
+    when(projection.getCutBlockId()).thenReturn("BLK-1");
+    when(projection.getRuNumber()).thenReturn(879L);
+    when(projection.getClientNumber()).thenReturn("00001271");
+    when(projection.getLicenseNumber()).thenReturn("A91320");
+    when(projection.getCuttingPermit()).thenReturn("CP1");
+    when(projection.getTimberMark()).thenReturn("TM001");
+    when(projection.getMultiMark()).thenReturn(0);
+    when(projection.getSecondaryEntry()).thenReturn(0);
+    when(projection.getSamplingCode()).thenReturn("S");
+    when(projection.getSamplingName()).thenReturn("Sampling");
+    when(projection.getDistrictCode()).thenReturn("DCR");
+    when(projection.getDistrictName()).thenReturn("Campbell River Natural Resource District");
+    when(projection.getStatusCode()).thenReturn("AC");
+    when(projection.getStatusName()).thenReturn("Active");
+    when(projection.getLastUpdated()).thenReturn(LocalDateTime.of(2025, 1, 15, 10, 30));
+  }
+
+  // -----------------------------------------------------------------------
+  // Null projection
+  // -----------------------------------------------------------------------
+  @Test
+  @DisplayName("should return null when projection is null")
+  void shouldReturnNullWhenProjectionIsNull() {
+    ReportingUnitSearchResultDto dto = mapper.fromProjection(null);
+    assertNull(dto);
+  }
+
+  // -----------------------------------------------------------------------
+  // Full mapping
+  // -----------------------------------------------------------------------
+  @Test
+  @DisplayName("should map all fields from a complete projection")
+  void shouldMapAllFieldsFromCompleteProjection() {
+    stubFullProjection();
+
+    ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+    assertNotNull(dto);
+    assertEquals(100L, dto.wasteAssessmentAreaId());
+    assertEquals("BLK-1", dto.cutBlockId());
+    assertEquals(879L, dto.ruNumber());
+    assertEquals("00001271", dto.client().code());
+    assertNull(dto.client().description());
+    assertEquals("A91320", dto.licenseNumber());
+    assertEquals("CP1", dto.cuttingPermit());
+    assertEquals("TM001", dto.timberMark());
+    assertEquals("S", dto.sampling().code());
+    assertEquals("Sampling", dto.sampling().description());
+    assertEquals("DCR", dto.district().code());
+    assertEquals("Campbell River", dto.district().description());
+    assertEquals("AC", dto.status().code());
+    assertEquals("Active", dto.status().description());
+    assertEquals(LocalDateTime.of(2025, 1, 15, 10, 30), dto.lastUpdated());
+  }
+
+  // -----------------------------------------------------------------------
+  // bookmarked mapping
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("bookmarked mapping")
+  class BookmarkedMapping {
+
+    @Test
+    @DisplayName("should always map bookmarked to false")
+    void shouldAlwaysMapBookmarkedToFalse() {
+      stubFullProjection();
+
+      ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+      assertNotNull(dto);
+      assertFalse(dto.bookmarked());
+    }
+
+    @Test
+    @DisplayName("bookmarked should be false regardless of projection values")
+    void bookmarkedShouldBeFalseRegardlessOfProjectionValues() {
+      stubFullProjection();
+      when(projection.getMultiMark()).thenReturn(1);
+      when(projection.getSecondaryEntry()).thenReturn(1);
+
+      ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+      assertNotNull(dto);
+      assertFalse(dto.bookmarked());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // multiMark mapping
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("multiMark mapping")
+  class MultiMarkMapping {
+
+    @Test
+    @DisplayName("should map multiMark to true when projection value is 1")
+    void shouldMapMultiMarkTrueWhenOne() {
+      stubFullProjection();
+      when(projection.getMultiMark()).thenReturn(1);
+
+      ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+      assertNotNull(dto);
+      assertTrue(dto.multiMark());
+    }
+
+    @Test
+    @DisplayName("should map multiMark to false when projection value is 0")
+    void shouldMapMultiMarkFalseWhenZero() {
+      stubFullProjection();
+      when(projection.getMultiMark()).thenReturn(0);
+
+      ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+      assertNotNull(dto);
+      assertFalse(dto.multiMark());
+    }
+
+    @Test
+    @DisplayName("should map multiMark to false when projection value is null")
+    void shouldMapMultiMarkFalseWhenNull() {
+      stubFullProjection();
+      when(projection.getMultiMark()).thenReturn(null);
+
+      ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+      assertNotNull(dto);
+      assertFalse(dto.multiMark());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // secondaryEntry mapping
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("secondaryEntry mapping")
+  class SecondaryEntryMapping {
+
+    @Test
+    @DisplayName("should map secondaryEntry to true when projection value is 1")
+    void shouldMapSecondaryEntryTrueWhenOne() {
+      stubFullProjection();
+      when(projection.getSecondaryEntry()).thenReturn(1);
+
+      ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+      assertNotNull(dto);
+      assertTrue(dto.secondaryEntry());
+    }
+
+    @Test
+    @DisplayName("should map secondaryEntry to false when projection value is 0")
+    void shouldMapSecondaryEntryFalseWhenZero() {
+      stubFullProjection();
+      when(projection.getSecondaryEntry()).thenReturn(0);
+
+      ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+      assertNotNull(dto);
+      assertFalse(dto.secondaryEntry());
+    }
+
+    @Test
+    @DisplayName("should map secondaryEntry to false when projection value is null")
+    void shouldMapSecondaryEntryFalseWhenNull() {
+      stubFullProjection();
+      when(projection.getSecondaryEntry()).thenReturn(null);
+
+      ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+      assertNotNull(dto);
+      assertFalse(dto.secondaryEntry());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // district name cleanup
+  // -----------------------------------------------------------------------
+  @Nested
+  @DisplayName("district name mapping")
+  class DistrictNameMapping {
+
+    @Test
+    @DisplayName("should strip 'Natural Resource District' from district name")
+    void shouldStripNaturalResourceDistrictSuffix() {
+      stubFullProjection();
+      when(projection.getDistrictName()).thenReturn("Campbell River Natural Resource District");
+
+      ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+      assertNotNull(dto);
+      assertEquals("Campbell River", dto.district().description());
+    }
+
+    @Test
+    @DisplayName("should handle district name without the suffix")
+    void shouldHandleDistrictNameWithoutSuffix() {
+      stubFullProjection();
+      when(projection.getDistrictName()).thenReturn("Some District");
+
+      ReportingUnitSearchResultDto dto = mapper.fromProjection(projection);
+
+      assertNotNull(dto);
+      assertEquals("Some District", dto.district().description());
+    }
+  }
+}
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Add bookmarking functionality for reporting units across backend and frontend, including storage, search filtering/enrichment, row actions and UI, tests, and a DB migration to support bookmarks. Users can bookmark reporting units, filter search results by bookmarks, and the backend exposes bookmarked state and supports storing user bookmarks. Many tests were added/updated to cover the feature.
- Implements #779 


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] New unit tests
- [x] New integrated tests
- [x] New component tests
- [x] New end-to-end tests

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

If this PR adds, changes, or removes behavior behind a feature flag, this section is required.
Use the architecture checklist in the Feature Flags page as the source of truth.

- [x] Canonical key follows `<domain>-<capability>-enabled`
- [x] Frontend and backend use the same canonical key

If any required checkbox above is unchecked, stop and resolve before requesting review.


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-32-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)