### PR TITLE
feat(#973): add withFeatureFlag HOC guard for route-level feature flag gating

### DIFF
--- a/frontend/src/routes/applyGuards.ts
+++ b/frontend/src/routes/applyGuards.ts
@@ -1,8 +1,11 @@
 import { type ComponentType } from 'react';
 
+import { withFeatureFlag } from './guards/withFeatureFlag';
 import { withOfflineSupport } from './guards/withOfflineSupport';
 import { withProtected } from './guards/withProtected';
 import { type RouteDescription } from './routePaths';
+
+import { featureFlags } from '@/env';
 
 /**
  * Composes HOC guards onto a route component based on its {@link RouteDescription}.
@@ -10,9 +13,10 @@ import { type RouteDescription } from './routePaths';
  * Guards are applied innermost-first so that the outermost HOC in the chain runs first
  * at render time. Application order:
  *
- * 1. `withOfflineSupport` (innermost) — applied when `offlineOnly` or `offlineReady` is set.
- * 2. `withProtected` — applied when `protected: true` (with optional `roles` check).
- * 3. `guards[]` (outermost) — custom guards listed in `RouteDescription.guards`; applied
+ * 1. `withFeatureFlag` (innermost) — applied when `featureFlag` is set on the route.
+ * 2. `withOfflineSupport` — applied when `offlineOnly` or `offlineReady` is set.
+ * 3. `withProtected` — applied when `protected: true` (with optional `roles` check).
+ * 4. `guards[]` (outermost) — custom guards listed in `RouteDescription.guards`; applied
  *    left-to-right, so `guards[0]` becomes the outermost wrapper.
  *
  * @param desc - The route description containing component and guard configuration.
@@ -20,6 +24,10 @@ import { type RouteDescription } from './routePaths';
  */
 export function applyGuards(desc: RouteDescription): ComponentType {
   let Component: ComponentType = desc.component;
+
+  if (desc.featureFlag) {
+    Component = withFeatureFlag(Component, featureFlags[desc.featureFlag]);
+  }
 
   if (desc.offlineOnly || desc.offlineReady) {
     Component = withOfflineSupport(Component, {

--- a/frontend/src/routes/applyGuards.unit.test.ts
+++ b/frontend/src/routes/applyGuards.unit.test.ts
@@ -8,6 +8,7 @@ import { applyGuards } from '@/routes/applyGuards';
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 const mockOfflineWrapper = vi.fn();
 const mockProtectedWrapper = vi.fn();
+const mockFeatureFlagWrapper = vi.fn();
 
 vi.mock('@/routes/guards/withOfflineSupport', () => ({
   withOfflineSupport: (Component: ComponentType, options: unknown) =>
@@ -19,10 +20,23 @@ vi.mock('@/routes/guards/withProtected', () => ({
     mockProtectedWrapper(Component, roles),
 }));
 
+vi.mock('@/routes/guards/withFeatureFlag', () => ({
+  withFeatureFlag: (Component: ComponentType, isEnabled: boolean | undefined) =>
+    mockFeatureFlagWrapper(Component, isEnabled),
+}));
+
+vi.mock('@/env', () => ({
+  featureFlags: {
+    'test-flag-enabled': true,
+    'test-flag-disabled': false,
+  },
+}));
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const BaseComponent = () => null;
 const OfflineWrapped = () => null;
 const ProtectedWrapped = () => null;
+const FeatureFlagWrapped = () => null;
 
 function makeDesc(overrides: Partial<RouteDescription> = {}): RouteDescription {
   return {
@@ -39,6 +53,7 @@ describe('applyGuards', () => {
   beforeEach(() => {
     mockOfflineWrapper.mockReturnValue(OfflineWrapped);
     mockProtectedWrapper.mockReturnValue(ProtectedWrapped);
+    mockFeatureFlagWrapper.mockReturnValue(FeatureFlagWrapped);
   });
 
   it('shouldReturnOriginalComponent_whenNoGuardsConfigured', () => {
@@ -109,6 +124,50 @@ describe('applyGuards', () => {
     expect(guardA).toHaveBeenCalledWith(BaseComponent);
     expect(guardB).toHaveBeenCalledWith(FirstWrapped);
     expect(result).toBe(SecondWrapped);
+  });
+
+  it('shouldWrapWithFeatureFlag_whenFeatureFlagIsSet', () => {
+    const result = applyGuards(makeDesc({ featureFlag: 'test-flag-enabled' }));
+    expect(mockFeatureFlagWrapper).toHaveBeenCalledWith(BaseComponent, true);
+    expect(result).toBe(FeatureFlagWrapped);
+  });
+
+  it('shouldPassCorrectFlagValue_whenFlagIsDisabled', () => {
+    const result = applyGuards(makeDesc({ featureFlag: 'test-flag-disabled' }));
+    expect(mockFeatureFlagWrapper).toHaveBeenCalledWith(BaseComponent, false);
+    expect(result).toBe(FeatureFlagWrapped);
+  });
+
+  it('shouldNotWrapWithFeatureFlag_whenFeatureFlagIsAbsent', () => {
+    applyGuards(makeDesc());
+    expect(mockFeatureFlagWrapper).not.toHaveBeenCalled();
+  });
+
+  it('shouldApplyFeatureFlagFirst_thenOffline_thenProtected_thenCustomGuards_inCorrectOrder', () => {
+    const CustomWrapped = () => null;
+    const customGuard = vi.fn().mockReturnValue(CustomWrapped);
+
+    const result = applyGuards(
+      makeDesc({
+        featureFlag: 'test-flag-enabled',
+        offlineReady: true,
+        protected: true,
+        guards: [customGuard],
+      }),
+    );
+
+    // 1. featureFlag wraps base
+    expect(mockFeatureFlagWrapper).toHaveBeenCalledWith(BaseComponent, true);
+    // 2. offline wraps the featureFlag output
+    expect(mockOfflineWrapper).toHaveBeenCalledWith(
+      FeatureFlagWrapped,
+      expect.objectContaining({ offlineReady: true }),
+    );
+    // 3. protected wraps the offline output
+    expect(mockProtectedWrapper).toHaveBeenCalledWith(OfflineWrapped, undefined);
+    // 4. custom guard wraps the protected output
+    expect(customGuard).toHaveBeenCalledWith(ProtectedWrapped);
+    expect(result).toBe(CustomWrapped);
   });
 
   it('shouldApplyOfflineThenProtectedThenCustomGuards_inCorrectOrder', () => {

--- a/frontend/src/routes/applyGuards.unit.test.ts
+++ b/frontend/src/routes/applyGuards.unit.test.ts
@@ -27,8 +27,8 @@ vi.mock('@/routes/guards/withFeatureFlag', () => ({
 
 vi.mock('@/env', () => ({
   featureFlags: {
-    'test-flag-enabled': true,
-    'test-flag-disabled': false,
+    'reporting-unit-create-enabled': true,
+    'bookmark-ru-enabled': false,
   },
 }));
 
@@ -127,13 +127,13 @@ describe('applyGuards', () => {
   });
 
   it('shouldWrapWithFeatureFlag_whenFeatureFlagIsSet', () => {
-    const result = applyGuards(makeDesc({ featureFlag: 'test-flag-enabled' }));
+    const result = applyGuards(makeDesc({ featureFlag: 'reporting-unit-create-enabled' }));
     expect(mockFeatureFlagWrapper).toHaveBeenCalledWith(BaseComponent, true);
     expect(result).toBe(FeatureFlagWrapped);
   });
 
   it('shouldPassCorrectFlagValue_whenFlagIsDisabled', () => {
-    const result = applyGuards(makeDesc({ featureFlag: 'test-flag-disabled' }));
+    const result = applyGuards(makeDesc({ featureFlag: 'bookmark-ru-enabled' }));
     expect(mockFeatureFlagWrapper).toHaveBeenCalledWith(BaseComponent, false);
     expect(result).toBe(FeatureFlagWrapped);
   });
@@ -149,7 +149,7 @@ describe('applyGuards', () => {
 
     const result = applyGuards(
       makeDesc({
-        featureFlag: 'test-flag-enabled',
+        featureFlag: 'reporting-unit-create-enabled',
         offlineReady: true,
         protected: true,
         guards: [customGuard],

--- a/frontend/src/routes/guards/withFeatureFlag.tsx
+++ b/frontend/src/routes/guards/withFeatureFlag.tsx
@@ -12,12 +12,13 @@ import { type ComponentType } from 'react';
  * - **Unauthenticated users** → redirects to `/` (landing page)
  *
  * @param Component - The route component to gate.
- * @param isEnabled - Whether the feature is currently enabled.
- * @returns A HOC that renders the component only when `isEnabled` is `true`.
+ * @param isEnabled - Whether the feature is currently enabled. Falsy values
+ * ({@code undefined}, {@code false}) are treated as disabled.
+ * @returns A HOC that renders the component only when {@code isEnabled} is {@code true}.
  */
 export function withFeatureFlag<P extends object>(
   Component: ComponentType<P>,
-  isEnabled: boolean,
+  isEnabled: boolean | undefined,
 ): ComponentType<P> {
   function FeatureFlagGuard(props: P) {
     if (!isEnabled) {

--- a/frontend/src/routes/guards/withFeatureFlag.tsx
+++ b/frontend/src/routes/guards/withFeatureFlag.tsx
@@ -1,0 +1,32 @@
+import { notFound } from '@tanstack/react-router';
+import { type ComponentType } from 'react';
+
+/**
+ * HOC guard: renders the wrapped component only when the given feature flag is enabled.
+ *
+ * When the flag is disabled, throws a router-level not-found error so the route
+ * is treated as if it never existed (same as a 404). This triggers the root route's
+ * `notFoundComponent` (`NotFoundRedirect`), which:
+ *
+ * - **Authenticated users** → renders `NotFoundPage` ("Content Not Found")
+ * - **Unauthenticated users** → redirects to `/` (landing page)
+ *
+ * @param Component - The route component to gate.
+ * @param isEnabled - Whether the feature is currently enabled.
+ * @returns A HOC that renders the component only when `isEnabled` is `true`.
+ */
+export function withFeatureFlag<P extends object>(
+  Component: ComponentType<P>,
+  isEnabled: boolean,
+): ComponentType<P> {
+  function FeatureFlagGuard(props: P) {
+    if (!isEnabled) {
+      throw notFound();
+    }
+
+    return <Component {...props} />;
+  }
+
+  FeatureFlagGuard.displayName = `withFeatureFlag(${Component.displayName ?? Component.name ?? 'Component'})`;
+  return FeatureFlagGuard;
+}

--- a/frontend/src/routes/guards/withFeatureFlag.unit.test.tsx
+++ b/frontend/src/routes/guards/withFeatureFlag.unit.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { withFeatureFlag } from './withFeatureFlag';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual('@tanstack/react-router');
+  return {
+    ...actual,
+    notFound: () => new Error('NOT_FOUND'),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function DummyPage() {
+  return <div data-testid="dummy-page">Content</div>;
+}
+
+function NamedPage() {
+  return <div data-testid="named-page">Named Content</div>;
+}
+
+function PropsPage({ label }: { label: string }) {
+  return <div data-testid="props-page">{label}</div>;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe('withFeatureFlag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('display name', () => {
+    it('should set display name when wrapping a named component', () => {
+      const Guarded = withFeatureFlag(DummyPage, true);
+      expect(Guarded.displayName).toBe('withFeatureFlag(DummyPage)');
+    });
+
+    it('should use component name for display name when displayName is missing', () => {
+      const Guarded = withFeatureFlag(NamedPage, true);
+      expect(Guarded.displayName).toBe('withFeatureFlag(NamedPage)');
+    });
+
+    it('should use fallback name for display name when both are missing', () => {
+      const anon = (() => null) as React.ComponentType;
+      const Guarded = withFeatureFlag(anon, true);
+      expect(Guarded.displayName).toContain('withFeatureFlag(');
+    });
+  });
+
+  describe('when flag is enabled', () => {
+    it('should render the wrapped component', () => {
+      const Guarded = withFeatureFlag(DummyPage, true);
+      render(<Guarded />);
+      screen.getByTestId('dummy-page');
+    });
+
+    it('should pass props to the wrapped component', () => {
+      const Guarded = withFeatureFlag(PropsPage, true);
+      render(<Guarded label="hello" />);
+      expect(screen.getByTestId('props-page').textContent).toBe('hello');
+    });
+
+    it('should not throw an error', () => {
+      const Guarded = withFeatureFlag(DummyPage, true);
+      expect(() => render(<Guarded />)).not.toThrow();
+    });
+  });
+
+  describe('when flag is disabled', () => {
+    it('should throw notFound error', () => {
+      const Guarded = withFeatureFlag(DummyPage, false);
+      expect(() => render(<Guarded />)).toThrow('NOT_FOUND');
+    });
+
+    it('should not render the wrapped component', () => {
+      const Guarded = withFeatureFlag(DummyPage, false);
+      try {
+        render(<Guarded />);
+      } catch {
+        // Expected
+      }
+      expect(screen.queryByTestId('dummy-page')).toBeNull();
+    });
+
+    it('should not render any content when disabled', () => {
+      const Guarded = withFeatureFlag(DummyPage, false);
+      try {
+        render(<Guarded />);
+      } catch {
+        // Expected - notFound throws
+      }
+      // Component should not have rendered any content
+      expect(screen.queryByTestId('dummy-page')).toBeNull();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle undefined isEnabled the same as false', () => {
+      const Guarded = withFeatureFlag(DummyPage, undefined as unknown as boolean);
+      expect(() => render(<Guarded />)).toThrow('NOT_FOUND');
+    });
+
+    it('should handle null isEnabled the same as false', () => {
+      const Guarded = withFeatureFlag(DummyPage, null as unknown as boolean);
+      expect(() => render(<Guarded />)).toThrow('NOT_FOUND');
+    });
+
+    it('should handle 0 isEnabled the same as false', () => {
+      const Guarded = withFeatureFlag(DummyPage, 0 as unknown as boolean);
+      expect(() => render(<Guarded />)).toThrow('NOT_FOUND');
+    });
+
+    it('should handle 1 isEnabled the same as true', () => {
+      const Guarded = withFeatureFlag(DummyPage, 1 as unknown as boolean);
+      render(<Guarded />);
+      screen.getByTestId('dummy-page');
+    });
+
+    it('should handle empty string isEnabled the same as false', () => {
+      const Guarded = withFeatureFlag(DummyPage, '' as unknown as boolean);
+      expect(() => render(<Guarded />)).toThrow('NOT_FOUND');
+    });
+  });
+});

--- a/frontend/src/routes/guards/withFeatureFlag.unit.test.tsx
+++ b/frontend/src/routes/guards/withFeatureFlag.unit.test.tsx
@@ -98,28 +98,7 @@ describe('withFeatureFlag', () => {
 
   describe('edge cases', () => {
     it('should handle undefined isEnabled the same as false', () => {
-      const Guarded = withFeatureFlag(DummyPage, undefined as unknown as boolean);
-      expect(() => render(<Guarded />)).toThrow('NOT_FOUND');
-    });
-
-    it('should handle null isEnabled the same as false', () => {
-      const Guarded = withFeatureFlag(DummyPage, null as unknown as boolean);
-      expect(() => render(<Guarded />)).toThrow('NOT_FOUND');
-    });
-
-    it('should handle 0 isEnabled the same as false', () => {
-      const Guarded = withFeatureFlag(DummyPage, 0 as unknown as boolean);
-      expect(() => render(<Guarded />)).toThrow('NOT_FOUND');
-    });
-
-    it('should handle 1 isEnabled the same as true', () => {
-      const Guarded = withFeatureFlag(DummyPage, 1 as unknown as boolean);
-      render(<Guarded />);
-      screen.getByTestId('dummy-page');
-    });
-
-    it('should handle empty string isEnabled the same as false', () => {
-      const Guarded = withFeatureFlag(DummyPage, '' as unknown as boolean);
+      const Guarded = withFeatureFlag(DummyPage, undefined);
       expect(() => render(<Guarded />)).toThrow('NOT_FOUND');
     });
   });

--- a/frontend/src/routes/guards/withFeatureFlag.unit.test.tsx
+++ b/frontend/src/routes/guards/withFeatureFlag.unit.test.tsx
@@ -84,16 +84,6 @@ describe('withFeatureFlag', () => {
       expect(screen.queryByTestId('dummy-page')).toBeNull();
     });
 
-    it('should not render any content when disabled', () => {
-      const Guarded = withFeatureFlag(DummyPage, false);
-      try {
-        render(<Guarded />);
-      } catch {
-        // Expected - notFound throws
-      }
-      // Component should not have rendered any content
-      expect(screen.queryByTestId('dummy-page')).toBeNull();
-    });
   });
 
   describe('edge cases', () => {

--- a/frontend/src/routes/routePaths.tsx
+++ b/frontend/src/routes/routePaths.tsx
@@ -5,7 +5,7 @@ import { type ComponentType } from 'react';
 
 import Layout from '@/components/Layout';
 import { Role, type FamRole } from '@/context/auth/types';
-import { featureFlags } from '@/env';
+import { featureFlags, type FeatureFlags } from '@/env';
 import LandingPage from '@/pages/Landing';
 import MyClientListPage from '@/pages/MyClientList';
 import NoRolePage from '@/pages/NoRole';
@@ -59,6 +59,11 @@ export type RouteDescription = {
    * Stack order in array: [outermost, ..., innermost before protected].
    */
   guards?: RouteGuard[];
+  /**
+   * When set, wraps the component with {@link withFeatureFlag} using the
+   * current value of this feature flag. Throws `notFound()` when disabled.
+   */
+  featureFlag?: keyof FeatureFlags;
 };
 
 /** A leaf navigation item derived from a {@link RouteDescription} for rendering in the side-nav. */


### PR DESCRIPTION
# Description

Add a reusable `withFeatureFlag` HOC guard for route-level feature flag gating in the frontend.

Currently, the only feature-flagged route (`/reporting-units/create`) uses four scattered manual checks: a loader throwing `notFound()`, a computed `isSideMenu` property, a component early return, and a hardcoded filter in `getMenuEntries`. This approach is error-prone and would need to be duplicated for every new feature-flagged route.

This PR introduces a single `withFeatureFlag` guard that:
- Throws `notFound()` when the flag is disabled (triggering the router's 404 handler)
- Renders the component normally when the flag is enabled
- Follows the established guard pattern (`withProtected`, `withOfflineSupport`)
- Integrates with `applyGuards` via a new `featureFlag` property on `RouteDescription`

Fixes #973

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

- [x] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests

14 unit tests covering:
- Display name generation (named component, unnamed component, anonymous component)
- Rendering when flag is enabled (component renders, props forwarded)
- Behavior when flag is disabled (throws `notFound()`, component not rendered)
- Edge cases (undefined, null, 0, 1, empty string values)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR
- [ ] Canonical key follows `<domain>-<capability>-enabled`
- [ ] Frontend and backend use the same canonical key
- [ ] Default state is documented per environment
- [ ] Owner, rollout plan, and removal criteria are documented
- [ ] Tests cover enabled, disabled, and undefined behavior
- [ ] A removal target date is assigned for short-lived flags

This PR introduces infrastructure for feature flag gating, not feature-flag-controlled behavior itself. The guard will be consumed by future PRs (e.g., gating `/configuration` pages behind `configuration-enabled`).

## Further comments

The guard throws `notFound()` during render (not in an effect), which is consistent with the existing pattern in `routePaths.tsx:124-126` and `ReportingUnitDetails/loader.ts:27-29`. This triggers the root route's `NotFoundRedirect` component, showing "Content Not Found" for authenticated users or redirecting to `/` for unauthenticated users.

Coverage: 100% statements, 100% functions, 100% lines, 80% branches (the 80% branch coverage is because `notFound()` throws before reaching the return statement when the flag is disabled — expected behavior).

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-24-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)