### PR TITLE
fix(scans): match Trivy SARIF category to old default to resolve neutral check status

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -46,6 +46,7 @@ jobs:
     name: Repository Report
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     permissions:
+      contents: read
       security-events: write
     runs-on: ubuntu-24.04
     steps:
@@ -64,7 +65,6 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: "trivy-results.sarif"
-          category: "trivy"
 
   cve-lite:
     name: CVE Lite Scan (${{ matrix.folder }})
@@ -106,7 +106,7 @@ jobs:
   # ==========================================================================
   results:
     name: Analysis Results
-    needs: [tests-java, tests-frontend, tests-frontend-ex, trivy, cve-lite] # Restore trivy when/if fixed
+    needs: [tests-java, tests-frontend, tests-frontend-ex, trivy, cve-lite]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 1


### PR DESCRIPTION
## Summary

Fixes the `neutral` check run status ("1 configuration not found") for security scans on PRs by aligning the Trivy SARIF upload category with the historical default on `main`.

## Changes

1. **`analysis.yml` — Trivy upload**: Removed explicit `category: "trivy"` so the upload uses the default format (`.github/workflows/analysis.yml:trivy`), matching hundreds of historical analyses on `main` that can't be deleted (GitHub doesn't allow deleting analyses older than ~30 days).

2. **`analysis.yml` — Trivy permissions**: Added `contents: read` for consistency with `cve-lite` job.

3. **`analysis.yml` — Stale comment**: Removed the `# Restore trivy when/if fixed` comment — Trivy was restored in #958.

## Background

When PR #974 runs security scans, the Trivy check shows `neutral` with this warning:

> Code scanning cannot determine the alerts introduced by this pull request, because 1 configuration present on `refs/heads/main` was not found: `.github/workflows/analysis.yml:trivy`

This happens because:
- Commit #958 added explicit `category: "trivy"` to the upload step
- Hundreds of historical Trivy analyses on `main` used the **default** category (`.github/workflows/analysis.yml:trivy`)
- GitHub considers the old default as a "configuration present on main" and warns when the PR doesn't include it

The old analyses can't be deleted (API returns `Analysis specified is not deletable` for entries older than ~30 days). The fix is to revert to the default category so new uploads match old ones.

For `CVE Lite CLI`, the stale empty-category analyses were successfully deleted via the API directly on `main` (they were recent enough to be deletable).

## Related

Closes the root cause of the check status issue observed in PR #974.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-25-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)