### PR TITLE
fix(sec:container): Update outdated Docker base images (300+ CVEs)

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,5 +1,7 @@
 FROM postgres:17-alpine
 
+RUN apk add --no-cache bash
+
 HEALTHCHECK --interval=35s --timeout=4s CMD pg_isready -d db_prod
  
 # Non-privileged user

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13.23
+FROM postgres:17-alpine
 
 HEALTHCHECK --interval=35s --timeout=4s CMD pg_isready -d db_prod
  

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgres:17-alpine
 
-HEALTHCHECK --interval=35s --timeout=4s CMD pg_isready -d db_prod
+HEALTHCHECK --interval=35s --timeout=4s CMD pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}"
  
 # Non-privileged user
 USER postgres

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,7 +1,5 @@
 FROM postgres:17-alpine
 
-RUN apk add --no-cache bash
-
 HEALTHCHECK --interval=35s --timeout=4s CMD pg_isready -d db_prod
  
 # Non-privileged user

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:17-alpine
+FROM postgres:17.4-alpine
 
 HEALTHCHECK --interval=35s --timeout=4s CMD pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}"
  

--- a/database/init-db.sh
+++ b/database/init-db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -87,8 +87,7 @@ objects:
               readinessProbe:
                 exec:
                   command:
-                    - /usr/bin/env
-                    - bash
+                    - /bin/sh
                     - -c
                     - psql -q -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'
                 failureThreshold: 5
@@ -98,8 +97,7 @@ objects:
               livenessProbe:
                 exec:
                   command:
-                    - /usr/bin/env
-                    - bash
+                    - /bin/sh
                     - -c
                     - psql -q -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'
                 failureThreshold: 5

--- a/legacy/Dockerfile
+++ b/legacy/Dockerfile
@@ -1,6 +1,6 @@
 ### Builder
-# Use GraalVM Native Image with Java 21 (LTS) to satisfy connectivity with Oracle DB
-FROM ghcr.io/graalvm/native-image-community:21 AS build
+# Use GraalVM Native Image with Java 25 (latest LTS) to satisfy connectivity with Oracle DB
+FROM ghcr.io/graalvm/native-image-community:25.0.2 AS build
 
 # Copy
 WORKDIR /app


### PR DESCRIPTION
## Summary
CRITICAL: Resolves 300+ HIGH CVEs in Docker base images across the stack.

## Changes
- **legacy/Dockerfile**: GraalVM 21 → 25.0.2
  - Resolves 180+ HIGH CVEs including privilege escalation (CVE-2026-46333, CVE-2026-23401)
  - RCE risks in OpenSSL, libcap, gnutls
  
- **database/Dockerfile**: PostgreSQL 13.23 → 17-alpine
  - Resolves 110+ HIGH CVEs including GnuPG RCE (CVE-2026-24882)
  - OpenSSL use-after-free vulnerability (CVE-2026-28387)
  - Symlink traversal privilege escalation (CVE-2026-54369, CVE-2026-54371)
  - Alpine base further reduces attack surface

- **backend/Dockerfile**: Already on GraalVM 25.0.2 (current)

## Related Issues
Closes #1013

## Testing
- [ ] Full regression test suite passes
- [ ] Docker images build successfully
- [ ] Multi-architecture builds (amd64, arm64) verified
- [ ] Health checks pass on all services
- [ ] Database migrations work with PostgreSQL 17

## Security Impact
Eliminates critical container escape and privilege escalation vectors.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-16-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)