### PR TITLE
fix(#791): enable conditional service worker registration based on offline mode feature flag

### DIFF
--- a/frontend/src/registerServiceWorker.ts
+++ b/frontend/src/registerServiceWorker.ts
@@ -1,39 +1,48 @@
 import { registerSW } from 'virtual:pwa-register';
 
+import { featureFlags } from '@/env';
 import { sendToastEvent } from '@/hooks/useNotificationEvents/eventHandler';
 
-/**
- * Registers the PWA service worker and emits user-facing events for lifecycle changes.
- */
-const updateSW = registerSW({
-  onRegistered() {
-    sendToastEvent({
-      eventType: 'success',
-      title: 'Application registered successfully',
-      description: 'Your application is now ready to work offline.',
-    });
-  },
-  onRegisterError(error) {
-    sendToastEvent({
-      eventType: 'error',
-      title: 'Failed to register the app for offline use',
-      description: error instanceof Error ? error.message : String(error),
-    });
-  },
-  onNeedRefresh() {
-    sendToastEvent({
-      eventType: 'info',
-      title: 'New content available',
-      description: 'A new version of the app is available. Please refresh the app by pressing F5.',
-    });
-  },
-  onOfflineReady() {
-    sendToastEvent({
-      eventType: 'info',
-      title: 'You are offline',
-      description: "Don't worry, you will still be able to access offline content.",
-    });
-  },
-});
+const updateSW = featureFlags['offline-mode-enabled']
+  ? registerSW({
+      onRegistered() {
+        sendToastEvent({
+          eventType: 'success',
+          title: 'Application registered successfully',
+          description: 'Your application is now ready to work offline.',
+        });
+      },
+      onRegisterError(error) {
+        sendToastEvent({
+          eventType: 'error',
+          title: 'Failed to register the app for offline use',
+          description: error instanceof Error ? error.message : String(error),
+        });
+      },
+      onNeedRefresh() {
+        sendToastEvent({
+          eventType: 'info',
+          title: 'New content available',
+          description:
+            'A new version of the app is available. Please refresh the app by pressing F5.',
+        });
+      },
+      onOfflineReady() {
+        sendToastEvent({
+          eventType: 'info',
+          title: 'You are offline',
+          description: "Don't worry, you will still be able to access offline content.",
+        });
+      },
+    })
+  : (reloadPage?: boolean) => {
+      // No-op when offline mode is disabled. Keep the signature compatible with
+      // the registerSW return value so callers don't need to change.
+      // eslint-disable-next-line no-console
+      console.debug(
+        '[pwa] offline-mode-disabled: skipping service worker registration',
+        reloadPage,
+      );
+    };
 
 export default updateSW;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- Summary: Gate service worker registration behind the offline mode feature flag, so the service worker isn't registered when the feature is disabled.
- Context: The application previously registered a service worker regardless of the offline mode feature flag, causing unintended offline caching and potentially serving stale assets. This change conditions registration on the offline-mode flag.
- Fixes #791 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] No new tests are required

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

If this PR adds, changes, or removes behavior behind a feature flag, this section is required.
Use the architecture checklist in the Feature Flags page as the source of truth.

- [x] Canonical key follows `<domain>-<capability>-enabled`

If any required checkbox above is unchecked, stop and resolve before requesting review.


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-42-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)