### PR TITLE
fix(#1007): fix ineffective and orphaned npm overrides in cypress

### DIFF
--- a/cypress/package.json
+++ b/cypress/package.json
@@ -58,30 +58,16 @@
     "fast-uri@<=3.1.1": "3.1.2",
     "postcss@<8.5.10": "8.5.10",
     "picomatch@^4.0.0": "^4.0.4",
-    "dompurify@<3.3.2": "^3.3.2",
     "serialize-javascript": "^7.0.5",
     "lodash@^4.0.0": "^4.18.1",
     "lodash-es@^4.0.0": "^4.18.1",
-    "basic-ftp@^5.0.0": "5.2.2",
-    "ip-address@<=10.1.0": "10.1.1",
     "qs": "6.15.3",
     "form-data": "4.0.6",
     "tmp": "^0.2.6",
     "undici": "8.5.0",
     "uuid@<14.0.0": "14.0.0",
-    "fast-xml-parser@<5.7.0": "5.7.0",
-    "shelljs": {
-      "glob": "13.0.6"
-    },
-    "module-lookup-amd": {
-      "glob": "13.0.6"
-    },
-    "mocha": {
-      "diff": "9.0.0"
-    },
-    "@sentry/node": {
-      "@opentelemetry/core": "2.8.0"
-    },
+    "diff@^7.0.0": "9.0.0",
+    "@opentelemetry/core@^1.30.1": "2.8.0",
     "ws@^7.0.0": "7.5.11"
   },
   "allowScripts": {


### PR DESCRIPTION
# Description

Removes 4 orphaned npm override entries and fixes 4 ineffective nested overrides in `cypress/package.json` flagged by Code Scanning (rules OA001 and OA005).

**OrphanedTarget (OA001):** Overrides for `dompurify`, `basic-ftp`, `ip-address`, and `fast-xml-parser` targeted packages not present in the resolved dependency tree — removed entirely.

**NestedIneffective (OA005):** Nested overrides `shelljs→glob` and `module-lookup-amd→glob` targeted child packages that aren't dependencies of the parent — removed. Nested overrides `mocha→diff` and `@sentry/node→@opentelemetry/core` replaced with flat version-scoped overrides so they apply regardless of parent depth.

Closes #1007

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] No new tests are required
- Verified `npm install` succeeds with 0 vulnerabilities
- Verified `npm ls diff` and `npm ls @opentelemetry/core` show "overridden" status

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Feature-Flag Controlled Changes

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-8-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)