### PR TITLE
feat(#1061): include district description in district volume detail views

### DIFF
--- a/frontend/src/components/waste/CodeDescriptionTag/index.tsx
+++ b/frontend/src/components/waste/CodeDescriptionTag/index.tsx
@@ -12,7 +12,7 @@ import type { CodeDescriptionDto } from '@/services/search.types';
 const CodeDescriptionTag: FC<{ value: CodeDescriptionDto }> = ({ value }) => {
   return (
     <span>
-      {value.code} - {value.description}
+      {value.code === value.description ? value.code : `${value.code} - ${value.description}`}
     </span>
   );
 };

--- a/frontend/src/components/waste/DistrictVolumeDetail/CoastDetailView.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/CoastDetailView.tsx
@@ -1,13 +1,13 @@
-import { useMemo, type FC } from 'react';
+import { type FC } from 'react';
 
 import DistrictVolumeDetailHeader from './DistrictVolumeDetailHeader';
 import DistrictVolumeDetailTabs from './DistrictVolumeDetailTabs';
+import { useDistrictCodeColumn } from './useDistrictCodeColumn';
 
 import type { TableHeaderType } from '@/components/Form/TableResource/types';
 import type { CoastDistrictRow, DistrictVolumeDetail } from '@/services/districtvolumes.types';
 import type { CodeDescriptionDto } from '@/services/search.types';
 
-import CodeDescriptionTag from '@/components/waste/CodeDescriptionTag';
 import PrecisionNumberTag from '@/components/core/Tags/PrecisionNumberTag';
 
 /**
@@ -39,21 +39,15 @@ const CoastDetailView: FC<CoastDetailViewProps> = ({ data, districtOptions }) =>
   const { tableData, startDate, endDate, tableLevelFactor, heliMultiplier } = data;
   const sections = tableData.sections;
 
-  /** Pre-built O(1) code→description lookup map. */
-  const districtMap = useMemo(
-    () => new Map(districtOptions.map((d) => [d.code, d.description])),
-    [districtOptions],
-  );
+  /** O(1) code→description render function for the district column. */
+  const renderDistrictCode = useDistrictCodeColumn(districtOptions);
 
   const headers: TableHeaderType<CoastDistrictRow>[] = [
     {
       key: 'code',
       header: 'District',
       selected: true,
-      renderAs: (value) => {
-        const description = districtMap.get(value as string) ?? (value as string);
-        return <CodeDescriptionTag value={{ code: value as string, description }} />;
-      },
+      renderAs: renderDistrictCode,
     },
     {
       key: 'avoidableSawlog',

--- a/frontend/src/components/waste/DistrictVolumeDetail/CoastDetailView.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/CoastDetailView.tsx
@@ -1,4 +1,4 @@
-import { type FC } from 'react';
+import { useMemo, type FC } from 'react';
 
 import DistrictVolumeDetailHeader from './DistrictVolumeDetailHeader';
 import DistrictVolumeDetailTabs from './DistrictVolumeDetailTabs';
@@ -39,18 +39,20 @@ const CoastDetailView: FC<CoastDetailViewProps> = ({ data, districtOptions }) =>
   const { tableData, startDate, endDate, tableLevelFactor, heliMultiplier } = data;
   const sections = tableData.sections;
 
+  /** Pre-built O(1) code→description lookup map. */
+  const districtMap = useMemo(
+    () => new Map(districtOptions.map((d) => [d.code, d.description])),
+    [districtOptions],
+  );
+
   const headers: TableHeaderType<CoastDistrictRow>[] = [
     {
       key: 'code',
       header: 'District',
       selected: true,
       renderAs: (value) => {
-        const match = districtOptions.find((d) => d.code === value);
-        return (
-          <CodeDescriptionTag
-            value={{ code: value as string, description: match?.description ?? (value as string) }}
-          />
-        );
+        const description = districtMap.get(value as string) ?? (value as string);
+        return <CodeDescriptionTag value={{ code: value as string, description }} />;
       },
     },
     {

--- a/frontend/src/components/waste/DistrictVolumeDetail/CoastDetailView.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/CoastDetailView.tsx
@@ -5,7 +5,9 @@ import DistrictVolumeDetailTabs from './DistrictVolumeDetailTabs';
 
 import type { TableHeaderType } from '@/components/Form/TableResource/types';
 import type { CoastDistrictRow, DistrictVolumeDetail } from '@/services/districtvolumes.types';
+import type { CodeDescriptionDto } from '@/services/search.types';
 
+import CodeDescriptionTag from '@/components/waste/CodeDescriptionTag';
 import PrecisionNumberTag from '@/components/core/Tags/PrecisionNumberTag';
 
 /**
@@ -14,6 +16,8 @@ import PrecisionNumberTag from '@/components/core/Tags/PrecisionNumberTag';
 interface CoastDetailViewProps {
   /** The district volume detail data (must be COASTAL variant). */
   readonly data: DistrictVolumeDetail;
+  /** All district codes/descriptions for looking up district names by code. */
+  readonly districtOptions: CodeDescriptionDto[];
 }
 
 /**
@@ -26,7 +30,7 @@ interface CoastDetailViewProps {
  * @param props.data - The district volume detail data.
  * @returns The Coast Detail view.
  */
-const CoastDetailView: FC<CoastDetailViewProps> = ({ data }) => {
+const CoastDetailView: FC<CoastDetailViewProps> = ({ data, districtOptions }) => {
   // Narrow the discriminated union to the COASTAL variant
   if (data.area !== 'COASTAL') {
     throw new Error('CoastDetailView requires data with area="COASTAL"');
@@ -36,7 +40,19 @@ const CoastDetailView: FC<CoastDetailViewProps> = ({ data }) => {
   const sections = tableData.sections;
 
   const headers: TableHeaderType<CoastDistrictRow>[] = [
-    { key: 'code', header: 'Code', selected: true },
+    {
+      key: 'code',
+      header: 'District',
+      selected: true,
+      renderAs: (value) => {
+        const match = districtOptions.find((d) => d.code === value);
+        return (
+          <CodeDescriptionTag
+            value={{ code: value as string, description: match?.description ?? (value as string) }}
+          />
+        );
+      },
+    },
     {
       key: 'avoidableSawlog',
       header: 'Avoidable sawlog',

--- a/frontend/src/components/waste/DistrictVolumeDetail/CoastDetailView.unit.test.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/CoastDetailView.unit.test.tsx
@@ -6,6 +6,13 @@ import CoastDetailView from './CoastDetailView';
 
 import type { DistrictVolumeDetail } from '@/services/districtvolumes.types';
 
+/** Shared district options for testing the lookup in the coast district column. */
+const SAMPLE_DISTRICT_OPTIONS = [
+  { code: 'DCK', description: 'Chilliwack' },
+  { code: 'DUN', description: 'Duncan' },
+  { code: 'DKL', description: 'Dakota Knowles' },
+];
+
 // ============================================================================
 // Mocks
 // ============================================================================
@@ -163,7 +170,9 @@ describe('CoastDetailView', () => {
 
   describe('header fields', () => {
     it('should render start date with ReadonlyInput and DateTag', async () => {
-      render(<CoastDetailView data={createCoastData()} />);
+      render(
+        <CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={createCoastData()} />,
+      );
       await waitFor(() => {});
 
       const startDateField = screen.getByTestId('readonly-input-start-date');
@@ -178,14 +187,18 @@ describe('CoastDetailView', () => {
     });
 
     it('should render end date with ReadonlyInput and DateTag', async () => {
-      render(<CoastDetailView data={createCoastData()} />);
+      render(
+        <CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={createCoastData()} />,
+      );
       await waitFor(() => {});
 
       expect(screen.getByTestId('readonly-input-end-date')).toBeTruthy();
     });
 
     it('should render table level factor with ReadonlyInput and PrecisionNumberTag', async () => {
-      render(<CoastDetailView data={createCoastData()} />);
+      render(
+        <CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={createCoastData()} />,
+      );
       await waitFor(() => {});
 
       const factorField = screen.getByTestId('readonly-input-dispersed-retention-reduction-factor');
@@ -197,7 +210,9 @@ describe('CoastDetailView', () => {
     });
 
     it('should render heli multiplier with ReadonlyInput and PrecisionNumberTag', async () => {
-      render(<CoastDetailView data={createCoastData()} />);
+      render(
+        <CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={createCoastData()} />,
+      );
       await waitFor(() => {});
 
       expect(screen.getByTestId('readonly-input-heli-multiplier')).toBeTruthy();
@@ -206,7 +221,9 @@ describe('CoastDetailView', () => {
 
   describe('tabs and sections', () => {
     it('should render a tab for each section', async () => {
-      render(<CoastDetailView data={createCoastData()} />);
+      render(
+        <CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={createCoastData()} />,
+      );
       await waitFor(() => {});
 
       expect(screen.getByRole('tab', { name: 'Mature' })).toBeTruthy();
@@ -214,14 +231,18 @@ describe('CoastDetailView', () => {
     });
 
     it('should render DistrictZoneSection for each section', async () => {
-      render(<CoastDetailView data={createCoastData()} />);
+      render(
+        <CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={createCoastData()} />,
+      );
       await waitFor(() => {});
 
       expect(screen.getAllByTestId('district-zone-section').length).toBe(2);
     });
 
     it('should pass correct zone name and headers to DistrictZoneSection', async () => {
-      render(<CoastDetailView data={createCoastData()} />);
+      render(
+        <CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={createCoastData()} />,
+      );
       await waitFor(() => {});
 
       const zoneNames = screen.getAllByTestId('dzz-zone-name');
@@ -237,7 +258,9 @@ describe('CoastDetailView', () => {
     });
 
     it('should pass correct row count per section', async () => {
-      render(<CoastDetailView data={createCoastData()} />);
+      render(
+        <CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={createCoastData()} />,
+      );
       await waitFor(() => {});
 
       const rowCounts = screen.getAllByTestId('dzz-rows-count');
@@ -261,7 +284,7 @@ describe('CoastDetailView', () => {
         total: 9.25,
       });
 
-      render(<CoastDetailView data={data} />);
+      render(<CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={data} />);
       await waitFor(() => {});
 
       expect(screen.getAllByTestId('dzz-rows-count')[0].textContent).toBe('2');
@@ -271,7 +294,7 @@ describe('CoastDetailView', () => {
   describe('edge cases', () => {
     it('should handle null endDate — not render DateTag for end date', async () => {
       const data = createCoastData({ endDate: null });
-      render(<CoastDetailView data={data} />);
+      render(<CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={data} />);
       await waitFor(() => {});
 
       // End date field children should be empty (no DateTag when endDate is null)
@@ -283,7 +306,7 @@ describe('CoastDetailView', () => {
       const data = createCoastData({
         tableData: { type: 'COASTAL', sections: [], formulas: {} },
       });
-      render(<CoastDetailView data={data} />);
+      render(<CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={data} />);
       await waitFor(() => {});
 
       expect(screen.queryAllByTestId('district-zone-section').length).toBe(0);
@@ -292,7 +315,7 @@ describe('CoastDetailView', () => {
 
     it('should skip DateTag when startDate is an empty string', async () => {
       const data = createCoastData({ startDate: '' });
-      render(<CoastDetailView data={data} />);
+      render(<CoastDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={data} />);
       await waitFor(() => {});
 
       // Only the end-date DateTag renders; start-date is empty string (falsy)
@@ -309,6 +332,7 @@ describe('CoastDetailView', () => {
       render(
         <TestErrorBoundary onError={onError}>
           <CoastDetailView
+            districtOptions={SAMPLE_DISTRICT_OPTIONS}
             data={
               {
                 ...BASE_COAST_DATA,

--- a/frontend/src/components/waste/DistrictVolumeDetail/InteriorDetailView.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/InteriorDetailView.tsx
@@ -1,13 +1,13 @@
-import { useMemo, type FC } from 'react';
+import { type FC } from 'react';
 
 import DistrictVolumeDetailHeader from './DistrictVolumeDetailHeader';
 import DistrictVolumeDetailTabs from './DistrictVolumeDetailTabs';
+import { useDistrictCodeColumn } from './useDistrictCodeColumn';
 
 import type { TableHeaderType } from '@/components/Form/TableResource/types';
 import type { DistrictVolumeDetail, InteriorDistrictRow } from '@/services/districtvolumes.types';
 import type { CodeDescriptionDto } from '@/services/search.types';
 
-import CodeDescriptionTag from '@/components/waste/CodeDescriptionTag';
 import PrecisionNumberTag from '@/components/core/Tags/PrecisionNumberTag';
 
 /**
@@ -40,11 +40,8 @@ const InteriorDetailView: FC<InteriorDetailViewProps> = ({ data, districtOptions
   const { tableData, startDate, endDate, tableLevelFactor } = data;
   const zones = tableData.zones;
 
-  /** Pre-built O(1) code→description lookup map. */
-  const districtMap = useMemo(
-    () => new Map(districtOptions.map((d) => [d.code, d.description])),
-    [districtOptions],
-  );
+  /** O(1) code→description render function for the district column. */
+  const renderDistrictCode = useDistrictCodeColumn(districtOptions);
 
   /** Table headers for interior district volume rows. */
   const headers: TableHeaderType<InteriorDistrictRow>[] = [
@@ -52,10 +49,7 @@ const InteriorDetailView: FC<InteriorDetailViewProps> = ({ data, districtOptions
       key: 'code',
       header: 'District',
       selected: true,
-      renderAs: (value) => {
-        const description = districtMap.get(value as string) ?? (value as string);
-        return <CodeDescriptionTag value={{ code: value as string, description }} />;
-      },
+      renderAs: renderDistrictCode,
     },
     {
       key: 'avoidableSawlog',

--- a/frontend/src/components/waste/DistrictVolumeDetail/InteriorDetailView.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/InteriorDetailView.tsx
@@ -1,4 +1,4 @@
-import { type FC } from 'react';
+import { useMemo, type FC } from 'react';
 
 import DistrictVolumeDetailHeader from './DistrictVolumeDetailHeader';
 import DistrictVolumeDetailTabs from './DistrictVolumeDetailTabs';
@@ -40,6 +40,12 @@ const InteriorDetailView: FC<InteriorDetailViewProps> = ({ data, districtOptions
   const { tableData, startDate, endDate, tableLevelFactor } = data;
   const zones = tableData.zones;
 
+  /** Pre-built O(1) code→description lookup map. */
+  const districtMap = useMemo(
+    () => new Map(districtOptions.map((d) => [d.code, d.description])),
+    [districtOptions],
+  );
+
   /** Table headers for interior district volume rows. */
   const headers: TableHeaderType<InteriorDistrictRow>[] = [
     {
@@ -47,12 +53,8 @@ const InteriorDetailView: FC<InteriorDetailViewProps> = ({ data, districtOptions
       header: 'District',
       selected: true,
       renderAs: (value) => {
-        const match = districtOptions.find((d) => d.code === value);
-        return (
-          <CodeDescriptionTag
-            value={{ code: value as string, description: match?.description ?? (value as string) }}
-          />
-        );
+        const description = districtMap.get(value as string) ?? (value as string);
+        return <CodeDescriptionTag value={{ code: value as string, description }} />;
       },
     },
     {

--- a/frontend/src/components/waste/DistrictVolumeDetail/InteriorDetailView.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/InteriorDetailView.tsx
@@ -5,7 +5,9 @@ import DistrictVolumeDetailTabs from './DistrictVolumeDetailTabs';
 
 import type { TableHeaderType } from '@/components/Form/TableResource/types';
 import type { DistrictVolumeDetail, InteriorDistrictRow } from '@/services/districtvolumes.types';
+import type { CodeDescriptionDto } from '@/services/search.types';
 
+import CodeDescriptionTag from '@/components/waste/CodeDescriptionTag';
 import PrecisionNumberTag from '@/components/core/Tags/PrecisionNumberTag';
 
 /**
@@ -14,6 +16,8 @@ import PrecisionNumberTag from '@/components/core/Tags/PrecisionNumberTag';
 interface InteriorDetailViewProps {
   /** The district volume detail data (must be INTERIOR variant). */
   readonly data: DistrictVolumeDetail;
+  /** All district codes/descriptions for looking up district names by code. */
+  readonly districtOptions: CodeDescriptionDto[];
 }
 
 /**
@@ -27,7 +31,7 @@ interface InteriorDetailViewProps {
  * @param props.data - The district volume detail data.
  * @returns The Interior Detail view.
  */
-const InteriorDetailView: FC<InteriorDetailViewProps> = ({ data }) => {
+const InteriorDetailView: FC<InteriorDetailViewProps> = ({ data, districtOptions }) => {
   // Narrow the discriminated union to the INTERIOR variant
   if (data.area !== 'INTERIOR') {
     throw new Error('InteriorDetailView requires data with area="INTERIOR"');
@@ -38,7 +42,19 @@ const InteriorDetailView: FC<InteriorDetailViewProps> = ({ data }) => {
 
   /** Table headers for interior district volume rows. */
   const headers: TableHeaderType<InteriorDistrictRow>[] = [
-    { key: 'code', header: 'Code', selected: true },
+    {
+      key: 'code',
+      header: 'District',
+      selected: true,
+      renderAs: (value) => {
+        const match = districtOptions.find((d) => d.code === value);
+        return (
+          <CodeDescriptionTag
+            value={{ code: value as string, description: match?.description ?? (value as string) }}
+          />
+        );
+      },
+    },
     {
       key: 'avoidableSawlog',
       header: 'Avoidable sawlog',

--- a/frontend/src/components/waste/DistrictVolumeDetail/InteriorDetailView.unit.test.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/InteriorDetailView.unit.test.tsx
@@ -6,6 +6,15 @@ import InteriorDetailView from './InteriorDetailView';
 
 import type { DistrictVolumeDetail } from '@/services/districtvolumes.types';
 
+/** Shared district options for testing the lookup in the district column. */
+const SAMPLE_DISTRICT_OPTIONS = [
+  { code: 'DCC', description: 'Cariboo-Chilcotin' },
+  { code: 'DKL', description: 'Dakota Knowles' },
+  { code: 'DTH', description: 'Thompson' },
+  { code: 'DN1', description: 'District North 1' },
+  { code: 'DN2', description: 'District North 2' },
+];
+
 // ============================================================================
 // Mocks
 // ============================================================================
@@ -171,7 +180,12 @@ describe('InteriorDetailView', () => {
 
   describe('header fields', () => {
     it('should render start date with ReadonlyInput and DateTag', async () => {
-      render(<InteriorDetailView data={createInteriorData()} />);
+      render(
+        <InteriorDetailView
+          districtOptions={SAMPLE_DISTRICT_OPTIONS}
+          data={createInteriorData()}
+        />,
+      );
       await waitFor(() => {});
 
       const startDateField = screen.getByTestId('readonly-input-start-date');
@@ -184,7 +198,12 @@ describe('InteriorDetailView', () => {
     });
 
     it('should render end date with DateTag (NOT wrapped in ReadonlyInput)', async () => {
-      render(<InteriorDetailView data={createInteriorData()} />);
+      render(
+        <InteriorDetailView
+          districtOptions={SAMPLE_DISTRICT_OPTIONS}
+          data={createInteriorData()}
+        />,
+      );
       await waitFor(() => {});
 
       // End date in InteriorDetailView is rendered directly, NOT inside ReadonlyInput
@@ -196,7 +215,12 @@ describe('InteriorDetailView', () => {
     });
 
     it('should render table level factor with ReadonlyInput and PrecisionNumberTag', async () => {
-      render(<InteriorDetailView data={createInteriorData()} />);
+      render(
+        <InteriorDetailView
+          districtOptions={SAMPLE_DISTRICT_OPTIONS}
+          data={createInteriorData()}
+        />,
+      );
       await waitFor(() => {});
 
       const factorField = screen.getByTestId('readonly-input-dispersed-retention-reduction-factor');
@@ -208,7 +232,12 @@ describe('InteriorDetailView', () => {
     });
 
     it('should render heli multiplier ReadonlyInput with literal "TBD" text', async () => {
-      render(<InteriorDetailView data={createInteriorData()} />);
+      render(
+        <InteriorDetailView
+          districtOptions={SAMPLE_DISTRICT_OPTIONS}
+          data={createInteriorData()}
+        />,
+      );
       await waitFor(() => {});
 
       const heliField = screen.getByTestId('readonly-input-heli-multiplier');
@@ -220,7 +249,12 @@ describe('InteriorDetailView', () => {
 
   describe('tabs and zones', () => {
     it('should render a tab for each zone', async () => {
-      render(<InteriorDetailView data={createInteriorData()} />);
+      render(
+        <InteriorDetailView
+          districtOptions={SAMPLE_DISTRICT_OPTIONS}
+          data={createInteriorData()}
+        />,
+      );
       await waitFor(() => {});
 
       expect(screen.getByRole('tab', { name: 'Dry belt' })).toBeTruthy();
@@ -229,14 +263,24 @@ describe('InteriorDetailView', () => {
     });
 
     it('should render DistrictZoneSection for each zone', async () => {
-      render(<InteriorDetailView data={createInteriorData()} />);
+      render(
+        <InteriorDetailView
+          districtOptions={SAMPLE_DISTRICT_OPTIONS}
+          data={createInteriorData()}
+        />,
+      );
       await waitFor(() => {});
 
       expect(screen.getAllByTestId('district-zone-section').length).toBe(3);
     });
 
     it('should pass correct zone names to DistrictZoneSection', async () => {
-      render(<InteriorDetailView data={createInteriorData()} />);
+      render(
+        <InteriorDetailView
+          districtOptions={SAMPLE_DISTRICT_OPTIONS}
+          data={createInteriorData()}
+        />,
+      );
       await waitFor(() => {});
 
       const zoneNames = screen.getAllByTestId('dzz-zone-name');
@@ -246,7 +290,12 @@ describe('InteriorDetailView', () => {
     });
 
     it('should pass correct row counts per zone', async () => {
-      render(<InteriorDetailView data={createInteriorData()} />);
+      render(
+        <InteriorDetailView
+          districtOptions={SAMPLE_DISTRICT_OPTIONS}
+          data={createInteriorData()}
+        />,
+      );
       await waitFor(() => {});
 
       const rowCounts = screen.getAllByTestId('dzz-rows-count');
@@ -256,7 +305,12 @@ describe('InteriorDetailView', () => {
     });
 
     it('should pass all 5 headers to DistrictZoneSection', async () => {
-      render(<InteriorDetailView data={createInteriorData()} />);
+      render(
+        <InteriorDetailView
+          districtOptions={SAMPLE_DISTRICT_OPTIONS}
+          data={createInteriorData()}
+        />,
+      );
       await waitFor(() => {});
 
       const headersCounts = screen.getAllByTestId('dzz-headers-count');
@@ -269,7 +323,7 @@ describe('InteriorDetailView', () => {
   describe('edge cases', () => {
     it('should handle null endDate — not render DateTag for end date', async () => {
       const data = createInteriorData({ endDate: null });
-      render(<InteriorDetailView data={data} />);
+      render(<InteriorDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={data} />);
       await waitFor(() => {});
 
       // Only the start-date DateTag should render
@@ -279,7 +333,7 @@ describe('InteriorDetailView', () => {
 
     it('should skip DateTag when startDate is an empty string', async () => {
       const data = createInteriorData({ startDate: '' });
-      render(<InteriorDetailView data={data} />);
+      render(<InteriorDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={data} />);
       await waitFor(() => {});
 
       // startDate is '' (falsy), endDate is present — only end date renders
@@ -291,7 +345,7 @@ describe('InteriorDetailView', () => {
       const data = createInteriorData({
         tableData: { type: 'INTERIOR', zones: [], formulas: {} },
       });
-      render(<InteriorDetailView data={data} />);
+      render(<InteriorDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={data} />);
       await waitFor(() => {});
 
       expect(screen.queryAllByTestId('district-zone-section').length).toBe(0);
@@ -325,7 +379,7 @@ describe('InteriorDetailView', () => {
         },
       );
 
-      render(<InteriorDetailView data={data} />);
+      render(<InteriorDetailView districtOptions={SAMPLE_DISTRICT_OPTIONS} data={data} />);
       await waitFor(() => {});
 
       const rowCounts = screen.getAllByTestId('dzz-rows-count');
@@ -341,6 +395,7 @@ describe('InteriorDetailView', () => {
       render(
         <TestErrorBoundary onError={onError}>
           <InteriorDetailView
+            districtOptions={SAMPLE_DISTRICT_OPTIONS}
             data={
               {
                 ...BASE_INTERIOR_DATA,

--- a/frontend/src/components/waste/DistrictVolumeDetail/index.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/index.tsx
@@ -5,6 +5,8 @@ import InteriorDetailView from './InteriorDetailView';
 
 import type { DistrictVolumeDetail } from '@/services/districtvolumes.types';
 
+import { useDistrictOptionsQuery } from '@/config/react-query/hooks';
+
 /**
  * Props for the {@link DistrictVolumeDetailView} component.
  */
@@ -17,15 +19,20 @@ interface DistrictVolumeDetailViewProps {
  * District Volume Detail view wrapper — renders either {@link InteriorDetailView}
  * or {@link CoastDetailView} based on the `area` field in the data.
  *
+ * Fetches the full list of district codes/descriptions so each view can
+ * look up the human-readable name by district code at render time.
+ *
  * @param props - Component props.
  * @param props.data - The district volume detail data.
  * @returns The appropriate detail view for the district area type.
  */
 const DistrictVolumeDetailView: FC<DistrictVolumeDetailViewProps> = ({ data }) => {
+  const { data: districtOptions = [] } = useDistrictOptionsQuery();
+
   return data.area === 'INTERIOR' ? (
-    <InteriorDetailView data={data} />
+    <InteriorDetailView data={data} districtOptions={districtOptions} />
   ) : (
-    <CoastDetailView data={data} />
+    <CoastDetailView data={data} districtOptions={districtOptions} />
   );
 };
 

--- a/frontend/src/components/waste/DistrictVolumeDetail/index.unit.test.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/index.unit.test.tsx
@@ -9,6 +9,16 @@ import type { DistrictVolumeDetail } from '@/services/districtvolumes.types';
 // Mocks
 // ============================================================================
 
+// Mock the TanStack Query hook that fetches district codes/descriptions
+vi.mock('@/config/react-query/hooks', () => ({
+  useDistrictOptionsQuery: vi.fn(() => ({
+    data: [
+      { code: 'DCC', description: 'Cariboo-Chilcotin' },
+      { code: 'DKM', description: 'Coast Mountains' },
+    ],
+  })),
+}));
+
 // Mock the sub-views to isolate the conditional routing logic
 vi.mock('./InteriorDetailView', () => ({
   default: ({ data }: { data: DistrictVolumeDetail }) => (

--- a/frontend/src/components/waste/DistrictVolumeDetail/useDistrictCodeColumn.tsx
+++ b/frontend/src/components/waste/DistrictVolumeDetail/useDistrictCodeColumn.tsx
@@ -1,0 +1,34 @@
+import { useMemo, type ReactNode } from 'react';
+
+import type { CodeDescriptionDto } from '@/services/search.types';
+
+import CodeDescriptionTag from '@/components/waste/CodeDescriptionTag';
+
+/**
+ * Builds a `renderAs` function for the district *code* column used by both
+ * the Interior and Coast detail views.
+ *
+ * Creates an O(1) `Map` lookup from the cached {@link districtOptions} so each
+ * cell renders `<CodeDescriptionTag>` with both the district code and its
+ * human-readable description. Falls back to showing just the code when no
+ * description is found.
+ *
+ * @param districtOptions - Cached district code/description pairs from
+ *   `useDistrictOptionsQuery`.
+ * @returns A render function that accepts a district code string and returns a
+ *   `<CodeDescriptionTag>` element.
+ */
+export function useDistrictCodeColumn(
+  districtOptions: CodeDescriptionDto[],
+): (value: string | number) => ReactNode {
+  const districtMap = useMemo(
+    () => new Map(districtOptions.map((d) => [d.code, d.description])),
+    [districtOptions],
+  );
+
+  return (value: string | number) => {
+    const code = String(value);
+    const description = districtMap.get(code) ?? code;
+    return <CodeDescriptionTag value={{ code, description }} />;
+  };
+}

--- a/frontend/src/pages/DistrictVolumeTableDetail/coast-detail.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/coast-detail.e2e.test.tsx
@@ -92,7 +92,7 @@ test.describe('District Volume Table Detail — Coast View', () => {
     await expect(matureSection.getByText('DCR')).toBeVisible();
 
     // Table headers visible
-    await expect(matureSection.getByText('Code')).toBeVisible();
+    await expect(matureSection.getByText('District')).toBeVisible();
   });
 
   // ─── E6: Switch to Immature Tab ─────────────────────────────────────────
@@ -124,7 +124,7 @@ test.describe('District Volume Table Detail — Coast View', () => {
     // Default Mature tab — verify all column headers (Coast has 6 columns)
     // Scope to the Mature section to avoid strict mode violation from Immature panel
     const matureSection = page.getByTestId('district-zone-Mature');
-    await expect(matureSection.getByText('Code')).toBeVisible();
+    await expect(matureSection.getByText('District')).toBeVisible();
     await expect(matureSection.getByText('Avoidable sawlog')).toBeVisible();
     await expect(matureSection.getByText('Avoidable Hembal Grade U')).toBeVisible();
     await expect(matureSection.getByText('Avoidable Grade Y')).toBeVisible();

--- a/frontend/src/pages/DistrictVolumeTableDetail/interior-detail.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/interior-detail.e2e.test.tsx
@@ -90,7 +90,7 @@ test.describe('District Volume Table Detail — Interior View', () => {
 
     // Table headers visible (use exact matching to avoid "Avoidable Grade 4"
     // matching "Unavoidable Grade 4" as a substring)
-    await expect(dryBeltSection.getByText('Code', { exact: true })).toBeVisible();
+    await expect(dryBeltSection.getByText('District', { exact: true })).toBeVisible();
     await expect(dryBeltSection.getByText('Avoidable sawlog', { exact: true })).toBeVisible();
   });
 
@@ -139,7 +139,7 @@ test.describe('District Volume Table Detail — Interior View', () => {
 
     // Default Dry belt tab — verify all column headers (use exact matching to
     // avoid "Avoidable Grade 4" matching "Unavoidable Grade 4" as a substring)
-    await expect(dryBeltSection.getByText('Code', { exact: true })).toBeVisible();
+    await expect(dryBeltSection.getByText('District', { exact: true })).toBeVisible();
     await expect(dryBeltSection.getByText('Avoidable sawlog', { exact: true })).toBeVisible();
     await expect(dryBeltSection.getByText('Avoidable Grade 4', { exact: true })).toBeVisible();
     await expect(dryBeltSection.getByText('Unavoidable Grade 4', { exact: true })).toBeVisible();


### PR DESCRIPTION
<!-- generated-by: opencode-skill pull-request-description-generator; created-at: 2026-07-09T16:26:21Z -->

# Description

Include district code description in the district volume detail views (Interior and Coast). Previously, only the district code was displayed. Now, the code is looked up against the cached `useDistrictOptionsQuery` list and rendered alongside its description using the `CodeDescriptionTag` component.

Additionally, `CodeDescriptionTag` now handles the edge case where code equals description (e.g., "Weighted Average (TOTAL)") — it renders the single value alone instead of duplicating it as "Weighted Average (TOTAL) - Weighted Average (TOTAL)".

Fixes #1061

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Updated existing tests
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR

## Further comments

This change enriches the district code display at the presentation layer — no Zod schema changes were needed. The `useDistrictOptionsQuery` already exists with `staleTime: Infinity`, so no new API calls were introduced.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-13-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)