### PR TITLE
fix(#1038): recognize coastal district volume uploads

### DIFF
--- a/frontend/src/components/waste/DistrictVolumeUpload/index.tsx
+++ b/frontend/src/components/waste/DistrictVolumeUpload/index.tsx
@@ -114,7 +114,10 @@ const DistrictVolumeTableUpload: FC = () => {
 
   /**
    * Processes the results emitted by {@link FileUploadInput} after the spreadsheet is parsed.
-   * Updates the form's `area` and `tableData` fields to match the parsed file.
+   * Validates that the uploaded file type matches the currently selected area.
+   * If the file type does not match the selected area, sets a file-level error
+   * and rejects the file without updating form state.
+   * Otherwise, updates the form's `area` and `tableData` fields to match the parsed file.
    * For Coastal files, also reads the heli multiplier extracted from the spreadsheet.
    *
    * @param results - Array of parsed table data returned by the file processor.
@@ -125,6 +128,18 @@ const DistrictVolumeTableUpload: FC = () => {
 
       const data = results[0];
       if (!data) return;
+
+      // Check for area/file type mismatch
+      const currentArea = form.getFieldValue('area');
+      if (currentArea !== data.type) {
+        const areaLabel = currentArea === 'INTERIOR' ? 'Interior' : 'Coast';
+        const fileTypeLabel = data.type === 'COASTAL' ? 'Coast' : 'Interior';
+        setFileErrors([
+          `Area mismatch: "${areaLabel}" is selected, but the uploaded file is a "${fileTypeLabel}" spreadsheet. ` +
+            `Please select "${fileTypeLabel}" as the area or upload a "${areaLabel}" spreadsheet instead.`,
+        ]);
+        return;
+      }
 
       setFileErrors([]);
       form.setFieldValue('area', data.type);
@@ -284,8 +299,31 @@ const DistrictVolumeTableUpload: FC = () => {
               const reader = new ExcelReader();
               const sheets = await reader.listSheets(file);
               const upperSheets = sheets.map((s) => s.trim().toUpperCase());
-              if (upperSheets.includes('COAST')) return coastValidator(file);
-              if (upperSheets.includes('INTERIOR')) return interiorValidator(file);
+
+              // Detect the file type from sheet names
+              const detectedType = upperSheets.some((sheet) => sheet.includes('COAST'))
+                ? 'COASTAL'
+                : upperSheets.some((sheet) => sheet.includes('INTERIOR'))
+                  ? 'INTERIOR'
+                  : null;
+
+              if (detectedType) {
+                // Check for area/file type mismatch before format validation
+                const currentArea = form.getFieldValue('area');
+                if (currentArea !== detectedType) {
+                  const areaLabel = currentArea === 'INTERIOR' ? 'Interior' : 'Coast';
+                  const fileTypeLabel = detectedType === 'COASTAL' ? 'Coast' : 'Interior';
+                  return [
+                    `Area mismatch: "${areaLabel}" is selected, but the uploaded file is a "${fileTypeLabel}" spreadsheet. ` +
+                      `Please select "${fileTypeLabel}" as the area or upload a "${areaLabel}" spreadsheet instead.`,
+                  ];
+                }
+
+                // Area matches — proceed with format validation
+                if (detectedType === 'COASTAL') return coastValidator(file);
+                return interiorValidator(file);
+              }
+
               return [
                 'Could not detect spreadsheet format. Expected a sheet named "Interior" or "Coast".',
               ];

--- a/frontend/src/components/waste/DistrictVolumeUpload/index.tsx
+++ b/frontend/src/components/waste/DistrictVolumeUpload/index.tsx
@@ -101,6 +101,21 @@ const DistrictVolumeTableUpload: FC = () => {
     },
   });
 
+  const resetUploadedTableData = useCallback(
+    (
+      selectedArea: 'INTERIOR' | 'COASTAL' = form.getFieldValue('area') as 'INTERIOR' | 'COASTAL',
+    ) => {
+      const clearedData =
+        selectedArea === 'COASTAL'
+          ? ({ type: 'COASTAL', sections: [], formulas: {} } as CoastData)
+          : ({ type: 'INTERIOR', zones: [], formulas: {} } as InteriorData);
+
+      form.setFieldValue('tableData', clearedData);
+      form.setFieldValue('heliMultiplier', 1);
+    },
+    [form],
+  );
+
   /**
    * Handles form submission by clearing any prior error and invoking the TanStack form submit.
    * Catches validation or mutation errors and surfaces them as an inline error message.
@@ -138,6 +153,7 @@ const DistrictVolumeTableUpload: FC = () => {
           `Area mismatch: "${areaLabel}" is selected, but the uploaded file is a "${fileTypeLabel}" spreadsheet. ` +
             `Please select "${fileTypeLabel}" as the area or upload a "${areaLabel}" spreadsheet instead.`,
         ]);
+        resetUploadedTableData(currentArea);
         return;
       }
 
@@ -149,7 +165,7 @@ const DistrictVolumeTableUpload: FC = () => {
         form.setFieldValue('heliMultiplier', processor.heliMultiplier ?? 1);
       }
     },
-    [form],
+    [form, resetUploadedTableData],
   );
 
   /**
@@ -311,6 +327,7 @@ const DistrictVolumeTableUpload: FC = () => {
                 // Check for area/file type mismatch before format validation
                 const currentArea = form.getFieldValue('area');
                 if (currentArea !== detectedType) {
+                  resetUploadedTableData(currentArea);
                   const areaLabel = currentArea === 'INTERIOR' ? 'Interior' : 'Coast';
                   const fileTypeLabel = detectedType === 'COASTAL' ? 'Coast' : 'Interior';
                   return [
@@ -320,14 +337,24 @@ const DistrictVolumeTableUpload: FC = () => {
                 }
 
                 // Area matches — proceed with format validation
-                if (detectedType === 'COASTAL') return coastValidator(file);
-                return interiorValidator(file);
+                const validationErrors =
+                  detectedType === 'COASTAL'
+                    ? await coastValidator(file)
+                    : await interiorValidator(file);
+
+                if (validationErrors.length > 0) {
+                  resetUploadedTableData(currentArea);
+                }
+
+                return validationErrors;
               }
 
+              resetUploadedTableData(form.getFieldValue('area'));
               return [
                 'Could not detect spreadsheet format. Expected a sheet named "Interior" or "Coast".',
               ];
             } catch (e) {
+              resetUploadedTableData(form.getFieldValue('area'));
               return [(e as Error).message];
             }
           }}

--- a/frontend/src/components/waste/DistrictVolumeUpload/index.unit.test.tsx
+++ b/frontend/src/components/waste/DistrictVolumeUpload/index.unit.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -84,29 +84,14 @@ vi.mock('@/components/Form/FileUploadInput', () => ({
         type="file"
         data-testid="mock-file-input"
         onChange={async (e) => {
-          console.log('[DEBUG mock onChange] fired');
           if (e.target.files?.[0]) {
-            console.log('[DEBUG mock onChange] file received:', e.target.files[0].name);
-            // Run validation first (mirrors real component behaviour)
             if (validator) {
-              console.log('[DEBUG mock onChange] calling validator...');
               const errors = await validator(e.target.files[0]);
-              console.log(
-                '[DEBUG mock onChange] validator returned:',
-                JSON.stringify(errors),
-                'length:',
-                errors?.length,
-              );
               if (errors && errors.length > 0) {
-                console.log('[DEBUG mock onChange] validator rejected file');
                 return;
               }
             }
-            console.log(
-              '[DEBUG mock onChange] validator passed, calling onProcessed with:',
-              JSON.stringify(mockTableData.current),
-            );
-            // Validation passed — simulate successful processing
+
             onProcessed([mockTableData.current] as TableData[]);
           }
         }}
@@ -502,11 +487,9 @@ describe('DistrictVolumeTableUpload', () => {
         );
       });
 
-      // 3. Submit the form by dispatching a submit event on the <form> element.
-      // Using fireEvent.submit avoids issues with the button being disabled during
-      // TanStack Form's async validation cycle after setFieldValue.
-      const formEl = screen.getByTestId('district-volume-upload-column').querySelector('form')!;
-      fireEvent.submit(formEl);
+      // 3. Submit the form by clicking the Upload table button after the async
+      // validation cycle resolves.
+      await user.click(screen.getByRole('button', { name: 'Upload table' }));
 
       await waitFor(() => {
         expect(mockMutateAsync).toHaveBeenCalledWith(

--- a/frontend/src/components/waste/DistrictVolumeUpload/index.unit.test.tsx
+++ b/frontend/src/components/waste/DistrictVolumeUpload/index.unit.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -15,6 +15,37 @@ import * as inTreePaths from '@/routes/inTreePaths';
 // Mocks
 // ============================================================================
 
+/**
+ * Hoisted mock utilities shared across module-level mocks.
+ *
+ * - `mockListSheets` controls what ExcelReader.listSheets() returns
+ * - `mockTableData` controls what FileUploadInput's onProcessed receives
+ * - `coastValidator` / `interiorValidator` intercept format-validation calls
+ */
+const { mockListSheets, mockTableData, coastValidator, interiorValidator } = vi.hoisted(() => ({
+  mockListSheets: vi.fn().mockResolvedValue(['Interior']),
+  mockTableData: { current: null as unknown },
+  coastValidator: vi.fn().mockResolvedValue([] as string[]),
+  interiorValidator: vi.fn().mockResolvedValue([] as string[]),
+}));
+
+// Mock ExcelReader so the validator doesn't need real .xlsx files
+// Must use a regular function (not arrow) so `new ExcelReader()` works as a constructor.
+vi.mock('@/services/spreadsheet/excelReader', () => ({
+  ExcelReader: vi.fn().mockImplementation(function () {
+    return { listSheets: mockListSheets };
+  }),
+}));
+
+// Mock the format-specific validators the component validator delegates to
+vi.mock('@/services/districtvolumes/validators/coastValidator', () => ({
+  coastValidator,
+}));
+
+vi.mock('@/services/districtvolumes/validators/interiorValidator', () => ({
+  interiorValidator,
+}));
+
 vi.mock('@/config/react-query/hooks');
 
 const mockMutateAsync = vi.fn();
@@ -26,14 +57,25 @@ vi.mock('@/routes/inTreePaths', () => ({
   navigateInTree: vi.fn(),
 }));
 
-// Mock FileUploadInput to avoid Excel processing in tests
+/**
+ * FileUploadInput mock that mirrors the real component's validation flow:
+ *
+ * 1. Calls the `validator` prop with the selected file
+ * 2. If validator returns errors → file is rejected, onProcessed is NOT called
+ * 3. If validator passes → onProcessed is called with the current mockTableData
+ *
+ * This lets tests exercise the area-mismatch & format-detection logic in the
+ * component's inlined validator function.
+ */
 vi.mock('@/components/Form/FileUploadInput', () => ({
   default: ({
     onProcessed,
     externalErrors,
+    validator,
   }: {
     onProcessed: (results: TableData[]) => void;
     externalErrors?: string[];
+    validator?: (file: File) => Promise<string[]>;
   }) => (
     <div data-testid="file-upload-input">
       <label htmlFor="mock-file-input">Upload spreadsheet</label>
@@ -41,16 +83,31 @@ vi.mock('@/components/Form/FileUploadInput', () => ({
         id="mock-file-input"
         type="file"
         data-testid="mock-file-input"
-        onChange={(e) => {
-          // Simulate processor returning interior data
+        onChange={async (e) => {
+          console.log('[DEBUG mock onChange] fired');
           if (e.target.files?.[0]) {
-            onProcessed([
-              {
-                type: 'INTERIOR',
-                zones: [{ name: 'Dry belt', districts: [] }],
-                formulas: {},
-              },
-            ]);
+            console.log('[DEBUG mock onChange] file received:', e.target.files[0].name);
+            // Run validation first (mirrors real component behaviour)
+            if (validator) {
+              console.log('[DEBUG mock onChange] calling validator...');
+              const errors = await validator(e.target.files[0]);
+              console.log(
+                '[DEBUG mock onChange] validator returned:',
+                JSON.stringify(errors),
+                'length:',
+                errors?.length,
+              );
+              if (errors && errors.length > 0) {
+                console.log('[DEBUG mock onChange] validator rejected file');
+                return;
+              }
+            }
+            console.log(
+              '[DEBUG mock onChange] validator passed, calling onProcessed with:',
+              JSON.stringify(mockTableData.current),
+            );
+            // Validation passed — simulate successful processing
+            onProcessed([mockTableData.current] as TableData[]);
           }
         }}
       />
@@ -87,6 +144,15 @@ describe('DistrictVolumeTableUpload', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseDistrictVolumeTableCreateMutation.mockReturnValue(createDefaultMutationReturn());
+    // Restore hoisted mock defaults
+    mockListSheets.mockResolvedValue(['Interior']);
+    mockTableData.current = {
+      type: 'INTERIOR' as const,
+      zones: [{ name: 'Dry belt', districts: [] }],
+      formulas: {},
+    } as unknown;
+    coastValidator.mockResolvedValue([]);
+    interiorValidator.mockResolvedValue([]);
   });
 
   describe('rendering', () => {
@@ -263,6 +329,209 @@ describe('DistrictVolumeTableUpload', () => {
       await renderWithAppAsync(<DistrictVolumeTableUpload />);
 
       expect(screen.getByTestId('district-volume-upload-column')).toBeTruthy();
+    });
+  });
+
+  describe('validator (area/file-type mismatch detection)', () => {
+    it('should accept a file when detected type matches the selected area (Interior)', async () => {
+      const user = userEvent.setup();
+      await renderWithAppAsync(<DistrictVolumeTableUpload />);
+
+      // Default area is INTERIOR, default mockListSheets returns ['Interior']
+      const fileInput = screen.getByTestId('mock-file-input');
+      await user.upload(
+        fileInput,
+        new File(['test'], 'interior.xlsx', {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        }),
+      );
+
+      // Validator passed → onProcessed was called → file errors stay empty & Interior stays checked
+      await waitFor(() => {
+        expect((screen.getByLabelText('Interior') as HTMLInputElement).checked).toBe(true);
+      });
+      expect(screen.queryByTestId('file-error')).toBeNull();
+    });
+
+    it('should reject a Coast file when Interior is selected', async () => {
+      const user = userEvent.setup();
+      await renderWithAppAsync(<DistrictVolumeTableUpload />);
+
+      // Make ExcelReader report Coast-style sheet names
+      mockListSheets.mockResolvedValue(['Coast Districts']);
+
+      const fileInput = screen.getByTestId('mock-file-input');
+      await user.upload(
+        fileInput,
+        new File(['test'], 'coast.xlsx', {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        }),
+      );
+
+      // Validator rejects the file — onProcessed is never called, Interior stays selected
+      await waitFor(() => {
+        expect((screen.getByLabelText('Interior') as HTMLInputElement).checked).toBe(true);
+      });
+    });
+
+    it('should reject an Interior file when Coast is selected', async () => {
+      const user = userEvent.setup();
+      await renderWithAppAsync(<DistrictVolumeTableUpload />);
+
+      // First switch area to Coast
+      await user.click(screen.getByLabelText('Coast'));
+
+      // mockListSheets already defaults to ['Interior']
+      const fileInput = screen.getByTestId('mock-file-input');
+      await user.upload(
+        fileInput,
+        new File(['test'], 'interior.xlsx', {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        }),
+      );
+
+      // Validator rejects the file — area stays Coast
+      await waitFor(() => {
+        expect((screen.getByLabelText('Coast') as HTMLInputElement).checked).toBe(true);
+      });
+    });
+
+    it('should return a format error when sheet names are unrecognized', async () => {
+      const user = userEvent.setup();
+      await renderWithAppAsync(<DistrictVolumeTableUpload />);
+
+      mockListSheets.mockResolvedValue(['Unknown Sheet']);
+
+      // The validator can't match "COAST" or "INTERIOR" and returns a format error.
+      // The mock rejects the file when errors are present, so onProcessed is not called.
+      const fileInput = screen.getByTestId('mock-file-input');
+      await user.upload(
+        fileInput,
+        new File(['test'], 'unknown.xlsx', {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        }),
+      );
+
+      // Interior stays selected (default) since onProcessed was never called
+      await waitFor(() => {
+        expect((screen.getByLabelText('Interior') as HTMLInputElement).checked).toBe(true);
+      });
+    });
+
+    it('should catch and return errors thrown during sheet inspection', async () => {
+      const user = userEvent.setup();
+      await renderWithAppAsync(<DistrictVolumeTableUpload />);
+
+      mockListSheets.mockRejectedValue(new Error('Corrupted file'));
+
+      const fileInput = screen.getByTestId('mock-file-input');
+      await user.upload(
+        fileInput,
+        new File(['test'], 'corrupted.xlsx', {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        }),
+      );
+
+      // Validator's catch block returns the error message; onProcessed never called
+      await waitFor(() => {
+        expect((screen.getByLabelText('Interior') as HTMLInputElement).checked).toBe(true);
+      });
+    });
+  });
+
+  describe('file upload processing (handleFileChange)', () => {
+    it('should update area to COASTAL and set heliMultiplier when a Coast-file result is processed', async () => {
+      const user = userEvent.setup();
+      await renderWithAppAsync(<DistrictVolumeTableUpload />);
+
+      // Switch area to Coast first so the mismatch guard doesn't block
+      await user.click(screen.getByLabelText('Coast'));
+
+      // Set up the mock to return Coast data
+      mockTableData.current = {
+        type: 'COASTAL',
+        sections: [{ name: 'Mature', districts: [] }],
+        formulas: {},
+      } as unknown;
+
+      // Also need the validator to pass — mock sheets containing "COAST"
+      mockListSheets.mockResolvedValue(['Coast Districts']);
+
+      const fileInput = screen.getByTestId('mock-file-input');
+      await user.upload(
+        fileInput,
+        new File(['test'], 'coast.xlsx', {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        }),
+      );
+
+      await waitFor(() => {
+        expect((screen.getByLabelText('Coast') as HTMLInputElement).checked).toBe(true);
+      });
+    });
+  });
+
+  describe('form submission', () => {
+    it('should successfully submit a valid COASTAL form', async () => {
+      const user = userEvent.setup();
+      await renderWithAppAsync(<DistrictVolumeTableUpload />);
+
+      // 1. Switch area to Coast
+      await user.click(screen.getByLabelText('Coast'));
+
+      // 2. Upload a Coast file so tableData gets populated with sections
+      mockTableData.current = {
+        type: 'COASTAL',
+        sections: [{ name: 'Mature', districts: [] }],
+        formulas: {},
+      } as unknown;
+      mockListSheets.mockResolvedValue(['Coast Districts']);
+
+      const fileInput = screen.getByTestId('mock-file-input');
+      await user.upload(
+        fileInput,
+        new File(['test'], 'coast.xlsx', {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        }),
+      );
+
+      // Wait for async validators to settle & re-render
+      await waitFor(() => {
+        expect((screen.getByTestId('upload-table-button') as HTMLButtonElement).disabled).toBe(
+          false,
+        );
+      });
+
+      // 3. Submit the form by dispatching a submit event on the <form> element.
+      // Using fireEvent.submit avoids issues with the button being disabled during
+      // TanStack Form's async validation cycle after setFieldValue.
+      const formEl = screen.getByTestId('district-volume-upload-column').querySelector('form')!;
+      fireEvent.submit(formEl);
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            area: 'COASTAL' as const,
+            startDate: expect.any(String),
+          }),
+        );
+      });
+    });
+
+    it('should display a submit error when the mutation fails', async () => {
+      const user = userEvent.setup();
+      await renderWithAppAsync(<DistrictVolumeTableUpload />);
+
+      // Make mutateAsync reject on submission
+      mockMutateAsync.mockRejectedValue(new Error('API failure'));
+
+      // Click submit — form validation fails (no file uploaded)
+      await user.click(screen.getByRole('button', { name: 'Upload table' }));
+
+      // The submit error should appear
+      await waitFor(() => {
+        expect(screen.getByTestId('submit-error')).toBeTruthy();
+      });
     });
   });
 });

--- a/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
@@ -209,6 +209,10 @@ test.describe('District Volume Table Upload Page - E2E', () => {
       await page.goto('/configuration/upload-district-volume');
       await page.waitForLoadState('domcontentloaded');
 
+      // Select "Coast" first — the validator rejects files that don't match the selected area
+      await page.getByLabel('Coast').click();
+      await expect(page.getByLabel('Coast')).toBeChecked();
+
       // Upload a valid Coast spreadsheet
       const buffer = await buildValidCoastBuffer();
       await uploadFile(page, buffer);
@@ -217,7 +221,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
       const fileItem = page.getByTestId('file-upload-item');
       await expect(fileItem).toBeVisible({ timeout: 10_000 });
 
-      // The Coast radio should now be selected (file data overrides the default)
+      // The Coast radio should remain selected
       await expect(page.getByLabel('Coast')).toBeChecked();
 
       // The radio group should be visible
@@ -374,6 +378,10 @@ test.describe('District Volume Table Upload Page - E2E', () => {
 
       await page.goto('/configuration/upload-district-volume');
       await page.waitForLoadState('domcontentloaded');
+
+      // Select "Coast" first — the validator rejects files that don't match the selected area
+      await page.getByLabel('Coast').click();
+      await expect(page.getByLabel('Coast')).toBeChecked();
 
       // Step 1: Upload a valid Coast spreadsheet
       const buffer = await buildValidCoastBuffer();

--- a/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
@@ -209,8 +209,9 @@ test.describe('District Volume Table Upload Page - E2E', () => {
       await page.goto('/configuration/upload-district-volume');
       await page.waitForLoadState('domcontentloaded');
 
-      // Select "Coast" first — the validator rejects files that don't match the selected area
-      await page.getByLabel('Coast').click();
+      // Select "Coast" first — the validator rejects files that don't match the selected area.
+      // Carbon renders radio inputs as visually-hidden; click the <label> instead.
+      await page.locator('label[for="area-coast"]').click();
       await expect(page.getByLabel('Coast')).toBeChecked();
 
       // Upload a valid Coast spreadsheet
@@ -379,8 +380,9 @@ test.describe('District Volume Table Upload Page - E2E', () => {
       await page.goto('/configuration/upload-district-volume');
       await page.waitForLoadState('domcontentloaded');
 
-      // Select "Coast" first — the validator rejects files that don't match the selected area
-      await page.getByLabel('Coast').click();
+      // Select "Coast" first — the validator rejects files that don't match the selected area.
+      // Carbon renders radio inputs as visually-hidden; click the <label> instead.
+      await page.locator('label[for="area-coast"]').click();
       await expect(page.getByLabel('Coast')).toBeChecked();
 
       // Step 1: Upload a valid Coast spreadsheet


### PR DESCRIPTION
<!-- generated-by: copilot-skill pull-request-description-generator; created-at:
2026-07-07T12:15:00Z -->
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include
relevant context. List dependency changes.

Fixes #1038

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

## How Has This Been Tested?

- [x] New unit tests
- [ ] New integrated tests
- [x] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [x] Updated existing tests

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature
      works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR

## Further comments

This PR fixes the district volume upload flow for coastal spreadsheets whose
sheet names contain values such as "Coast Districts". The upload validator now
recognizes those sheet names, rejects mismatched area/file combinations before
processing, and preserves the uploaded coastal `tableData` for form
submission. Regression tests were added to cover the validator, file-processing
path, and successful coastal submission flow.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-39-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)