### PR TITLE
feat(fe:#909): Added stubs for /api/configuration/district-average-volumes/{id} endpoint

### DIFF
--- a/frontend/stub/__files/district-average-volumes/coast-detail.json
+++ b/frontend/stub/__files/district-average-volumes/coast-detail.json
@@ -1,0 +1,50 @@
+{
+  "id": 4,
+  "area": "COASTAL",
+  "startDate": "2026-06-01",
+  "endDate": null,
+  "uploadedBy": "bwong@gov.bc.ca",
+  "dateOfUpload": "2026-05-15T14:50:00Z",
+  "tableLevelFactor": 0.4,
+  "heliMultiplier": 3.47,
+  "tableData": {
+    "type": "COASTAL",
+    "sections": [
+      {
+        "name": "Mature",
+        "districts": [
+          {
+            "code": "DCK",
+            "avoidableSawlog": 2.345,
+            "avoidableHembalGradeU": 1.234,
+            "avoidableGradeY": 0.567,
+            "unavoidable": 0.123,
+            "total": 4.269
+          },
+          {
+            "code": "DCR",
+            "avoidableSawlog": 2.456,
+            "avoidableHembalGradeU": 1.345,
+            "avoidableGradeY": 0.678,
+            "unavoidable": 0.234,
+            "total": 4.713
+          }
+        ]
+      },
+      {
+        "name": "Immature",
+        "districts": [
+          {
+            "code": "DNI",
+            "avoidableSawlog": 1.234,
+            "avoidableHembalGradeU": 0.567,
+            "avoidableGradeY": 0.234,
+            "unavoidable": 0.089,
+            "total": 2.124
+          }
+        ]
+      }
+    ],
+    "formulas": {}
+  }
+}

--- a/frontend/stub/__files/district-average-volumes/interior-detail.json
+++ b/frontend/stub/__files/district-average-volumes/interior-detail.json
@@ -6,7 +6,6 @@
   "uploadedBy": "jsmith@gov.bc.ca",
   "dateOfUpload": "2026-05-15T14:23:00Z",
   "tableLevelFactor": 0.4,
-  "heliMultiplier": null,
   "tableData": {
     "type": "INTERIOR",
     "zones": [

--- a/frontend/stub/__files/district-average-volumes/interior-detail.json
+++ b/frontend/stub/__files/district-average-volumes/interior-detail.json
@@ -1,0 +1,59 @@
+{
+  "id": 1,
+  "area": "INTERIOR",
+  "startDate": "2026-06-01",
+  "endDate": null,
+  "uploadedBy": "jsmith@gov.bc.ca",
+  "dateOfUpload": "2026-05-15T14:23:00Z",
+  "tableLevelFactor": 0.4,
+  "heliMultiplier": null,
+  "tableData": {
+    "type": "INTERIOR",
+    "zones": [
+      {
+        "name": "Dry belt",
+        "districts": [
+          {
+            "code": "DCC",
+            "avoidableSawlog": 1.234,
+            "avoidableGrade4": 0.567,
+            "unavoidableGrade4": 0.123,
+            "total": 1.924
+          },
+          {
+            "code": "DCS",
+            "avoidableSawlog": 1.345,
+            "avoidableGrade4": 0.678,
+            "unavoidableGrade4": 0.234,
+            "total": 2.257
+          }
+        ]
+      },
+      {
+        "name": "Transition zone",
+        "districts": [
+          {
+            "code": "DFN",
+            "avoidableSawlog": 1.456,
+            "avoidableGrade4": 0.789,
+            "unavoidableGrade4": 0.345,
+            "total": 2.59
+          }
+        ]
+      },
+      {
+        "name": "Wet belt",
+        "districts": [
+          {
+            "code": "DKA",
+            "avoidableSawlog": 1.567,
+            "avoidableGrade4": 0.89,
+            "unavoidableGrade4": 0.456,
+            "total": 2.913
+          }
+        ]
+      }
+    ],
+    "formulas": {}
+  }
+}

--- a/frontend/stub/mappings/district-volume-detail-coast.json
+++ b/frontend/stub/mappings/district-volume-detail-coast.json
@@ -1,11 +1,15 @@
 {
-  "name": "Get Coast district volume detail",
-  "request": {
-    "urlPattern": "/api/configuration/district-average-volumes/4",
-    "method": "GET"
-  },
-  "response": {
-    "status": 200,
-    "bodyFileName": "district-volume-tables/coast-detail.json"
-  }
+  "mappings": [
+    {
+      "name": "Get Coast district volume detail",
+      "request": {
+        "urlPattern": "/api/configuration/district-average-volumes/4",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "district-average-volumes/coast-detail.json"
+      }
+    }
+  ]
 }

--- a/frontend/stub/mappings/district-volume-detail-coast.json
+++ b/frontend/stub/mappings/district-volume-detail-coast.json
@@ -1,0 +1,11 @@
+{
+  "name": "Get Coast district volume table",
+  "request": {
+    "urlPattern": "/api/configuration/district-average-volumes/4",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "district-volume-tables/coast-detail.json"
+  }
+}

--- a/frontend/stub/mappings/district-volume-detail-coast.json
+++ b/frontend/stub/mappings/district-volume-detail-coast.json
@@ -1,5 +1,5 @@
 {
-  "name": "Get Coast district volume table",
+  "name": "Get Coast district volume detail",
   "request": {
     "urlPattern": "/api/configuration/district-average-volumes/4",
     "method": "GET"

--- a/frontend/stub/mappings/district-volume-detail-interior.json
+++ b/frontend/stub/mappings/district-volume-detail-interior.json
@@ -1,11 +1,15 @@
 {
-  "name": "Get Interior district volume detail",
-  "request": {
-    "urlPattern": "/api/configuration/district-average-volumes/1",
-    "method": "GET"
-  },
-  "response": {
-    "status": 200,
-    "bodyFileName": "district-average-volumes/interior-detail.json"
-  }
+  "mappings": [
+    {
+      "name": "Get Interior district volume detail",
+      "request": {
+        "urlPattern": "/api/configuration/district-average-volumes/1",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "district-average-volumes/interior-detail.json"
+      }
+    }
+  ]
 }

--- a/frontend/stub/mappings/district-volume-detail-interior.json
+++ b/frontend/stub/mappings/district-volume-detail-interior.json
@@ -1,0 +1,11 @@
+{
+  "name": "Get Interior district volume table",
+  "request": {
+    "urlPattern": "/api/configuration/district-average-volumes/1",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "district-volume-tables/interior-detail.json"
+  }
+}

--- a/frontend/stub/mappings/district-volume-detail-interior.json
+++ b/frontend/stub/mappings/district-volume-detail-interior.json
@@ -1,11 +1,11 @@
 {
-  "name": "Get Interior district volume table",
+  "name": "Get Interior district volume detail",
   "request": {
     "urlPattern": "/api/configuration/district-average-volumes/1",
     "method": "GET"
   },
   "response": {
     "status": 200,
-    "bodyFileName": "district-volume-tables/interior-detail.json"
+    "bodyFileName": "district-average-volumes/interior-detail.json"
   }
 }


### PR DESCRIPTION
## Task Summary
Add API stubs (WireMock/JSON) for District Volume Configuration detail endpoints to support frontend development and testing.

## Background
To unblock frontend development and facilitate contract testing for the new District Volume configuration views, we need static API responses that mirror the expected backend data structures. These stubs represent the detailed views for both INTERIOR and COASTAL areas.

## Changes

The following files have been added to the stubs/ directory:

**Request Mappings:**

district-volume-detail-interior.json (Maps GET /api/configuration/district-average-volumes/1)

district-volume-detail-coast.json (Maps GET /api/configuration/district-average-volumes/4)

**Response Content:**

interior-detail.json: Contains the INTERIOR specific schema (including zones and districts).

coast-detail.json: Contains the COASTAL specific schema (including sections and districts).

## Acceptance Criteria
[x] API stubs are correctly placed in the project directory.
[x] JSON structures match the defined DistrictVolumeDetailDto backend schema.
[x] type property is correctly set to support polymorphic deserialization (INTERIOR vs COASTAL).

## Notes
These stubs are intended for use with WireMock or local frontend development environments to ensure consistent data contracts between the backend DTOs and the frontend implementation.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-10-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)