### PR TITLE
fix: remediate container scan findings

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -86,9 +86,9 @@
         <resilience4j.version>2.4.0</resilience4j.version>
         <wiremock.version>3.13.2</wiremock.version>
         <jackson-2-bom.version>2.21.1</jackson-2-bom.version>
-        <jackson-bom.version>3.1.1</jackson-bom.version>
+        <jackson-bom.version>3.1.4</jackson-bom.version>
         <spring-security.version>7.0.5</spring-security.version>
-        <tomcat.version>11.0.21</tomcat.version>
+        <tomcat.version>11.0.22</tomcat.version>
         <postgresql.version>42.7.11</postgresql.version>
     </properties>
 

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -88,9 +88,9 @@
         <mapstruct.version>1.6.3</mapstruct.version>
         <tomcat.version>11.0.10</tomcat.version>
         <testcontainers.version>1.21.3</testcontainers.version>
-        <jackson.version>2.21.1</jackson.version>
-        <jackson-bom.version>2.21.1</jackson-bom.version>
-        <spring-security.version>6.5.10</spring-security.version>
+        <jackson.version>2.21.4</jackson.version>
+        <jackson-bom.version>2.21.4</jackson-bom.version>
+        <spring-security.version>6.5.11</spring-security.version>
     </properties>
     <profiles>
         <profile>


### PR DESCRIPTION
## Summary

Container scan remediation from Phase 1 results.

### Changes

**backend/pom.xml**
- Bump tomcat-embed-core 11.0.21 → 11.0.22 (fixes 3 CRITICAL, 3 HIGH CVEs)
- Bump jackson-databind 3.1.1 → 3.1.4 (fixes 2 HIGH, 5 MEDIUM CVEs)

**legacy/pom.xml**
- Bump jackson-databind 2.21.1 → 2.21.4 (fixes 2 HIGH, 5 MEDIUM CVEs)
- Bump spring-security-web 6.5.10 → 6.5.11 (fixes 1 MEDIUM CVE)

### Advisory
- JWT secrets in `frontend/stub/mappings/fam.json` are mock WireMock test tokens — no auto-patch applied.

Closes #1009

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-10-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)