### PR TITLE
feat(#866): Add ConditionalField component for declarative form field visibility control

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@carbon/icons-react": "^11.76.0",
         "@carbon/pictograms-react": "^11.97.0",
         "@carbon/react": "^1.103.0",
+        "@tanstack/react-form": "^1.32.0",
         "@tanstack/react-query": "^5.90.16",
         "@tanstack/react-router": "^1.169.2",
         "aws-amplify": "^6.17.0",
@@ -5241,6 +5242,22 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tanstack/devtools-event-client": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.4.3.tgz",
+      "integrity": "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==",
+      "license": "MIT",
+      "bin": {
+        "intent": "bin/intent.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/eslint-plugin-query": {
       "version": "5.91.2",
       "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.91.2.tgz",
@@ -5258,6 +5275,21 @@
         "eslint": "^8.57.0 || ^9.0.0"
       }
     },
+    "node_modules/@tanstack/form-core": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.32.0.tgz",
+      "integrity": "sha512-Tn5VRDSjyqjmaet2tJMuEWDRFyrCaon03vxXPlSSaiSs6C/N7lCIwGCXJbZXEUq1kTj8jYN9qyXHbsz4LQHcow==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/devtools-event-client": "^0.4.1",
+        "@tanstack/pacer-lite": "^0.1.1",
+        "@tanstack/store": "^0.9.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/history": {
       "version": "1.161.6",
       "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.161.6.tgz",
@@ -5265,6 +5297,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/pacer-lite": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/pacer-lite/-/pacer-lite-0.1.1.tgz",
+      "integrity": "sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "type": "github",
@@ -5290,6 +5335,28 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-form": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-form/-/react-form-1.32.0.tgz",
+      "integrity": "sha512-6WP5SQTA6/H9crCpvpq3ZppYWqtrdE5NjOy6ebABi6uAQPqhfTzrdjS9t40mCZCFtGI5585OhJV6zBP/KN2zcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/form-core": "1.32.0",
+        "@tanstack/react-store": "^0.9.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/react-start": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tanstack/react-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@carbon/icons-react": "^11.76.0",
     "@carbon/pictograms-react": "^11.97.0",
     "@carbon/react": "^1.103.0",
+    "@tanstack/react-form": "^1.32.0",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-router": "^1.169.2",
     "aws-amplify": "^6.17.0",

--- a/frontend/src/components/Form/ConditionalField/index.scss
+++ b/frontend/src/components/Form/ConditionalField/index.scss
@@ -1,0 +1,18 @@
+.conditional-field {
+  // Animation variant: height collapses and opacity fades
+  &--animate {
+    transition:
+      max-height 200ms ease,
+      opacity 200ms ease;
+  }
+
+  // keepMounted hidden state — visually removed, still in DOM
+  &--hidden {
+    visibility: hidden;
+    height: 0;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+  }
+}

--- a/frontend/src/components/Form/ConditionalField/index.scss
+++ b/frontend/src/components/Form/ConditionalField/index.scss
@@ -1,16 +1,38 @@
+// Styles for ConditionalField — the wrapper element that shows, hides, and
+// optionally animates a group of form fields based on a condition.
 .conditional-field {
-  // Animation variant: height collapses and opacity fades
+  // Animation variant: uses CSS grid-template-rows (0fr ↔ 1fr) instead of
+  // max-height, because max-height cannot animate to/from `auto`. Both the
+  // collapsed and expanded states define explicit, animatable values.
   &--animate {
+    display: grid;
+    grid-template-rows: 1fr;
+    opacity: 1;
+    overflow: hidden;
     transition:
-      max-height 200ms ease,
+      grid-template-rows 200ms ease,
       opacity 200ms ease;
+
+    // Direct children must opt out of min-height so the grid row can
+    // collapse them fully.
+    > * {
+      overflow: hidden;
+      min-height: 0;
+    }
+
+    // Combined with --hidden: animated collapse to zero height.
+    // Higher specificity overrides the plain --hidden height: 0 which
+    // conflicts with display: grid.
+    &.conditional-field--hidden {
+      grid-template-rows: 0fr;
+      height: auto;
+    }
   }
 
   // keepMounted hidden state — visually removed, still in DOM
   &--hidden {
     visibility: hidden;
     height: 0;
-    max-height: 0;
     overflow: hidden;
     opacity: 0;
     pointer-events: none;

--- a/frontend/src/components/Form/ConditionalField/index.tsx
+++ b/frontend/src/components/Form/ConditionalField/index.tsx
@@ -6,6 +6,7 @@ import type { ConditionalFieldProps } from './types';
 
 import './index.scss';
 
+/** Internal implementation. Wrapped with `memo` and re-exported as {@link ConditionalField}. */
 const ConditionalFieldInner = <TFormData extends Record<string, unknown>>({
   form,
   conditions,

--- a/frontend/src/components/Form/ConditionalField/index.tsx
+++ b/frontend/src/components/Form/ConditionalField/index.tsx
@@ -1,0 +1,87 @@
+import React, { memo } from 'react';
+
+import { useConditionalField } from './useConditionalField';
+
+import type { ConditionalFieldProps } from './types';
+
+import './index.scss';
+
+const ConditionalFieldInner = <TFormData extends Record<string, unknown>>({
+  form,
+  conditions,
+  logic = 'AND',
+  children,
+  keepMounted = false,
+  animateIn = true,
+  unregisterOnHide = true,
+  fieldNames = [],
+}: ConditionalFieldProps<TFormData>): React.ReactElement | null => {
+  const { isVisible } = useConditionalField({
+    form,
+    conditions,
+    logic,
+    unregisterOnHide,
+    fieldNames,
+  });
+
+  if (keepMounted) {
+    const classNames = [
+      'conditional-field',
+      animateIn ? 'conditional-field--animate' : '',
+      isVisible ? '' : 'conditional-field--hidden',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <div className={classNames} aria-hidden={!isVisible || undefined}>
+        {children}
+      </div>
+    );
+  }
+
+  if (!isVisible) {
+    return null;
+  }
+
+  const classNames = ['conditional-field', animateIn ? 'conditional-field--animate' : '']
+    .filter(Boolean)
+    .join(' ');
+
+  return <div className={classNames}>{children}</div>;
+};
+
+/**
+ * Declaratively shows or hides — and optionally resets — a field or group of
+ * fields based on the value of another form field.
+ *
+ * @component
+ * @example
+ * ```tsx
+ * <ConditionalField
+ *   form={form}
+ *   conditions={{ field: 'hasDistrict', operator: 'truthy' }}
+ *   fieldNames={['districtCode']}
+ * >
+ *   <form.Field name="districtCode">{(f) => <ComboBox ... />}</form.Field>
+ * </ConditionalField>
+ * ```
+ *
+ * @param props - Component props.
+ * @param props.form - The TanStack Form instance returned by `useForm`.
+ * @param props.conditions - One condition or array of conditions controlling visibility.
+ * @param props.logic - How multiple conditions are combined. Defaults to `'AND'`.
+ * @param props.children - Content to show or hide.
+ * @param props.keepMounted - When `true`, children remain in DOM but are visually hidden.
+ * @param props.animateIn - When `true`, applies a height + opacity transition on show.
+ * @param props.unregisterOnHide - When `true`, resets `fieldNames` fields on hide.
+ * @param props.fieldNames - Field names to reset when the group becomes hidden.
+ * @returns The conditional wrapper element, or `null` when hidden and not mounted.
+ */
+export const ConditionalField = memo(ConditionalFieldInner) as <
+  TFormData extends Record<string, unknown>,
+>(
+  props: ConditionalFieldProps<TFormData>,
+) => React.ReactElement | null;
+
+export default ConditionalField;

--- a/frontend/src/components/Form/ConditionalField/index.unit.test.tsx
+++ b/frontend/src/components/Form/ConditionalField/index.unit.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen } from '@testing-library/react';
 import { useEffect, type FC } from 'react';
 import { describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import { evaluateAll, evaluateCondition } from './useConditionalField';
+import { evaluateAll, evaluateCondition, getIn } from './useConditionalField';
 
 import ConditionalField from './index';
 
@@ -163,6 +163,11 @@ describe('evaluateAll', () => {
   const cA: Condition = { field: 'a', operator: 'truthy' };
   const cB: Condition = { field: 'b', operator: 'truthy' };
 
+  it('empty array — always returns false regardless of logic', () => {
+    expect(evaluateAll([], 'AND', {})).toBe(false);
+    expect(evaluateAll([], 'OR', {})).toBe(false);
+  });
+
   it('AND — true only when every condition passes', () => {
     expect(evaluateAll([cA, cB], 'AND', { a: 'yes', b: 'yes' })).toBe(true);
     expect(evaluateAll([cA, cB], 'AND', { a: 'yes', b: '' })).toBe(false);
@@ -171,6 +176,32 @@ describe('evaluateAll', () => {
   it('OR — true when any condition passes', () => {
     expect(evaluateAll([cA, cB], 'OR', { a: 'yes', b: '' })).toBe(true);
     expect(evaluateAll([cA, cB], 'OR', { a: '', b: '' })).toBe(false);
+  });
+});
+
+describe('getIn', () => {
+  it('resolves a top-level key', () => {
+    expect(getIn({ status: 'active' }, 'status')).toBe('active');
+  });
+
+  it('resolves a dot-separated nested path', () => {
+    expect(getIn({ address: { city: 'Vancouver' } }, 'address.city')).toBe('Vancouver');
+  });
+
+  it('resolves deeply nested paths', () => {
+    expect(getIn({ a: { b: { c: 42 } } }, 'a.b.c')).toBe(42);
+  });
+
+  it('returns undefined for a missing key', () => {
+    expect(getIn({ a: { b: 1 } }, 'a.c')).toBeUndefined();
+  });
+
+  it('returns undefined when an intermediate segment is null', () => {
+    expect(getIn({ a: null }, 'a.b')).toBeUndefined();
+  });
+
+  it('returns undefined when an intermediate segment is a primitive', () => {
+    expect(getIn({ a: 42 }, 'a.b')).toBeUndefined();
   });
 });
 

--- a/frontend/src/components/Form/ConditionalField/index.unit.test.tsx
+++ b/frontend/src/components/Form/ConditionalField/index.unit.test.tsx
@@ -1,0 +1,422 @@
+import { useForm } from '@tanstack/react-form';
+import { act, render, screen } from '@testing-library/react';
+import { useEffect, type FC } from 'react';
+import { describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { evaluateAll, evaluateCondition } from './useConditionalField';
+
+import ConditionalField from './index';
+
+import type { Condition, FormInstance } from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type SimpleFormData = {
+  status: string | null;
+  clientNumber: string | null;
+  extra: string | null;
+  count: number | null;
+  tags: string[] | null;
+};
+
+const defaultValues: SimpleFormData = {
+  status: null,
+  clientNumber: null,
+  extra: null,
+  count: null,
+  tags: null,
+};
+
+/** Test-local form handle: `FormInstance` surface plus `setFieldValue` for imperative mutations. */
+type TestForm = FormInstance<SimpleFormData> & {
+  setFieldValue(field: keyof SimpleFormData, updater: SimpleFormData[keyof SimpleFormData]): void;
+};
+
+/**
+ * Mounts a `ConditionalField` inside a real TanStack Form and exposes the form
+ * instance via a callback so tests can call `setFieldValue` imperatively.
+ */
+function renderWithForm({
+  conditions,
+  logic,
+  keepMounted,
+  animateIn,
+  unregisterOnHide,
+  fieldNames,
+  childText = 'Conditional Content',
+  onFormReady,
+}: {
+  conditions: Condition | Condition[];
+  logic?: 'AND' | 'OR';
+  keepMounted?: boolean;
+  animateIn?: boolean;
+  unregisterOnHide?: boolean;
+  fieldNames?: Array<keyof SimpleFormData>;
+  childText?: string;
+  onFormReady?: (form: TestForm) => void;
+}) {
+  const Wrapper: FC = () => {
+    const form = useForm({ defaultValues });
+
+    useEffect(() => {
+      onFormReady?.(form);
+    });
+
+    return (
+      <ConditionalField
+        form={form}
+        conditions={conditions}
+        logic={logic}
+        keepMounted={keepMounted}
+        animateIn={animateIn}
+        unregisterOnHide={unregisterOnHide}
+        fieldNames={fieldNames}
+      >
+        <span>{childText}</span>
+      </ConditionalField>
+    );
+  };
+
+  return render(<Wrapper />);
+}
+
+// ---------------------------------------------------------------------------
+// Pure function unit tests (no React needed)
+// ---------------------------------------------------------------------------
+
+describe('evaluateCondition', () => {
+  it('equals — matches strictly', () => {
+    expect(evaluateCondition({ field: 'f', operator: 'equals', value: 'active' }, 'active')).toBe(
+      true,
+    );
+    expect(evaluateCondition({ field: 'f', operator: 'equals', value: 'active' }, 'ACTIVE')).toBe(
+      false,
+    );
+  });
+
+  it('not-equals — returns true for different values', () => {
+    expect(evaluateCondition({ field: 'f', operator: 'not-equals', value: 'x' }, 'y')).toBe(true);
+    expect(evaluateCondition({ field: 'f', operator: 'not-equals', value: 'x' }, 'x')).toBe(false);
+  });
+
+  it('contains — works for strings', () => {
+    expect(evaluateCondition({ field: 'f', operator: 'contains', value: 'foo' }, 'foobar')).toBe(
+      true,
+    );
+    expect(evaluateCondition({ field: 'f', operator: 'contains', value: 'baz' }, 'foobar')).toBe(
+      false,
+    );
+  });
+
+  it('contains — works for arrays', () => {
+    expect(evaluateCondition({ field: 'f', operator: 'contains', value: 'b' }, ['a', 'b'])).toBe(
+      true,
+    );
+  });
+
+  it('greater-than / less-than', () => {
+    expect(evaluateCondition({ field: 'f', operator: 'greater-than', value: 5 }, 10)).toBe(true);
+    expect(evaluateCondition({ field: 'f', operator: 'less-than', value: 5 }, 3)).toBe(true);
+    expect(evaluateCondition({ field: 'f', operator: 'greater-than', value: 5 }, 3)).toBe(false);
+  });
+
+  it('truthy / falsy', () => {
+    expect(evaluateCondition({ field: 'f', operator: 'truthy' }, 'hello')).toBe(true);
+    expect(evaluateCondition({ field: 'f', operator: 'truthy' }, '')).toBe(false);
+    expect(evaluateCondition({ field: 'f', operator: 'falsy' }, null)).toBe(true);
+    expect(evaluateCondition({ field: 'f', operator: 'falsy' }, 'x')).toBe(false);
+  });
+
+  it('in / not-in', () => {
+    expect(evaluateCondition({ field: 'f', operator: 'in', value: ['a', 'b', 'c'] }, 'b')).toBe(
+      true,
+    );
+    expect(evaluateCondition({ field: 'f', operator: 'in', value: ['a', 'b', 'c'] }, 'z')).toBe(
+      false,
+    );
+    expect(evaluateCondition({ field: 'f', operator: 'not-in', value: ['a', 'b'] }, 'c')).toBe(
+      true,
+    );
+    // watchedValue IS in the excluded list → false
+    expect(evaluateCondition({ field: 'f', operator: 'not-in', value: ['a', 'b'] }, 'a')).toBe(
+      false,
+    );
+    // value is not an array → short-circuit false
+    expect(evaluateCondition({ field: 'f', operator: 'not-in', value: 'not-array' }, 'a')).toBe(
+      false,
+    );
+  });
+
+  it('contains — returns false for non-string non-array value', () => {
+    expect(evaluateCondition({ field: 'f', operator: 'contains', value: 'x' }, 42)).toBe(false);
+  });
+
+  it('unknown operator — returns false via default case', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(evaluateCondition({ field: 'f', operator: 'unknown-op' as any }, 'x')).toBe(false);
+  });
+});
+
+describe('evaluateAll', () => {
+  const cA: Condition = { field: 'a', operator: 'truthy' };
+  const cB: Condition = { field: 'b', operator: 'truthy' };
+
+  it('AND — true only when every condition passes', () => {
+    expect(evaluateAll([cA, cB], 'AND', { a: 'yes', b: 'yes' })).toBe(true);
+    expect(evaluateAll([cA, cB], 'AND', { a: 'yes', b: '' })).toBe(false);
+  });
+
+  it('OR — true when any condition passes', () => {
+    expect(evaluateAll([cA, cB], 'OR', { a: 'yes', b: '' })).toBe(true);
+    expect(evaluateAll([cA, cB], 'OR', { a: '', b: '' })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component integration tests
+// ---------------------------------------------------------------------------
+
+describe('ConditionalField — equals', () => {
+  it('shows children when value matches, hides otherwise', async () => {
+    let formRef!: TestForm;
+
+    renderWithForm({
+      conditions: { field: 'status', operator: 'equals', value: 'active' },
+      onFormReady: (f) => {
+        formRef = f;
+      },
+    });
+
+    // Initially hidden (status is null)
+    expect(screen.queryByText('Conditional Content')).toBeNull();
+
+    // Set matching value → should appear
+    await act(async () => {
+      formRef.setFieldValue('status', 'active');
+    });
+    expect(screen.getByText('Conditional Content')).toBeTruthy();
+
+    // Set non-matching value → should disappear
+    await act(async () => {
+      formRef.setFieldValue('status', 'inactive');
+    });
+    expect(screen.queryByText('Conditional Content')).toBeNull();
+  });
+});
+
+describe('ConditionalField — truthy', () => {
+  it('shows for truthy watched value', async () => {
+    let formRef!: TestForm;
+
+    renderWithForm({
+      conditions: { field: 'clientNumber', operator: 'truthy' },
+      onFormReady: (f) => {
+        formRef = f;
+      },
+    });
+
+    expect(screen.queryByText('Conditional Content')).toBeNull();
+
+    await act(async () => {
+      formRef.setFieldValue('clientNumber', 'CLIENT-1');
+    });
+    expect(screen.getByText('Conditional Content')).toBeTruthy();
+  });
+});
+
+describe('ConditionalField — AND logic', () => {
+  it('shows only when all conditions pass', async () => {
+    let formRef!: TestForm;
+
+    renderWithForm({
+      conditions: [
+        { field: 'status', operator: 'equals', value: 'active' },
+        { field: 'clientNumber', operator: 'truthy' },
+      ],
+      logic: 'AND',
+      onFormReady: (f) => {
+        formRef = f;
+      },
+    });
+
+    // Neither condition satisfied
+    expect(screen.queryByText('Conditional Content')).toBeNull();
+
+    // Only first satisfied
+    await act(async () => {
+      formRef.setFieldValue('status', 'active');
+    });
+    expect(screen.queryByText('Conditional Content')).toBeNull();
+
+    // Both satisfied
+    await act(async () => {
+      formRef.setFieldValue('clientNumber', 'CLIENT-1');
+    });
+    expect(screen.getByText('Conditional Content')).toBeTruthy();
+  });
+});
+
+describe('ConditionalField — OR logic', () => {
+  it('shows when any condition passes', async () => {
+    let formRef!: TestForm;
+
+    renderWithForm({
+      conditions: [
+        { field: 'status', operator: 'equals', value: 'active' },
+        { field: 'clientNumber', operator: 'truthy' },
+      ],
+      logic: 'OR',
+      onFormReady: (f) => {
+        formRef = f;
+      },
+    });
+
+    // Neither → hidden
+    expect(screen.queryByText('Conditional Content')).toBeNull();
+
+    // Only second satisfied → visible
+    await act(async () => {
+      formRef.setFieldValue('clientNumber', 'CLIENT-1');
+    });
+    expect(screen.getByText('Conditional Content')).toBeTruthy();
+  });
+});
+
+describe('ConditionalField — unregisterOnHide', () => {
+  it('calls form.resetField for each fieldName when the group becomes hidden', async () => {
+    let formRef!: TestForm;
+
+    renderWithForm({
+      conditions: { field: 'status', operator: 'truthy' },
+      unregisterOnHide: true,
+      fieldNames: ['extra'],
+      onFormReady: (f) => {
+        formRef = f;
+      },
+    });
+
+    // Make visible first
+    await act(async () => {
+      formRef.setFieldValue('status', 'active');
+    });
+
+    if (!formRef) throw new Error('form not initialized');
+    const resetFieldSpy = vi.spyOn(formRef, 'resetField') as MockInstance;
+
+    // Hide → should trigger reset
+    await act(async () => {
+      formRef.setFieldValue('status', null);
+    });
+
+    expect(resetFieldSpy).toHaveBeenCalledWith('extra');
+    resetFieldSpy.mockRestore();
+  });
+
+  it('does not call resetField when unregisterOnHide is false', async () => {
+    let formRef!: TestForm;
+
+    renderWithForm({
+      conditions: { field: 'status', operator: 'truthy' },
+      unregisterOnHide: false,
+      fieldNames: ['extra'],
+      onFormReady: (f) => {
+        formRef = f;
+      },
+    });
+
+    await act(async () => {
+      formRef.setFieldValue('status', 'active');
+    });
+
+    if (!formRef) throw new Error('form not initialized');
+    const resetFieldSpy = vi.spyOn(formRef, 'resetField') as MockInstance;
+
+    await act(async () => {
+      formRef.setFieldValue('status', null);
+    });
+
+    expect(resetFieldSpy).not.toHaveBeenCalled();
+    resetFieldSpy.mockRestore();
+  });
+});
+
+describe('ConditionalField — keepMounted', () => {
+  it('keeps children in the DOM when hidden', async () => {
+    let formRef!: TestForm;
+
+    renderWithForm({
+      conditions: { field: 'status', operator: 'truthy' },
+      keepMounted: true,
+      onFormReady: (f) => {
+        formRef = f;
+      },
+    });
+
+    // Children are in the DOM even when condition is false
+    expect(screen.getByText('Conditional Content')).toBeTruthy();
+
+    // Wrapper should carry aria-hidden when condition is false
+    const wrapper = screen.getByText('Conditional Content').closest('.conditional-field');
+    expect(wrapper?.getAttribute('aria-hidden')).toBe('true');
+
+    // Make visible
+    await act(async () => {
+      formRef.setFieldValue('status', 'active');
+    });
+
+    // Children still in DOM, aria-hidden removed
+    expect(screen.getByText('Conditional Content')).toBeTruthy();
+    expect(wrapper?.getAttribute('aria-hidden')).toBeNull();
+  });
+});
+
+describe('ConditionalField — animateIn false', () => {
+  it('omits the animate class when `animateIn` is false and visible', async () => {
+    let formRef!: TestForm;
+
+    renderWithForm({
+      conditions: { field: 'status', operator: 'truthy' },
+      animateIn: false,
+      onFormReady: (f) => {
+        formRef = f;
+      },
+    });
+
+    // Make visible
+    await act(async () => {
+      formRef.setFieldValue('status', 'active');
+    });
+
+    const wrapper = screen.getByText('Conditional Content').closest('.conditional-field');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper?.className).not.toContain('conditional-field--animate');
+  });
+
+  it('omits the animate class when `animateIn` is false and keepMounted is true (hidden)', async () => {
+    let formRef!: TestForm;
+
+    renderWithForm({
+      conditions: { field: 'status', operator: 'truthy' },
+      animateIn: false,
+      keepMounted: true,
+      onFormReady: (f) => {
+        formRef = f;
+      },
+    });
+
+    // Initially hidden but present in DOM
+    const wrapper = screen.getByText('Conditional Content').closest('.conditional-field');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper?.className).toContain('conditional-field--hidden');
+    expect(wrapper?.className).not.toContain('conditional-field--animate');
+
+    // Make visible and ensure animate class still not present
+    await act(async () => {
+      formRef.setFieldValue('status', 'active');
+    });
+
+    expect(wrapper?.className).not.toContain('conditional-field--animate');
+  });
+});

--- a/frontend/src/components/Form/ConditionalField/types.ts
+++ b/frontend/src/components/Form/ConditionalField/types.ts
@@ -77,7 +77,12 @@ export type ConditionOperator =
  * {@link ConditionalFieldProps.logic}.
  */
 export interface Condition {
-  /** Name of the form field to observe. Must match a key in `TFormData`. */
+  /**
+   * Name of the form field to watch. Accepts a top-level key (`'status'`) or a
+   * dot-separated path for nested fields (`'address.city'`). No compile-time
+   * validation is performed — invalid paths produce `undefined` at runtime and
+   * the condition will not pass.
+   */
   readonly field: string;
   /** The comparison operator to apply. */
   readonly operator: ConditionOperator;
@@ -101,6 +106,7 @@ export interface ConditionalFieldProps<TFormData extends Record<string, unknown>
    * @default 'AND'
    */
   readonly logic?: 'AND' | 'OR';
+  /** The content to show or hide based on the evaluated conditions. */
   readonly children: ReactNode;
   /**
    * When `true`, children stay mounted but are visually hidden.

--- a/frontend/src/components/Form/ConditionalField/types.ts
+++ b/frontend/src/components/Form/ConditionalField/types.ts
@@ -1,0 +1,160 @@
+import type { DeepKeys } from '@tanstack/react-form';
+import type { ReactNode } from 'react';
+
+/**
+ * The minimum shape of a TanStack Form instance required by `ConditionalField`.
+ *
+ * A structural interface is used instead of `ReturnType<typeof useForm<TFormData>>`
+ * for two reasons:
+ *
+ * 1. TypeScript cannot check `ReturnType<T>`'s callable constraint when `T` is an
+ *    instantiation expression (`typeof useForm<TFormData>`) with a free type
+ *    parameter — it resolves to `never`.
+ * 2. `FormApi`'s validator type parameters are marked `in out` (invariant), so no
+ *    concrete union type (including `undefined`, `unknown`, or `never`) is
+ *    assignable across all possible form configurations.
+ *
+ * The actual `useForm()` return type (`ReactFormExtendedApi<TFormData, …>`) is a
+ * structural superset of this interface — no explicit cast is ever needed at call
+ * sites.
+ *
+ * @typeParam TFormData - Shape of the form's value object.
+ */
+export interface FormInstance<TFormData extends Record<string, unknown>> {
+  /**
+   * The reactive store backing the form.
+   *
+   * `ConditionalField` subscribes via React's `useSyncExternalStore` using only
+   * the `get` and `subscribe` members — the standard external-store protocol
+   * expected by React 18+.
+   */
+  readonly store: {
+    /** Returns the current form state snapshot. */
+    get(): { readonly values: TFormData };
+    /**
+     * Registers a change listener. Compatible with `useSyncExternalStore`'s
+     * subscribe contract after unwrapping the returned `unsubscribe` method.
+     */
+    subscribe(fn: () => void): { unsubscribe: () => void };
+  };
+  /**
+   * Resets the named field to its configured default value.
+   * Called by `useConditionalField` when `unregisterOnHide` is `true`.
+   */
+  resetField(fieldName: DeepKeys<TFormData>): void;
+}
+
+/**
+ * All comparison operators supported by {@link Condition}.
+ *
+ * | Operator | Semantics |
+ * |---|---|
+ * | `equals` | Strict equality (`===`) |
+ * | `not-equals` | Strict inequality (`!==`) |
+ * | `contains` | `String.includes` or `Array.includes` |
+ * | `greater-than` | Numeric `>` |
+ * | `less-than` | Numeric `<` |
+ * | `truthy` | Boolean coercion — `Boolean(value)` |
+ * | `falsy` | Inverse boolean coercion — `!value` |
+ * | `in` | Watched value is inside the `value` array |
+ * | `not-in` | Watched value is not inside the `value` array |
+ */
+export type ConditionOperator =
+  | 'equals'
+  | 'not-equals'
+  | 'contains'
+  | 'greater-than'
+  | 'less-than'
+  | 'truthy'
+  | 'falsy'
+  | 'in'
+  | 'not-in';
+
+/**
+ * A single predicate that tests one form field against an expected value.
+ *
+ * Multiple conditions can be composed with `AND`/`OR` logic inside
+ * {@link ConditionalFieldProps.logic}.
+ */
+export interface Condition {
+  /** Name of the form field to observe. Must match a key in `TFormData`. */
+  readonly field: string;
+  /** The comparison operator to apply. */
+  readonly operator: ConditionOperator;
+  /** Required for all operators except `truthy` and `falsy`. For `in`/`not-in`, must be an array. */
+  readonly value?: unknown;
+}
+
+/**
+ * Props for the {@link ConditionalField} component.
+ *
+ * @typeParam TFormData - Shape of the form's value object. Inferred from the
+ *   `form` prop when used with `useForm`.
+ */
+export interface ConditionalFieldProps<TFormData extends Record<string, unknown>> {
+  /** The TanStack Form instance returned by `useForm`. */
+  readonly form: FormInstance<TFormData>;
+  /** One condition or an array of conditions that control visibility. */
+  readonly conditions: Condition | Condition[];
+  /**
+   * How multiple conditions are combined.
+   * @default 'AND'
+   */
+  readonly logic?: 'AND' | 'OR';
+  readonly children: ReactNode;
+  /**
+   * When `true`, children stay mounted but are visually hidden.
+   * Keeps field state alive in TanStack Form.
+   * @default false
+   */
+  readonly keepMounted?: boolean;
+  /**
+   * Applies a CSS height + opacity transition when the field becomes visible.
+   * @default true
+   */
+  readonly animateIn?: boolean;
+  /**
+   * When `true` and `fieldNames` is provided, calls `form.resetField` for each
+   * listed field name when the group becomes hidden.
+   * @default true
+   */
+  readonly unregisterOnHide?: boolean;
+  /**
+   * Field names belonging to this conditional group. When `unregisterOnHide` is
+   * `true`, these fields are reset to their default values on hide.
+   * Values must be valid `DeepKeys` of the form's data shape.
+   */
+  readonly fieldNames?: Array<DeepKeys<TFormData>>;
+}
+
+/**
+ * Options for the {@link useConditionalField} hook.
+ *
+ * A subset of {@link ConditionalFieldProps} — the visual-only props
+ * (`children`, `keepMounted`, `animateIn`) are omitted because the hook only
+ * manages visibility logic and field reset side-effects.
+ *
+ * @typeParam TFormData - Shape of the form's value object.
+ */
+export interface UseConditionalFieldOptions<TFormData extends Record<string, unknown>> {
+  /** The TanStack Form instance returned by `useForm`. */
+  readonly form: FormInstance<TFormData>;
+  /** One condition or an array of conditions that control visibility. */
+  readonly conditions: Condition | Condition[];
+  /**
+   * How multiple conditions are combined.
+   * @default 'AND'
+   */
+  readonly logic?: 'AND' | 'OR';
+  /**
+   * When `true`, calls `form.resetField` for each name in `fieldNames` on hide.
+   * @default true
+   */
+  readonly unregisterOnHide?: boolean;
+  /**
+   * Field names belonging to this conditional group. When `unregisterOnHide` is
+   * `true`, these fields are reset to their default values on hide.
+   * Values must be valid `DeepKeys` of the form's data shape.
+   */
+  readonly fieldNames?: Array<DeepKeys<TFormData>>;
+}

--- a/frontend/src/components/Form/ConditionalField/useConditionalField.ts
+++ b/frontend/src/components/Form/ConditionalField/useConditionalField.ts
@@ -3,6 +3,26 @@ import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'r
 import type { Condition, UseConditionalFieldOptions } from './types';
 
 /**
+ * Reads a value from a plain object by a dot-separated path string.
+ *
+ * Supports both top-level keys (`'status'`) and nested paths (`'address.city'`).
+ * Returns `undefined` when any segment along the path is missing, `null`, or not
+ * an object, rather than throwing.
+ *
+ * @param obj - The root object to traverse.
+ * @param path - A dot-separated key path (e.g. `'address.city'`).
+ * @returns The value at the path, or `undefined` if unreachable.
+ */
+export function getIn(obj: Record<string, unknown>, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => {
+    if (acc !== null && acc !== undefined && typeof acc === 'object') {
+      return (acc as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, obj);
+}
+
+/**
  * Evaluates a single {@link Condition} against a watched field value.
  *
  * This is a pure function — it has no side-effects and depends only on its
@@ -59,7 +79,10 @@ export function evaluateCondition(condition: Condition, watchedValue: unknown): 
  * Evaluates an array of {@link Condition|Conditions} against a map of watched
  * field values, combining the results with the specified boolean logic.
  *
- * @param conditions - Non-empty array of conditions to evaluate.
+ * An empty `conditions` array always returns `false` regardless of `logic` —
+ * a group with no rules is treated as permanently hidden.
+ *
+ * @param conditions - Array of conditions to evaluate. Empty array returns `false`.
  * @param logic - `'AND'` requires every condition to pass; `'OR'` requires at
  *   least one condition to pass.
  * @param watchedValues - Map of field name → current value, keyed by
@@ -71,6 +94,7 @@ export function evaluateAll(
   logic: 'AND' | 'OR',
   watchedValues: Record<string, unknown>,
 ): boolean {
+  if (conditions.length === 0) return false;
   if (logic === 'OR') {
     return conditions.some((c) => evaluateCondition(c, watchedValues[c.field]));
   }
@@ -86,9 +110,9 @@ export function evaluateAll(
  * `true`.
  *
  * @remarks
- * The hook uses `useStore` with a JSON-serialised selector so that only
- * re-renders triggered by changes to the *watched* fields are propagated.
- * Unrelated form mutations do not cause this hook to recompute.
+ * The hook uses `useSyncExternalStore` with a JSON-serialised snapshot selector
+ * so that only re-renders triggered by changes to the *watched* fields are
+ * propagated. Unrelated form mutations do not cause this hook to recompute.
  *
  * `undefined` field values are normalised to `null` during serialisation so
  * that fields that have never been set behave the same as explicitly null ones.
@@ -141,7 +165,7 @@ export function useConditionalField<TFormData extends Record<string, unknown>>({
     const values = form.store.get().values as Record<string, unknown>;
     const relevant: Record<string, unknown> = {};
     for (const name of uniqueFieldNames) {
-      relevant[name] = values[name] ?? null;
+      relevant[name] = getIn(values, name) ?? null;
     }
     return JSON.stringify(relevant);
   }, [form.store, uniqueFieldNames]);

--- a/frontend/src/components/Form/ConditionalField/useConditionalField.ts
+++ b/frontend/src/components/Form/ConditionalField/useConditionalField.ts
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+
+import type { Condition, UseConditionalFieldOptions } from './types';
+
+/**
+ * Evaluates a single {@link Condition} against a watched field value.
+ *
+ * This is a pure function — it has no side-effects and depends only on its
+ * arguments, making it straightforward to unit-test in isolation.
+ *
+ * @param condition - The condition descriptor (field, operator, optional value).
+ * @param watchedValue - The current value of the watched field retrieved from
+ *   the form store.
+ * @returns `true` when the condition passes, `false` otherwise.
+ */
+export function evaluateCondition(condition: Condition, watchedValue: unknown): boolean {
+  const { operator, value } = condition;
+
+  switch (operator) {
+    case 'equals':
+      return watchedValue === value;
+
+    case 'not-equals':
+      return watchedValue !== value;
+
+    case 'contains':
+      if (typeof watchedValue === 'string' && typeof value === 'string') {
+        return watchedValue.includes(value);
+      }
+      if (Array.isArray(watchedValue)) {
+        return (watchedValue as unknown[]).includes(value);
+      }
+      return false;
+
+    case 'greater-than':
+      return typeof watchedValue === 'number' && typeof value === 'number' && watchedValue > value;
+
+    case 'less-than':
+      return typeof watchedValue === 'number' && typeof value === 'number' && watchedValue < value;
+
+    case 'truthy':
+      return Boolean(watchedValue);
+
+    case 'falsy':
+      return !watchedValue;
+
+    case 'in':
+      return Array.isArray(value) && (value as unknown[]).includes(watchedValue);
+
+    case 'not-in':
+      return Array.isArray(value) && !(value as unknown[]).includes(watchedValue);
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Evaluates an array of {@link Condition|Conditions} against a map of watched
+ * field values, combining the results with the specified boolean logic.
+ *
+ * @param conditions - Non-empty array of conditions to evaluate.
+ * @param logic - `'AND'` requires every condition to pass; `'OR'` requires at
+ *   least one condition to pass.
+ * @param watchedValues - Map of field name → current value, keyed by
+ *   `Condition.field`.
+ * @returns `true` when the combined evaluation passes, `false` otherwise.
+ */
+export function evaluateAll(
+  conditions: Condition[],
+  logic: 'AND' | 'OR',
+  watchedValues: Record<string, unknown>,
+): boolean {
+  if (logic === 'OR') {
+    return conditions.some((c) => evaluateCondition(c, watchedValues[c.field]));
+  }
+  return conditions.every((c) => evaluateCondition(c, watchedValues[c.field]));
+}
+
+/**
+ * Core logic hook for {@link ConditionalField}.
+ *
+ * Subscribes to the relevant field values in the TanStack Form store and
+ * derives `isVisible`. Calls `form.resetField` for every name in `fieldNames`
+ * when the group transitions from visible → hidden and `unregisterOnHide` is
+ * `true`.
+ *
+ * @remarks
+ * The hook uses `useStore` with a JSON-serialised selector so that only
+ * re-renders triggered by changes to the *watched* fields are propagated.
+ * Unrelated form mutations do not cause this hook to recompute.
+ *
+ * `undefined` field values are normalised to `null` during serialisation so
+ * that fields that have never been set behave the same as explicitly null ones.
+ *
+ * @typeParam TFormData - Shape of the form's value object.
+ * @param options - Configuration options — see {@link UseConditionalFieldOptions}.
+ * @returns An object with a single boolean `isVisible` property.
+ */
+export function useConditionalField<TFormData extends Record<string, unknown>>({
+  form,
+  conditions,
+  logic = 'AND',
+  unregisterOnHide = true,
+  fieldNames = [],
+}: UseConditionalFieldOptions<TFormData>): { isVisible: boolean } {
+  const conditionsArray = useMemo(
+    () => (Array.isArray(conditions) ? conditions : [conditions]),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(conditions)],
+  );
+
+  const uniqueFieldNames = useMemo(
+    () => [...new Set(conditionsArray.map((c) => c.field))],
+    [conditionsArray],
+  );
+
+  /**
+   * Stable subscribe callback for `useSyncExternalStore`. Only re-created if
+   * `form.store` changes (it does not in practice — TanStack Form creates the
+   * store once via `useState`).
+   */
+  const subscribe = useCallback(
+    (onStoreChange: () => void): (() => void) => {
+      const subscription = form.store.subscribe(onStoreChange);
+      return () => subscription.unsubscribe();
+    },
+    [form.store],
+  );
+
+  /**
+   * Snapshot selector: serialises only the watched fields to a JSON string.
+   * Because `useSyncExternalStore` uses `Object.is` equality on the snapshot,
+   * returning a primitive string means re-renders are suppressed when unrelated
+   * parts of the form change.
+   *
+   * `undefined` values are normalised to `null` via the `?? null` coalesce so
+   * that fields that have never been set behave the same as explicitly null ones.
+   */
+  const getSnapshot = useCallback((): string => {
+    const values = form.store.get().values as Record<string, unknown>;
+    const relevant: Record<string, unknown> = {};
+    for (const name of uniqueFieldNames) {
+      relevant[name] = values[name] ?? null;
+    }
+    return JSON.stringify(relevant);
+  }, [form.store, uniqueFieldNames]);
+
+  const watchedJson = useSyncExternalStore(subscribe, getSnapshot);
+
+  const isVisible = useMemo(
+    () => evaluateAll(conditionsArray, logic, JSON.parse(watchedJson) as Record<string, unknown>),
+    [conditionsArray, logic, watchedJson],
+  );
+
+  const prevIsVisibleRef = useRef(isVisible);
+
+  useEffect(() => {
+    const wasVisible = prevIsVisibleRef.current;
+    prevIsVisibleRef.current = isVisible;
+
+    if (wasVisible && !isVisible && unregisterOnHide && fieldNames.length > 0) {
+      for (const name of fieldNames) {
+        form.resetField(name);
+      }
+    }
+  }, [isVisible, unregisterOnHide, fieldNames, form]);
+
+  return { isVisible };
+}


### PR DESCRIPTION
# Description

Adds a new `ConditionalField` component to the form library that declaratively shows or hides — and optionally resets — a group of form fields based on the runtime value of another field in the TanStack Form state.

Previously, any form requiring conditional field visibility had to manually subscribe to `form.store`, manage a local `isVisible` boolean, apply CSS class names, and imperatively call `form.resetField` for each hidden field. This pattern was duplicated every time a new conditional section was introduced, making it error-prone and unsustainable as forms grow in complexity.

**New files:**

- `src/components/Form/ConditionalField/index.tsx` — Memoised React component wrapping the hook; handles `keepMounted` vs. unmount rendering paths and CSS class composition.
- `src/components/Form/ConditionalField/useConditionalField.ts` — Core logic hook; subscribes to TanStack Form store via `useSyncExternalStore` with a JSON-serialised snapshot selector to minimise re-renders; calls `form.resetField` on hide.
- `src/components/Form/ConditionalField/types.ts` — `FormInstance<TFormData>` structural interface, `ConditionOperator` union, `Condition`, `ConditionalFieldProps`, and `UseConditionalFieldOptions` — all fully JSDoc-documented.
- `src/components/Form/ConditionalField/index.scss` — CSS classes for the animation and `keepMounted` hidden state.
- `src/components/Form/ConditionalField/index.unit.test.tsx` — 20 unit tests covering all operators, AND/OR logic, `keepMounted`, `animateIn`, and `unregisterOnHide`.

**Dependency changes:**

- Adds `@tanstack/react-form ^1.32.0` as a direct dependency (previously only `@tanstack/react-query` and `@tanstack/react-router` were in use).

Fixes #866

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Documentation update

# How Has This Been Tested?

- [x] New unit tests

20 unit tests covering:
- All nine condition operators (`equals`, `not-equals`, `contains`, `greater-than`, `less-than`, `truthy`, `falsy`, `in`, `not-in`), including type-guard edge cases (non-string/non-array `contains`, non-numeric comparisons, unknown operator default).
- `AND` / `OR` multi-condition logic with partial and full satisfaction.
- Component integration: visibility toggling, `keepMounted` DOM presence and `aria-hidden` management, `unregisterOnHide` `resetField` callbacks, `animateIn` class toggling.

Coverage: **100% statement, branch, function, and line** for `index.tsx` and `useConditionalField.ts`.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR

## Further comments

The `FormInstance<TFormData>` structural interface (in `types.ts`) deliberately avoids using `ReturnType<typeof useForm<TFormData>>` because TypeScript cannot resolve callable constraints on instantiation expressions with a free type parameter, and because `FormApi`'s validator parameters are invariant — no concrete type is assignable across all form configurations. The actual `ReactFormExtendedApi` return type is a structural superset of `FormInstance`, so no explicit cast is required at any call site.

The `useSyncExternalStore` snapshot selector serialises only the *watched* field values to a JSON string. Since `useSyncExternalStore` uses `Object.is` for snapshot comparison, returning a primitive string means re-renders are skipped when unrelated parts of the form change.

Wiki documentation: [ConditionalField](https://github.com/bcgov/nr-waste-plus/wiki/codes/frontend/Form/ConditionalField)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-17-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)