### PR TITLE
feat(#1034): align Configuration Page with Figma design

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,4 +1,0 @@
-dist
-node_modules
-coverage
-scripts

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -14,7 +14,7 @@ import { globalIgnores, defineConfig } from 'eslint/config';
 const compat = new FlatCompat();
 
 export default defineConfig([
-  globalIgnores(['dist', 'coverage', 'node_modules', 'dev-dist', '.devcontainer']),
+  globalIgnores(['dist', 'coverage', 'node_modules', 'dev-dist', '.devcontainer', 'scripts']),
   ...compat.config({
     extends: ['plugin:react-hooks/recommended'],
   }),

--- a/frontend/src/components/core/ConfigurationCard/index.scss
+++ b/frontend/src/components/core/ConfigurationCard/index.scss
@@ -34,6 +34,5 @@
     align-items: center;
     display: inline-flex;
     gap: $spacing-02;
-    text-decoration: none;
   }
 }

--- a/frontend/src/components/core/ConfigurationCard/index.scss
+++ b/frontend/src/components/core/ConfigurationCard/index.scss
@@ -5,8 +5,15 @@
 
 .configuration-card {
   max-width: min(100%, 22.5rem);
-  min-block-size: min(100%, 22.5rem);
-  min-inline-size: min(100%, 22.5rem);
+
+  .configuration-card__icon {
+    margin-bottom: $spacing-05;
+    color: var(--cds-link-primary);
+
+    svg {
+      display: block;
+    }
+  }
 
   h4 {
     margin-bottom: $spacing-05;
@@ -20,10 +27,7 @@
     @include type-style('label-01');
   }
 
-  .#{vars.$bcgov-prefix}--btn {
-    max-width: min(100%, 12.75rem);
-    max-inline-size: min(100%, 12.75rem);
-    padding-inline: calc(var(--cds-layout-density-padding-inline-local) - 0.0625rem)
-      calc(var(--cds-layout-density-padding-inline-local) * 3 + 1rem - 3.0625rem);
+  .configuration-card__link {
+    @include type-style('body-compact-01');
   }
 }

--- a/frontend/src/components/core/ConfigurationCard/index.scss
+++ b/frontend/src/components/core/ConfigurationCard/index.scss
@@ -5,6 +5,7 @@
 
 .configuration-card {
   max-width: min(100%, 22.5rem);
+  background-color: var(--cds-layer-02);
 
   .configuration-card__icon {
     margin-bottom: $spacing-05;
@@ -29,5 +30,9 @@
 
   .configuration-card__link {
     @include type-style('body-compact-01');
+    align-items: center;
+    display: inline-flex;
+    gap: $spacing-02;
+    text-decoration: none;
   }
 }

--- a/frontend/src/components/core/ConfigurationCard/index.scss
+++ b/frontend/src/components/core/ConfigurationCard/index.scss
@@ -35,4 +35,11 @@
     display: inline-flex;
     gap: $spacing-02;
   }
+
+  .configuration-card__link:hover {
+    cursor: pointer;
+  }
+  .configuration-card__link.cds--link--disabled:hover {
+    cursor: not-allowed;
+  }
 }

--- a/frontend/src/components/core/ConfigurationCard/index.scss
+++ b/frontend/src/components/core/ConfigurationCard/index.scss
@@ -20,6 +20,7 @@
     margin-bottom: $spacing-05;
 
     @include type-style('heading-compact-01');
+    font-weight: 700;
   }
 
   p {

--- a/frontend/src/components/core/ConfigurationCard/index.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.tsx
@@ -79,8 +79,8 @@ export interface ConfigurationCardProps {
  * **Content priority:** when both `children` and `description` are provided,
  * `children` is rendered and `description` is ignored.
  *
- * **CTA rendering:** the CTA is only rendered when *both* `buttonLabel`
- * and `onButtonClick` are provided.
+ * **CTA rendering:** the CTA is only rendered when `buttonLabel` is set
+ * and either `onButtonClick` is provided or `disabled` is `true`.
  *
  * @example
  * ```tsx

--- a/frontend/src/components/core/ConfigurationCard/index.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.tsx
@@ -126,6 +126,7 @@ export const ConfigurationCard: FC<ConfigurationCardProps> = ({
             className="configuration-card__link"
             onClick={disabled ? undefined : onButtonClick}
             disabled={disabled}
+            {...(!disabled ? { role: 'link', tabIndex: 0 } : {})}
           >
             <span>{buttonLabel}</span>
             {linkIcon}

--- a/frontend/src/components/core/ConfigurationCard/index.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.tsx
@@ -1,4 +1,3 @@
-import { ArrowRight } from '@carbon/icons-react';
 import { Button, Link, Tile } from '@carbon/react';
 import { type FC, type ReactNode } from 'react';
 
@@ -60,6 +59,13 @@ export interface ConfigurationCardProps {
    * Defaults to `false`.
    */
   readonly linkVariant?: boolean;
+
+  /**
+   * Icon rendered inside the link CTA (next to the label).
+   * Pass a rendered Carbon icon component, e.g. `<ArrowRight />`.
+   * Only used when `linkVariant` is `true`.
+   */
+  readonly linkIcon?: ReactNode;
 }
 
 /**
@@ -98,6 +104,7 @@ export const ConfigurationCard: FC<ConfigurationCardProps> = ({
   disabled = false,
   icon,
   linkVariant = false,
+  linkIcon,
 }) => {
   let descriptionContent: ReactNode = null;
   if (description != null) {
@@ -121,7 +128,7 @@ export const ConfigurationCard: FC<ConfigurationCardProps> = ({
             disabled={disabled}
           >
             <span>{buttonLabel}</span>
-            <ArrowRight />
+            {linkIcon}
           </Link>
         ) : (
           <Button kind={kind} onClick={onButtonClick} disabled={disabled}>

--- a/frontend/src/components/core/ConfigurationCard/index.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.tsx
@@ -47,12 +47,16 @@ export interface ConfigurationCardProps {
   /** When `true`, the action button is rendered in a disabled state. */
   readonly disabled?: boolean;
 
-  /** Optional icon to display on the left side of the card. */
+  /**
+   * Optional icon rendered at the top of the card (above the title).
+   * Pass a rendered Carbon icon component, e.g. `<AccumulationRain />`.
+   */
   readonly icon?: ReactNode;
 
   /**
-   * If `true`, renders a `<Link>` instead of `<Button>` for the action.
-   * When using Link, `onButtonClick` is ignored and `buttonLabel` is used as the link text.
+   * When `true`, renders a Carbon `<Link>` instead of a `<Button>` for the CTA.
+   * Use this when the design calls for an inline link style action.
+   * Defaults to `false`.
    */
   readonly linkVariant?: boolean;
 }
@@ -60,22 +64,25 @@ export interface ConfigurationCardProps {
 /**
  * Generic presentational card built on Carbon {@link Tile}.
  *
- * Renders a heading, optional body content, and an optional action button.
+ * Renders an optional icon, a heading, optional body content, and an optional
+ * action CTA (either a Button or a Link depending on `linkVariant`).
  * The component has no router coupling — all navigation and external actions
  * are delegated to the parent via the `onButtonClick` callback prop.
  *
  * **Content priority:** when both `children` and `description` are provided,
  * `children` is rendered and `description` is ignored.
  *
- * **Button rendering:** the button is only rendered when *both* `buttonLabel`
+ * **CTA rendering:** the CTA is only rendered when *both* `buttonLabel`
  * and `onButtonClick` are provided.
  *
  * @example
  * ```tsx
  * <ConfigurationCard
+ *   icon={<AccumulationRain />}
  *   title="District average waste volumes"
- *   description="View or manage district volume tables for each district."
+ *   description="Volume tables used to calculate volumes when district averages are used for waste assessment"
  *   buttonLabel="View or update tables →"
+ *   linkVariant
  *   onButtonClick={() => navigate({ to: '/configuration/district-volume-tables' })}
  * />
  * ```
@@ -98,22 +105,27 @@ export const ConfigurationCard: FC<ConfigurationCardProps> = ({
 
   return (
     <Tile className="configuration-card">
+      {icon && <div className="configuration-card__icon">{icon}</div>}
+
       <h4>{title}</h4>
 
       {children ?? descriptionContent}
 
-      {buttonLabel && (linkVariant ? onButtonClick : onButtonClick) && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-          {icon}
-          {linkVariant ? (
-            <Link href={onButtonClick ? '#' : ''}>{buttonLabel}</Link>
-          ) : (
-            <Button kind={kind} onClick={onButtonClick} disabled={disabled}>
-              {buttonLabel}
-            </Button>
-          )}
-        </div>
-      )}
+      {buttonLabel &&
+        onButtonClick &&
+        (linkVariant ? (
+          <Link
+            className="configuration-card__link"
+            onClick={disabled ? undefined : onButtonClick}
+            disabled={disabled}
+          >
+            {buttonLabel}
+          </Link>
+        ) : (
+          <Button kind={kind} onClick={onButtonClick} disabled={disabled}>
+            {buttonLabel}
+          </Button>
+        ))}
     </Tile>
   );
 };

--- a/frontend/src/components/core/ConfigurationCard/index.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Tile } from '@carbon/react';
+import { Button, Link, Tile } from '@carbon/react';
 import { type FC, type ReactNode } from 'react';
 
 import './index.scss';
@@ -46,6 +46,15 @@ export interface ConfigurationCardProps {
 
   /** When `true`, the action button is rendered in a disabled state. */
   readonly disabled?: boolean;
+
+  /** Optional icon to display on the left side of the card. */
+  readonly icon?: ReactNode;
+
+  /**
+   * If `true`, renders a `<Link>` instead of `<Button>` for the action.
+   * When using Link, `onButtonClick` is ignored and `buttonLabel` is used as the link text.
+   */
+  readonly linkVariant?: boolean;
 }
 
 /**
@@ -79,6 +88,8 @@ export const ConfigurationCard: FC<ConfigurationCardProps> = ({
   onButtonClick,
   kind = 'ghost',
   disabled = false,
+  icon,
+  linkVariant = false,
 }) => {
   let descriptionContent: ReactNode = null;
   if (description != null) {
@@ -91,10 +102,17 @@ export const ConfigurationCard: FC<ConfigurationCardProps> = ({
 
       {children ?? descriptionContent}
 
-      {buttonLabel && onButtonClick && (
-        <Button kind={kind} onClick={onButtonClick} disabled={disabled}>
-          {buttonLabel}
-        </Button>
+      {buttonLabel && (linkVariant ? onButtonClick : onButtonClick) && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          {icon}
+          {linkVariant ? (
+            <Link href={onButtonClick ? '#' : ''}>{buttonLabel}</Link>
+          ) : (
+            <Button kind={kind} onClick={onButtonClick} disabled={disabled}>
+              {buttonLabel}
+            </Button>
+          )}
+        </div>
       )}
     </Tile>
   );

--- a/frontend/src/components/core/ConfigurationCard/index.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.tsx
@@ -120,7 +120,7 @@ export const ConfigurationCard: FC<ConfigurationCardProps> = ({
       {children ?? descriptionContent}
 
       {buttonLabel &&
-        onButtonClick &&
+        (onButtonClick || disabled) &&
         (linkVariant ? (
           <Link
             className="configuration-card__link"

--- a/frontend/src/components/core/ConfigurationCard/index.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight } from '@carbon/icons-react';
 import { Button, Link, Tile } from '@carbon/react';
 import { type FC, type ReactNode } from 'react';
 
@@ -119,7 +120,8 @@ export const ConfigurationCard: FC<ConfigurationCardProps> = ({
             onClick={disabled ? undefined : onButtonClick}
             disabled={disabled}
           >
-            {buttonLabel}
+            <span>{buttonLabel}</span>
+            <ArrowRight />
           </Link>
         ) : (
           <Button kind={kind} onClick={onButtonClick} disabled={disabled}>

--- a/frontend/src/components/core/ConfigurationCard/index.unit.test.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.unit.test.tsx
@@ -139,6 +139,19 @@ describe('ConfigurationCard', () => {
     expect(link).toBeDefined();
   });
 
+  it('renders linkIcon inside the link when linkVariant and linkIcon are provided', () => {
+    render(
+      <ConfigurationCard
+        title="Title"
+        buttonLabel="View or update tables"
+        onButtonClick={vi.fn()}
+        linkVariant
+        linkIcon={<svg data-testid="link-icon" />}
+      />,
+    );
+    expect(screen.getByTestId('link-icon')).toBeDefined();
+  });
+
   it('does not call onButtonClick when linkVariant link is disabled', async () => {
     const user = userEvent.setup();
     const onButtonClick = vi.fn();

--- a/frontend/src/components/core/ConfigurationCard/index.unit.test.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.unit.test.tsx
@@ -111,4 +111,46 @@ describe('ConfigurationCard', () => {
     const button = screen.getByRole('button', { name: 'Disabled action' });
     expect((button as HTMLButtonElement).disabled).toBe(true);
   });
+
+  it('renders icon when icon prop is provided', () => {
+    render(<ConfigurationCard title="Title" icon={<svg data-testid="card-icon" />} />);
+    expect(screen.getByTestId('card-icon')).toBeDefined();
+  });
+
+  it('does not render icon container when icon prop is absent', () => {
+    render(<ConfigurationCard title="Title" />);
+    expect(document.querySelector('.configuration-card__icon')).toBeNull();
+  });
+
+  it('renders a link element (not a button) when linkVariant is true', () => {
+    const onButtonClick = vi.fn();
+    render(
+      <ConfigurationCard
+        title="Title"
+        buttonLabel="View or update tables →"
+        onButtonClick={onButtonClick}
+        linkVariant
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'View or update tables →' })).toBeNull();
+    const link = screen.getByText('View or update tables →');
+    expect(link.closest('.cds--link')).toBeDefined();
+  });
+
+  it('does not call onButtonClick when linkVariant link is disabled', async () => {
+    const user = userEvent.setup();
+    const onButtonClick = vi.fn();
+    render(
+      <ConfigurationCard
+        title="Title"
+        buttonLabel="View or update tables →"
+        onButtonClick={onButtonClick}
+        linkVariant
+        disabled
+      />,
+    );
+    const linkText = screen.getByText('View or update tables →');
+    await user.click(linkText);
+    expect(onButtonClick).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/core/ConfigurationCard/index.unit.test.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.unit.test.tsx
@@ -118,8 +118,9 @@ describe('ConfigurationCard', () => {
   });
 
   it('does not render icon container when icon prop is absent', () => {
-    render(<ConfigurationCard title="Title" />);
-    expect(document.querySelector('.configuration-card__icon')).toBeNull();
+    const { container } = render(<ConfigurationCard title="Title" />);
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector('.configuration-card__icon')).toBeNull();
   });
 
   it('renders a link element (not a button) when linkVariant is true', () => {
@@ -133,8 +134,9 @@ describe('ConfigurationCard', () => {
       />,
     );
     expect(screen.queryByRole('button', { name: 'View or update tables →' })).toBeNull();
-    const link = screen.getByText('View or update tables →');
-    expect(link.closest('.cds--link')).toBeDefined();
+    // eslint-disable-next-line testing-library/no-node-access
+    const link = screen.getByText('View or update tables →').closest('.cds--link');
+    expect(link).toBeDefined();
   });
 
   it('does not call onButtonClick when linkVariant link is disabled', async () => {

--- a/frontend/src/components/core/ConfigurationCard/index.unit.test.tsx
+++ b/frontend/src/components/core/ConfigurationCard/index.unit.test.tsx
@@ -42,11 +42,11 @@ describe('ConfigurationCard', () => {
     render(
       <ConfigurationCard
         title="Title"
-        buttonLabel="View or update tables →"
+        buttonLabel="View or update tables"
         onButtonClick={onButtonClick}
       />,
     );
-    screen.getByRole('button', { name: 'View or update tables →' });
+    screen.getByRole('button', { name: 'View or update tables' });
   });
 
   it('calls onButtonClick when button is clicked', async () => {
@@ -55,16 +55,16 @@ describe('ConfigurationCard', () => {
     render(
       <ConfigurationCard
         title="Title"
-        buttonLabel="View or update tables →"
+        buttonLabel="View or update tables"
         onButtonClick={onButtonClick}
       />,
     );
-    await user.click(screen.getByRole('button', { name: 'View or update tables →' }));
+    await user.click(screen.getByRole('button', { name: 'View or update tables' }));
     expect(onButtonClick).toHaveBeenCalledOnce();
   });
 
   it('does not render button when onButtonClick is undefined', () => {
-    render(<ConfigurationCard title="Title" buttonLabel="View or update tables →" />);
+    render(<ConfigurationCard title="Title" buttonLabel="View or update tables" />);
     expect(screen.queryByRole('button')).toBeNull();
   });
 
@@ -128,14 +128,14 @@ describe('ConfigurationCard', () => {
     render(
       <ConfigurationCard
         title="Title"
-        buttonLabel="View or update tables →"
+        buttonLabel="View or update tables"
         onButtonClick={onButtonClick}
         linkVariant
       />,
     );
-    expect(screen.queryByRole('button', { name: 'View or update tables →' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'View or update tables' })).toBeNull();
     // eslint-disable-next-line testing-library/no-node-access
-    const link = screen.getByText('View or update tables →').closest('.cds--link');
+    const link = screen.getByText('View or update tables').closest('.cds--link');
     expect(link).toBeDefined();
   });
 
@@ -145,13 +145,13 @@ describe('ConfigurationCard', () => {
     render(
       <ConfigurationCard
         title="Title"
-        buttonLabel="View or update tables →"
+        buttonLabel="View or update tables"
         onButtonClick={onButtonClick}
         linkVariant
         disabled
       />,
     );
-    const linkText = screen.getByText('View or update tables →');
+    const linkText = screen.getByText('View or update tables');
     await user.click(linkText);
     expect(onButtonClick).not.toHaveBeenCalled();
   });

--- a/frontend/src/pages/ConfigurationDistrictVolumeList/index.e2e.test.tsx
+++ b/frontend/src/pages/ConfigurationDistrictVolumeList/index.e2e.test.tsx
@@ -36,7 +36,7 @@ test.describe('Configuration District Volume List Page', () => {
       await configLink.click();
       await expect(page).toHaveURL(/\/configuration$/);
 
-      const districtVolumeLink = page.getByRole('button', { name: /View or update tables/ });
+      const districtVolumeLink = page.getByRole('link', { name: /View or update tables/ });
       await districtVolumeLink.click();
       await expect(page).toHaveURL(/\/configuration\/district-volume-tables$/);
     });

--- a/frontend/src/pages/ConfigurationDistrictVolumeList/index.e2e.test.tsx
+++ b/frontend/src/pages/ConfigurationDistrictVolumeList/index.e2e.test.tsx
@@ -36,7 +36,7 @@ test.describe('Configuration District Volume List Page', () => {
       await configLink.click();
       await expect(page).toHaveURL(/\/configuration$/);
 
-      const districtVolumeLink = page.getByRole('link', { name: /View or update tables/ });
+      const districtVolumeLink = page.getByRole('link', { name: /View or update tables/ }).first();
       await districtVolumeLink.click();
       await expect(page).toHaveURL(/\/configuration\/district-volume-tables$/);
     });

--- a/frontend/src/pages/ConfigurationPage/index.e2e.test.tsx
+++ b/frontend/src/pages/ConfigurationPage/index.e2e.test.tsx
@@ -66,7 +66,7 @@ test.describe('Configuration Page', () => {
           'Volume tables used to calculate volumes when district averages are used for waste assessment',
         ),
       ).toBeVisible();
-      await expect(page.getByRole('link', { name: 'View or update tables' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'View or update tables' }).first()).toBeVisible();
     });
 
     test('should navigate to district volume tables when card button is clicked @idir-only', async ({
@@ -82,7 +82,7 @@ test.describe('Configuration Page', () => {
       await page.goto('/configuration');
       await page.waitForLoadState('domcontentloaded');
 
-      await page.getByRole('link', { name: 'View or update tables' }).click();
+      await page.getByRole('link', { name: 'View or update tables' }).first().click();
 
       await expect(page).toHaveURL(/\/configuration\/district-volume-tables$/);
     });

--- a/frontend/src/pages/ConfigurationPage/index.e2e.test.tsx
+++ b/frontend/src/pages/ConfigurationPage/index.e2e.test.tsx
@@ -63,10 +63,10 @@ test.describe('Configuration Page', () => {
       await expect(page.getByText('District average waste volumes')).toBeVisible();
       await expect(
         page.getByText(
-          'Tables used to calculate volumes when district averages are used for waste assessment',
+          'Volume tables used to calculate volumes when district averages are used for waste assessment',
         ),
       ).toBeVisible();
-      await expect(page.getByRole('button', { name: 'View or update tables →' })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'View or update tables' })).toBeVisible();
     });
 
     test('should navigate to district volume tables when card button is clicked @idir-only', async ({
@@ -82,7 +82,7 @@ test.describe('Configuration Page', () => {
       await page.goto('/configuration');
       await page.waitForLoadState('domcontentloaded');
 
-      await page.getByRole('button', { name: 'View or update tables →' }).click();
+      await page.getByRole('link', { name: 'View or update tables' }).click();
 
       await expect(page).toHaveURL(/\/configuration\/district-volume-tables$/);
     });

--- a/frontend/src/pages/ConfigurationPage/index.scss
+++ b/frontend/src/pages/ConfigurationPage/index.scss
@@ -18,7 +18,8 @@
 }
 
 .configuration-section__heading {
-  @include type-style('heading-compact-01');
+  @include type-style('heading-compact-02');
+  font-weight: 700;
   margin-bottom: $spacing-05;
 }
 

--- a/frontend/src/pages/ConfigurationPage/index.scss
+++ b/frontend/src/pages/ConfigurationPage/index.scss
@@ -1,10 +1,29 @@
 @use '../../styles/variables' as vars;
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/react/scss/breakpoint' as *;
+@use '@carbon/type' as *;
 
 .configuration-column__header {
   margin-bottom: $spacing-08;
+
   @include breakpoint-down(md) {
     margin: $spacing-04;
   }
+}
+
+.configuration-section {
+  background-color: var(--cds-layer-01);
+  border-radius: 0.25rem;
+  padding: $spacing-05;
+}
+
+.configuration-section__heading {
+  @include type-style('heading-compact-01');
+  margin-bottom: $spacing-05;
+}
+
+.configuration-section__cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-05;
 }

--- a/frontend/src/pages/ConfigurationPage/index.tsx
+++ b/frontend/src/pages/ConfigurationPage/index.tsx
@@ -1,4 +1,4 @@
-import { Column } from '@carbon/react';
+import { Column, Link } from '@carbon/react';
 import { useNavigate } from '@tanstack/react-router';
 import { type FC } from 'react';
 
@@ -31,7 +31,7 @@ const ConfigurationPage: FC = () => {
           title="District average waste volumes"
           description="Tables used to calculate volumes when district averages are used for waste assessment"
           buttonLabel="View or update tables →"
-          kind="tertiary"
+          linkVariant={true}
           onButtonClick={() => navigateInTree(navigate, '/configuration/district-volume-tables')}
         />
       </Column>

--- a/frontend/src/pages/ConfigurationPage/index.tsx
+++ b/frontend/src/pages/ConfigurationPage/index.tsx
@@ -1,4 +1,4 @@
-import { AccumulationRain, CropGrowth } from '@carbon/icons-react';
+import { AccumulationRain, ArrowRight, CropGrowth } from '@carbon/icons-react';
 import { Column } from '@carbon/react';
 import { useNavigate } from '@tanstack/react-router';
 import { type FC } from 'react';
@@ -38,6 +38,7 @@ const ConfigurationPage: FC = () => {
               description="Volume tables used to calculate volumes when district averages are used for waste assessment"
               buttonLabel="View or update tables"
               linkVariant={true}
+              linkIcon={<ArrowRight />}
               onButtonClick={() =>
                 navigateInTree(navigate, '/configuration/district-volume-tables')
               }
@@ -49,6 +50,7 @@ const ConfigurationPage: FC = () => {
               description="Species composition table used to calculate volumes when HBS mark monthly billing report is not available"
               buttonLabel="View or update tables"
               linkVariant={true}
+              linkIcon={<ArrowRight />}
               disabled={true}
               onButtonClick={() => {}}
             />

--- a/frontend/src/pages/ConfigurationPage/index.tsx
+++ b/frontend/src/pages/ConfigurationPage/index.tsx
@@ -1,4 +1,5 @@
-import { Column, Link } from '@carbon/react';
+import { AccumulationRain, CropGrowth } from '@carbon/icons-react';
+import { Column } from '@carbon/react';
 import { useNavigate } from '@tanstack/react-router';
 import { type FC } from 'react';
 
@@ -27,13 +28,32 @@ const ConfigurationPage: FC = () => {
       </Column>
 
       <Column lg={16} md={8} sm={4} className="configuration-column__cards">
-        <ConfigurationCard
-          title="District average waste volumes"
-          description="Tables used to calculate volumes when district averages are used for waste assessment"
-          buttonLabel="View or update tables →"
-          linkVariant={true}
-          onButtonClick={() => navigateInTree(navigate, '/configuration/district-volume-tables')}
-        />
+        <div className="configuration-section">
+          <p className="configuration-section__heading">District average criteria</p>
+
+          <div className="configuration-section__cards">
+            <ConfigurationCard
+              icon={<AccumulationRain />}
+              title="District average waste volumes"
+              description="Volume tables used to calculate volumes when district averages are used for waste assessment"
+              buttonLabel="View or update tables →"
+              linkVariant={true}
+              onButtonClick={() =>
+                navigateInTree(navigate, '/configuration/district-volume-tables')
+              }
+            />
+
+            <ConfigurationCard
+              icon={<CropGrowth />}
+              title="District level species composition"
+              description="Species composition table used to calculate volumes when HBS mark monthly billing report is not available"
+              buttonLabel="View or update tables →"
+              linkVariant={true}
+              disabled={true}
+              onButtonClick={() => {}}
+            />
+          </div>
+        </div>
       </Column>
     </>
   );

--- a/frontend/src/pages/ConfigurationPage/index.tsx
+++ b/frontend/src/pages/ConfigurationPage/index.tsx
@@ -36,7 +36,7 @@ const ConfigurationPage: FC = () => {
               icon={<AccumulationRain />}
               title="District average waste volumes"
               description="Volume tables used to calculate volumes when district averages are used for waste assessment"
-              buttonLabel="View or update tables →"
+              buttonLabel="View or update tables"
               linkVariant={true}
               onButtonClick={() =>
                 navigateInTree(navigate, '/configuration/district-volume-tables')
@@ -47,7 +47,7 @@ const ConfigurationPage: FC = () => {
               icon={<CropGrowth />}
               title="District level species composition"
               description="Species composition table used to calculate volumes when HBS mark monthly billing report is not available"
-              buttonLabel="View or update tables →"
+              buttonLabel="View or update tables"
               linkVariant={true}
               disabled={true}
               onButtonClick={() => {}}

--- a/frontend/src/pages/ConfigurationPage/index.tsx
+++ b/frontend/src/pages/ConfigurationPage/index.tsx
@@ -52,7 +52,6 @@ const ConfigurationPage: FC = () => {
               linkVariant={true}
               linkIcon={<ArrowRight />}
               disabled={true}
-              onButtonClick={() => {}}
             />
           </div>
         </div>

--- a/frontend/src/pages/ConfigurationPage/index.tsx
+++ b/frontend/src/pages/ConfigurationPage/index.tsx
@@ -29,7 +29,7 @@ const ConfigurationPage: FC = () => {
 
       <Column lg={16} md={8} sm={4} className="configuration-column__cards">
         <div className="configuration-section">
-          <p className="configuration-section__heading">District average criteria</p>
+          <h2 className="configuration-section__heading">District average criteria</h2>
 
           <div className="configuration-section__cards">
             <ConfigurationCard

--- a/frontend/src/pages/ConfigurationPage/index.unit.test.tsx
+++ b/frontend/src/pages/ConfigurationPage/index.unit.test.tsx
@@ -61,7 +61,7 @@ describe('ConfigurationPage', () => {
 
   it('renders the card action link for district waste volumes', () => {
     render(<ConfigurationPage />);
-    const links = screen.getAllByText('View or update tables →');
+    const links = screen.getAllByText('View or update tables');
     expect(links.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -69,7 +69,7 @@ describe('ConfigurationPage', () => {
     const user = userEvent.setup();
     render(<ConfigurationPage />);
 
-    const links = screen.getAllByText('View or update tables →');
+    const links = screen.getAllByText('View or update tables');
     await user.click(links[0]);
 
     expect(navigateInTree).toHaveBeenCalledOnce();
@@ -95,7 +95,7 @@ describe('ConfigurationPage', () => {
     const user = userEvent.setup();
     render(<ConfigurationPage />);
 
-    const links = screen.getAllByText('View or update tables →');
+    const links = screen.getAllByText('View or update tables');
     // links[1] is the species composition card (second card, disabled)
     await user.click(links[1]);
 

--- a/frontend/src/pages/ConfigurationPage/index.unit.test.tsx
+++ b/frontend/src/pages/ConfigurationPage/index.unit.test.tsx
@@ -42,6 +42,11 @@ describe('ConfigurationPage', () => {
     screen.getByText('Check and manage configuration data');
   });
 
+  it('renders the section heading "District average criteria"', () => {
+    render(<ConfigurationPage />);
+    screen.getByText('District average criteria');
+  });
+
   it('renders the district volume card title', () => {
     render(<ConfigurationPage />);
     screen.getByText('District average waste volumes');
@@ -50,25 +55,50 @@ describe('ConfigurationPage', () => {
   it('renders the card description', () => {
     render(<ConfigurationPage />);
     screen.getByText(
-      'Tables used to calculate volumes when district averages are used for waste assessment',
+      'Volume tables used to calculate volumes when district averages are used for waste assessment',
     );
   });
 
-  it('renders the card action button', () => {
+  it('renders the card action link for district waste volumes', () => {
     render(<ConfigurationPage />);
-    screen.getByRole('button', { name: 'View or update tables →' });
+    const links = screen.getAllByText('View or update tables →');
+    expect(links.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('calls navigateInTree with correct path when button is clicked', async () => {
+  it('calls navigateInTree with correct path when first card link is clicked', async () => {
     const user = userEvent.setup();
     render(<ConfigurationPage />);
 
-    await user.click(screen.getByRole('button', { name: 'View or update tables →' }));
+    const links = screen.getAllByText('View or update tables →');
+    await user.click(links[0]);
 
     expect(navigateInTree).toHaveBeenCalledOnce();
     expect(navigateInTree).toHaveBeenCalledWith(
       mockNavigate,
       '/configuration/district-volume-tables',
     );
+  });
+
+  it('renders the species composition card title', () => {
+    render(<ConfigurationPage />);
+    screen.getByText('District level species composition');
+  });
+
+  it('renders the species composition card description', () => {
+    render(<ConfigurationPage />);
+    screen.getByText(
+      'Species composition table used to calculate volumes when HBS mark monthly billing report is not available',
+    );
+  });
+
+  it('species composition card link does not call navigateInTree when clicked', async () => {
+    const user = userEvent.setup();
+    render(<ConfigurationPage />);
+
+    const links = screen.getAllByText('View or update tables →');
+    // links[1] is the species composition card (second card, disabled)
+    await user.click(links[1]);
+
+    expect(navigateInTree).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/DistrictVolumeTableDetail/navigation.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/navigation.e2e.test.tsx
@@ -47,7 +47,10 @@ test.describe('District Volume Table Detail — Navigation & Access Control', ()
       await expect(page).toHaveURL(/\/configuration$/);
 
       // Step 3: Click "View or update tables" link
-      await page.getByRole('link', { name: /View or update tables/ }).click();
+      await page
+        .getByRole('link', { name: /View or update tables/ })
+        .first()
+        .click();
       await expect(page).toHaveURL(/\/configuration\/district-volume-tables$/);
 
       // Step 4: Click on the first Interior row's "See details" action (id=1, current)
@@ -92,7 +95,10 @@ test.describe('District Volume Table Detail — Navigation & Access Control', ()
       await expect(page).toHaveURL(/\/configuration$/);
 
       // Step 3: Click "View or update tables" link
-      await page.getByRole('link', { name: /View or update tables/ }).click();
+      await page
+        .getByRole('link', { name: /View or update tables/ })
+        .first()
+        .click();
       await expect(page).toHaveURL(/\/configuration\/district-volume-tables$/);
 
       // Step 4: Click on the first Coast row's "See details" action (id=4, current)

--- a/frontend/src/pages/DistrictVolumeTableDetail/navigation.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/navigation.e2e.test.tsx
@@ -46,8 +46,8 @@ test.describe('District Volume Table Detail — Navigation & Access Control', ()
       await configLink.click();
       await expect(page).toHaveURL(/\/configuration$/);
 
-      // Step 3: Click "View or update tables" button
-      await page.getByRole('button', { name: /View or update tables/ }).click();
+      // Step 3: Click "View or update tables" link
+      await page.getByRole('link', { name: /View or update tables/ }).click();
       await expect(page).toHaveURL(/\/configuration\/district-volume-tables$/);
 
       // Step 4: Click on the first Interior row's "See details" action (id=1, current)
@@ -91,8 +91,8 @@ test.describe('District Volume Table Detail — Navigation & Access Control', ()
       await configLink.click();
       await expect(page).toHaveURL(/\/configuration$/);
 
-      // Step 3: Click "View or update tables" button
-      await page.getByRole('button', { name: /View or update tables/ }).click();
+      // Step 3: Click "View or update tables" link
+      await page.getByRole('link', { name: /View or update tables/ }).click();
       await expect(page).toHaveURL(/\/configuration\/district-volume-tables$/);
 
       // Step 4: Click on the first Coast row's "See details" action (id=4, current)

--- a/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
@@ -100,8 +100,8 @@ test.describe('District Volume Table Upload Page - E2E', () => {
       await page.getByTestId('side-nav-link-config').click();
       await expect(page).toHaveURL(/\/configuration$/);
 
-      // Click the "View or update tables" button
-      await page.getByRole('button', { name: /View or update tables/i }).click();
+      // Click the "View or update tables" link
+      await page.getByRole('link', { name: /View or update tables/i }).click();
       await expect(page).toHaveURL(/\/configuration\/district-volume-tables$/);
 
       // Click the upload button

--- a/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
@@ -101,7 +101,10 @@ test.describe('District Volume Table Upload Page - E2E', () => {
       await expect(page).toHaveURL(/\/configuration$/);
 
       // Click the "View or update tables" link
-      await page.getByRole('link', { name: /View or update tables/i }).click();
+      await page
+        .getByRole('link', { name: /View or update tables/i })
+        .first()
+        .click();
       await expect(page).toHaveURL(/\/configuration\/district-volume-tables$/);
 
       // Click the upload button


### PR DESCRIPTION
<!-- generated-by: opencode pull-request-description-generator; created-at: 2026-07-07T18:00:00Z -->
<!-- Provide a general summary of your changes in the Title above -->

# Description

Aligns the Configuration Page and Configuration Card components with the latest Figma designs for issue #1034.

**ConfigurationCard:**
- Added `icon`, `linkVariant`, and `linkIcon` props for richer card rendering
- Renders icon above title, supports link with custom icon
- Allows button to be disabled; removed empty `onButtonClick` handler
- Updated SCSS per Figma: removed square sizing, added icon/link styles, updated button label styles

**ConfigurationPage:**
- Restructured with section wrapper, headings, and card layout styles per Figma
- Updated heading style to use `heading-compact-02` with correct font weight

**Other:**
- Removed `.eslintignore` file (moved config to `eslint.config.js`)
- Suppressed eslint warnings for intentional DOM access in tests

Fixes #1034

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

- [X] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [X] Updated existing tests

Tests added for ConfigurationCard (icon rendering, linkVariant, linkIcon, disabled state) and ConfigurationPage (section wrapper layout, heading styles).

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

- [X] Not applicable: no feature-flag-controlled behavior changed in this PR
- [ ] Canonical key follows `<domain>-<capability>-enabled`
- [ ] Frontend and backend use the same canonical key
- [ ] Default state is documented per environment
- [ ] Owner, rollout plan, and removal criteria are documented
- [ ] Tests cover enabled, disabled, and undefined behavior
- [ ] A removal target date is assigned for short-lived flags

## Further comments

This PR covers the frontend-only alignment of the Configuration page components with the Figma mockups. No backend or feature-flag changes required.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-37-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)