### PR TITLE
fix(#802): suppress 401 toast for unauthenticated requests during login/init

### DIFF
--- a/frontend/src/config/api/failureNotificationMiddleware.ts
+++ b/frontend/src/config/api/failureNotificationMiddleware.ts
@@ -46,6 +46,18 @@ export const failureNotificationMiddleware = (): ApiMiddleware => ({
       throw error;
     }
 
+    // Suppress 401 errors that fired without an auth token — this is the expected outcome
+    // during initial app load and right after the OAuth redirect, when the session cookie is
+    // not yet available. Showing a toast here would confuse users who are actively logging in.
+    // Requests that did carry a token but still got a 401 (expired/invalid token) are NOT
+    // suppressed so the user is still informed of a real auth problem.
+    const hasAuthHeader =
+      typeof error.config?.headers?.['Authorization'] === 'string' &&
+      error.config.headers['Authorization'].length > 0;
+    if (!hasAuthHeader && error.response?.status === 401) {
+      throw error;
+    }
+
     if (suppressFailureNotification || notificationTarget) {
       throw error;
     }

--- a/frontend/src/config/api/failureNotificationMiddleware.ts
+++ b/frontend/src/config/api/failureNotificationMiddleware.ts
@@ -32,6 +32,34 @@ const getProblemDetails = (error: AxiosError<unknown>): ProblemDetails | undefin
 };
 
 /**
+ * Returns the value of the Authorization header regardless of header container type or key casing.
+ *
+ * At runtime `error.config.headers` can be either an `AxiosHeaders` class instance (which exposes
+ * a case-insensitive `.get()` method) or a plain object where Axios may have normalised the key to
+ * lowercase. Both shapes are handled to avoid false negatives that would incorrectly suppress 401
+ * toast notifications for requests that did carry a bearer token.
+ */
+const getAuthorizationHeader = (
+  headers: InternalAxiosRequestConfig['headers'] | undefined,
+): string | undefined => {
+  if (!headers) return undefined;
+
+  // AxiosHeaders instances expose a case-insensitive .get() — verify at runtime because
+  // error.config.headers is not always an AxiosHeaders class instance.
+  if (typeof (headers as { get?: unknown }).get === 'function') {
+    const value = (headers as { get(name: string): string | false | null | undefined }).get(
+      'Authorization',
+    );
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  }
+
+  // Plain-object fallback: check both title-case and lowercase variants.
+  const plain = headers as Record<string, unknown>;
+  const raw = plain['Authorization'] ?? plain['authorization'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+};
+
+/**
  * Default middleware for API failures.
  *
  * Emits a toast error for unscoped request failures so network/CORS/backend issues are never silent.
@@ -51,9 +79,7 @@ export const failureNotificationMiddleware = (): ApiMiddleware => ({
     // not yet available. Showing a toast here would confuse users who are actively logging in.
     // Requests that did carry a token but still got a 401 (expired/invalid token) are NOT
     // suppressed so the user is still informed of a real auth problem.
-    const hasAuthHeader =
-      typeof error.config?.headers?.['Authorization'] === 'string' &&
-      error.config.headers['Authorization'].length > 0;
+    const hasAuthHeader = getAuthorizationHeader(error.config?.headers) !== undefined;
     if (!hasAuthHeader && error.response?.status === 401) {
       throw error;
     }

--- a/frontend/src/config/api/failureNotificationMiddleware.unit.test.ts
+++ b/frontend/src/config/api/failureNotificationMiddleware.unit.test.ts
@@ -116,7 +116,7 @@ describe('failureNotificationMiddleware', () => {
     // where no session cookie exists yet. A toast here would confuse users mid-login.
     const middleware = failureNotificationMiddleware();
     const error = makeError({
-      config: makeConfig({ headers: {} }),
+      config: makeConfig({ headers: {} as unknown as InternalAxiosRequestConfig['headers'] }),
       response: {
         status: 401,
         statusText: 'Unauthorized',
@@ -136,7 +136,7 @@ describe('failureNotificationMiddleware', () => {
     // The user should be informed rather than silently failing.
     const middleware = failureNotificationMiddleware();
     const error = makeError({
-      config: makeConfig({ headers: { Authorization: 'Bearer expired-token' } }),
+      config: makeConfig({ headers: { Authorization: 'Bearer expired-token' } as unknown as InternalAxiosRequestConfig['headers'] }),
       response: {
         status: 401,
         statusText: 'Unauthorized',

--- a/frontend/src/config/api/failureNotificationMiddleware.unit.test.ts
+++ b/frontend/src/config/api/failureNotificationMiddleware.unit.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { failureNotificationMiddleware } from './failureNotificationMiddleware';
 
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
+import { AxiosHeaders } from 'axios';
 
 import { sendEvent } from '@/hooks/useNotificationEvents/eventHandler';
 
@@ -157,6 +158,85 @@ describe('failureNotificationMiddleware', () => {
         meta: expect.objectContaining({ status: 401 }),
       }),
     );
+  });
+
+  it('still notifies for 401 when authorization header uses lowercase key (plain object)', async () => {
+    // Axios may normalise header names to lowercase on some request paths.
+    // Treating a lowercase key as absent would incorrectly suppress the toast.
+    const middleware = failureNotificationMiddleware();
+    const error = makeError({
+      config: makeConfig({ headers: { authorization: 'Bearer expired-token' } as unknown as InternalAxiosRequestConfig['headers'] }),
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+        data: { title: 'Unauthorized', status: 401, detail: 'Token expired' },
+        headers: {},
+        config: {} as InternalAxiosRequestConfig,
+      },
+    });
+
+    await expect(middleware.failure?.(error)).rejects.toBe(error);
+
+    expect(sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'error',
+        displayMode: 'toast',
+        title: 'Unauthorized',
+        description: 'Token expired',
+        meta: expect.objectContaining({ status: 401 }),
+      }),
+    );
+  });
+
+  it('still notifies for 401 when Authorization is set on an AxiosHeaders instance', async () => {
+    // At runtime error.config.headers is commonly an AxiosHeaders class instance.
+    // The case-insensitive .get() method must be used to detect the token.
+    const headers = new AxiosHeaders();
+    headers.set('Authorization', 'Bearer expired-token');
+
+    const middleware = failureNotificationMiddleware();
+    const error = makeError({
+      config: makeConfig({ headers: headers as unknown as InternalAxiosRequestConfig['headers'] }),
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+        data: { title: 'Unauthorized', status: 401, detail: 'Token expired' },
+        headers: {},
+        config: {} as InternalAxiosRequestConfig,
+      },
+    });
+
+    await expect(middleware.failure?.(error)).rejects.toBe(error);
+
+    expect(sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'error',
+        displayMode: 'toast',
+        title: 'Unauthorized',
+        description: 'Token expired',
+        meta: expect.objectContaining({ status: 401 }),
+      }),
+    );
+  });
+
+  it('does not notify for 401 when AxiosHeaders instance carries no Authorization header', async () => {
+    // An empty AxiosHeaders instance represents a request sent without a session token.
+    // The suppression logic must work with the class instance, not just plain objects.
+    const middleware = failureNotificationMiddleware();
+    const error = makeError({
+      config: makeConfig({ headers: new AxiosHeaders() as unknown as InternalAxiosRequestConfig['headers'] }),
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+        data: { title: 'Unauthorized', status: 401, detail: 'No token provided' },
+        headers: {},
+        config: {} as InternalAxiosRequestConfig,
+      },
+    });
+
+    await expect(middleware.failure?.(error)).rejects.toBe(error);
+
+    expect(sendEvent).not.toHaveBeenCalled();
   });
 
   it('uses Request failed fallback title and error.message_whenResponseDataIsNotProblemDetails', async () => {

--- a/frontend/src/config/api/failureNotificationMiddleware.unit.test.ts
+++ b/frontend/src/config/api/failureNotificationMiddleware.unit.test.ts
@@ -111,6 +111,54 @@ describe('failureNotificationMiddleware', () => {
     expect(sendEvent).not.toHaveBeenCalled();
   });
 
+  it('does not notify for 401 when no Authorization header was sent', async () => {
+    // Simulates unauthenticated requests during initial app load or the login page,
+    // where no session cookie exists yet. A toast here would confuse users mid-login.
+    const middleware = failureNotificationMiddleware();
+    const error = makeError({
+      config: makeConfig({ headers: {} }),
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+        data: { title: 'Unauthorized', status: 401, detail: 'No token provided' },
+        headers: {},
+        config: {} as InternalAxiosRequestConfig,
+      },
+    });
+
+    await expect(middleware.failure?.(error)).rejects.toBe(error);
+
+    expect(sendEvent).not.toHaveBeenCalled();
+  });
+
+  it('still notifies for 401 when Authorization header was present', async () => {
+    // An expired or invalid token was sent — the server explicitly rejected it.
+    // The user should be informed rather than silently failing.
+    const middleware = failureNotificationMiddleware();
+    const error = makeError({
+      config: makeConfig({ headers: { Authorization: 'Bearer expired-token' } }),
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+        data: { title: 'Unauthorized', status: 401, detail: 'Token expired' },
+        headers: {},
+        config: {} as InternalAxiosRequestConfig,
+      },
+    });
+
+    await expect(middleware.failure?.(error)).rejects.toBe(error);
+
+    expect(sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'error',
+        displayMode: 'toast',
+        title: 'Unauthorized',
+        description: 'Token expired',
+        meta: expect.objectContaining({ status: 401 }),
+      }),
+    );
+  });
+
   it('uses Request failed fallback title and error.message_whenResponseDataIsNotProblemDetails', async () => {
     const middleware = failureNotificationMiddleware();
     const error = makeError({


### PR DESCRIPTION
# Description

After a successful login via BCeID or IDIR, users were seeing a red error toast popup immediately after being redirected back into the application. The same issue occurred on first page load before the session was established.

**Root cause:** During the initial app load and right after the OAuth redirect completes, the app fires backend requests before the Cognito session cookie is fully available. These requests go out without an `Authorization` header and the backend correctly returns `401 Unauthorized`. The global failure notification middleware was treating these as regular errors and showing a toast — even though the login itself was completely successful.

**Fix:** The `failureNotificationMiddleware` now silently drops `401` responses when the original request carried no `Authorization` header. This is the only scenario where a `401` without a token is the _expected_ outcome (unauthenticated request to a protected endpoint during app init). Requests that did carry a token but still got a `401` (expired or invalid token) are **not** suppressed — those still surface a toast so the user knows there is a real auth problem.

Fixes #802

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New unit tests
- [x] Updated existing tests

Two new unit test cases were added to `failureNotificationMiddleware.unit.test.ts`:

1. **`does not notify for 401 when no Authorization header was sent`** — verifies the middleware silently re-throws without calling `sendEvent` when the request had no auth token and the server responded with `401`. This covers the login-page and initial-load scenarios.

2. **`still notifies for 401 when Authorization header was present`** — verifies that a `401` on a token-carrying request (expired/invalid token) still fires a toast. This guards against accidentally silencing real auth failures.

All 9 unit tests pass (7 existing + 2 new).

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR

## Further comments

The fix is intentionally narrow — only the conjunction of `no Authorization header` + `status 401` suppresses the toast. This avoids accidentally silencing:

- `403 Forbidden` on unauthenticated requests (misconfiguration signal)
- `500` or network errors on unauthenticated requests (unexpected backend problems)
- Any non-401 failure regardless of token presence

The change touches a single middleware factory function and its test file; no React Query hooks, route guards, or API service files were modified.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-7-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)