### PR TITLE
fix(ci): replace npm install with npm ci to prevent lockfile drift

### DIFF
--- a/.github/workflows/.automated-tests.yml
+++ b/.github/workflows/.automated-tests.yml
@@ -38,3 +38,52 @@ jobs:
           CYPRESS_MOCHAWESOME_REPORT: true
           CYPRESS_bceid_password: ${{ secrets.BCEID_UAT_PASSWORD }}
           CYPRESS_bceid_username: ${{ secrets.BCEID_UAT_USERNAME }}
+
+      - name: Generate Markdown Report
+        working-directory: cypress
+        if: always()
+        run: npm run report:md
+
+      - name: Add summary to GitHub Action
+        working-directory: cypress
+        if: always()
+        run: cat summary.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Check for Cypress Screenshots and Videos
+        continue-on-error: true
+        if: always()
+        run: |
+          if [ -d "cypress/cypress/screenshots" ] && [ "$(ls -A cypress/cypress/screenshots)" ]; then
+            echo "Screenshots folder is not empty, uploading artifacts."
+            echo "screenshots=true" >> $GITHUB_OUTPUT
+
+          else
+            echo "Screenshots folder is empty or does not exist."
+            echo "screenshots=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -d "cypress/cypress/videos" ] && [ "$(ls -A cypress/cypress/videos)" ]; then
+            echo "Videos folder is not empty, uploading artifacts."
+            echo "videos=true" >> $GITHUB_OUTPUT
+
+          else
+            echo "Videos folder is empty or does not exist."
+            echo "videos=false" >> $GITHUB_OUTPUT
+          fi
+        id: check_artifacts
+
+      - uses: actions/upload-artifact@v7
+        name: Upload Cypress Screenshots
+        if: always()
+        with:
+          name: cypress-screenshots
+          path: cypress/cypress/screenshots
+          retention-days: 7
+
+      - uses: actions/upload-artifact@v7
+        name: Upload Cypress Videos
+        if: always()
+        with:
+          name: cypress-videos
+          path: cypress/cypress/videos
+          retention-days: 7

--- a/.github/workflows/.automated-tests.yml
+++ b/.github/workflows/.automated-tests.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           working-directory: cypress
           browser: chrome
+          install-command: npm ci
         env:
           CYPRESS_baseUrl: https://${{ inputs.url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}          
@@ -37,52 +38,3 @@ jobs:
           CYPRESS_MOCHAWESOME_REPORT: true
           CYPRESS_bceid_password: ${{ secrets.BCEID_UAT_PASSWORD }}
           CYPRESS_bceid_username: ${{ secrets.BCEID_UAT_USERNAME }}
-
-      - name: Generate Markdown Report
-        working-directory: cypress
-        if: always()
-        run: npm run report:md
-
-      - name: Add summary to GitHub Action
-        working-directory: cypress
-        if: always()
-        run: cat summary.md >> $GITHUB_STEP_SUMMARY
-
-      - name: Check for Cypress Screenshots and Videos
-        continue-on-error: true
-        if: always()
-        run: |
-          if [ -d "cypress/cypress/screenshots" ] && [ "$(ls -A cypress/cypress/screenshots)" ]; then
-            echo "Screenshots folder is not empty, uploading artifacts."            
-            echo "screenshots=true" >> $GITHUB_OUTPUT
-
-          else
-            echo "Screenshots folder is empty or does not exist."
-            echo "screenshots=false" >> $GITHUB_OUTPUT
-          fi
-
-          if [ -d "cypress/cypress/videos" ] && [ "$(ls -A cypress/cypress/videos)" ]; then
-            echo "Videos folder is not empty, uploading artifacts."            
-            echo "videos=true" >> $GITHUB_OUTPUT
-
-          else
-            echo "Videos folder is empty or does not exist."
-            echo "videos=false" >> $GITHUB_OUTPUT
-          fi
-        id: check_artifacts
-
-      - uses: actions/upload-artifact@v7
-        name: Upload Cypress Screenshots
-        if: always()
-        with:
-          name: cypress-screenshots
-          path: cypress/cypress/screenshots
-          retention-days: 7
-
-      - uses: actions/upload-artifact@v7
-        name: Upload Cypress Videos
-        if: always()
-        with:
-          name: cypress-videos
-          path: cypress/cypress/videos
-          retention-days: 7

--- a/.github/workflows/reusable-tests-fe-extra.yml
+++ b/.github/workflows/reusable-tests-fe-extra.yml
@@ -44,7 +44,7 @@ jobs:
           node-version: "24"
 
       - name: Install Dependencies
-        run: npm i
+        run: npm ci
         working-directory: frontend
 
       - name: Frontend Tests

--- a/.github/workflows/reusable-tests-fe.yml
+++ b/.github/workflows/reusable-tests-fe.yml
@@ -60,7 +60,7 @@ jobs:
           node_version: 24
           commands: |
             git config --global --add safe.directory /__w/nr-waste-plus/nr-waste-plus
-            npm i
+            npm ci
             npx playwright install-deps
             npx playwright install
             npm run test:coverage


### PR DESCRIPTION
# Description

Replaces `npm i` / `npm install` with `npm ci` in all frontend and Cypress CI workflows.

`npm ci` installs strictly from the lockfile with no version resolution. This means a newly published malicious package version that is not already pinned in `package-lock.json` cannot be silently pulled into the build. `npm install`, by contrast, resolves `^`-ranged dependencies against the registry at install time, making it possible for a supply chain attack to land on a runner even when the lockfile is committed.

This hardening was identified following the TanStack npm supply chain compromise disclosed on 2026-05-11 (CVE-2026-45321 / GHSA-g7cv-rxg3-hmpx, Critical 9.6). An audit confirmed this project is **not affected** by that incident, but the `npm install` pattern in CI was identified as a structural risk worth closing.

Fixes #829

## Changes

| Workflow | Before | After |
|---|---|---|
| `reusable-tests-fe.yml` (unit + e2e) | `npm i` inside `bcgov/action-test-and-analyse` commands | `npm ci` |
| `reusable-tests-fe-extra.yml` (a11y) | `npm i` in explicit Install Dependencies step | `npm ci` |
| `.automated-tests.yml` (Cypress) | `cypress-io/github-action` default install | `install-command: npm ci` |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [x] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests

`npm ci` is a drop-in replacement for `npm install` when a valid `package-lock.json` exists. It fails fast if the lockfile is absent or mismatched, which is the desired CI behaviour. No functional code is changed.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR

## Further comments

**Why not `--ignore-scripts` as well?**

The advisory also recommends `npm config set ignore-scripts true` as defence-in-depth, since the TanStack malware executed via npm lifecycle scripts (`postinstall`/`prepare`). However, several build-tool packages used in this project (`esbuild`, `@playwright/test`) rely on their own `postinstall` scripts to download native binaries. Applying `--ignore-scripts` globally would break these workflows without additional `npm rebuild` steps for each affected package. This is deferred to a follow-up investigation to identify the exact set of packages that need explicit rebuild and to evaluate scoped alternatives (e.g. per-package `ignore-scripts` in `.npmrc`).

**References:**
- Advisory: https://github.com/advisories/GHSA-g7cv-rxg3-hmpx
- CVE-2026-45321 (Critical 9.6)
- Tracking issue: #829

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-30-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)