### PR TITLE
ci(scans): fix SARIF upload category collisions in analysis workflow

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -64,6 +64,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: "trivy-results.sarif"
+          category: "trivy"
 
   cve-lite:
     name: CVE Lite Scan (${{ matrix.folder }})
@@ -96,6 +97,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ steps.locate.outputs.path }}
+          category: "cve-lite-${{ matrix.folder }}"
 
   # ==========================================================================
   # WARNING: This job acts as the required merge gate for this workflow.


### PR DESCRIPTION
Resolves #961

### The Problem
We were running three separate security scans in `.github/workflows/analysis.yml` that uploaded SARIF files to GitHub Code Scanning via the `upload-sarif` action:
1. `trivy`
2. `cve-lite (cypress)`
3. `cve-lite (frontend)`

None of these jobs specified a `category` input parameter. By default, `upload-sarif` writes to the `"<default>"` category slot in GitHub's database. Because these jobs run in parallel, they raced to write to the same `API upload — <default>` namespace. Whichever finished last would overwrite the others, leaving the check runs in a broken/pending state and triggering the `1 configuration not found` mismatch warning on pull requests.

### The Fix
We added a unique `category` to the `upload-sarif` step in each job:
- Trivy uploads to category `"trivy"` (`API upload — trivy`)
- CVE-lite uploads to category `"cve-lite-${{ matrix.folder }}"` (`API upload — cve-lite-cypress` / `API upload — cve-lite-frontend`)

This isolates each scanner into its own database namespace, preventing writes from overriding one another, ensuring all security check runs populate properly, and silencing the configuration mismatch warning.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-13-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)