### PR TITLE
refactor(#1068): align upload route paths to consistent pattern

### DIFF
--- a/frontend/src/pages/ConfigurationDistrictVolumeList/index.e2e.test.tsx
+++ b/frontend/src/pages/ConfigurationDistrictVolumeList/index.e2e.test.tsx
@@ -110,7 +110,7 @@ test.describe('Configuration District Volume List Page', () => {
 
       await page.getByRole('button', { name: /Upload new volumes table/i }).click();
 
-      await expect(page).toHaveURL(/\/configuration\/upload-district-volume$/);
+      await expect(page).toHaveURL(/\/configuration\/district-volume-tables\/upload$/);
     });
 
     test('should navigate back to configuration via breadcrumb @idir-only', async ({

--- a/frontend/src/pages/ConfigurationDistrictVolumeList/index.tsx
+++ b/frontend/src/pages/ConfigurationDistrictVolumeList/index.tsx
@@ -30,7 +30,7 @@ const ConfigurationDistrictVolumeListPage: FC = () => {
         >
           <Button
             kind="primary"
-            onClick={() => navigateInTree(navigate, '/configuration/upload-district-volume')}
+            onClick={() => navigateInTree(navigate, '/configuration/district-volume-tables/upload')}
           >
             Upload new volumes table <Add />
           </Button>

--- a/frontend/src/pages/ConfigurationDistrictVolumeList/index.unit.test.tsx
+++ b/frontend/src/pages/ConfigurationDistrictVolumeList/index.unit.test.tsx
@@ -72,7 +72,7 @@ describe('ConfigurationDistrictVolumeListPage', () => {
     expect(navigateInTree).toHaveBeenCalledOnce();
     expect(navigateInTree).toHaveBeenCalledWith(
       mockNavigate,
-      '/configuration/upload-district-volume',
+      '/configuration/district-volume-tables/upload',
     );
   });
 });

--- a/frontend/src/pages/DistrictVolumeTableDetail/post-upload.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/post-upload.e2e.test.tsx
@@ -98,7 +98,7 @@ test.describe('District Volume Table Detail — Post-Upload', () => {
     await mockCreateApi(page);
 
     // Navigate to the upload page
-    await page.goto('/configuration/upload-district-volume');
+    await page.goto('/configuration/district-volume-tables/upload');
     await page.waitForLoadState('domcontentloaded');
 
     // Step 1: Upload a valid Interior spreadsheet
@@ -157,7 +157,7 @@ test.describe('District Volume Table Detail — Post-Upload', () => {
     await mockCreateApi(page);
 
     // Navigate to the upload page
-    await page.goto('/configuration/upload-district-volume');
+    await page.goto('/configuration/district-volume-tables/upload');
     await page.waitForLoadState('domcontentloaded');
 
     // Step 1: Select Coast area before uploading the Coast spreadsheet

--- a/frontend/src/pages/DistrictVolumeTableUpload/index.tsx
+++ b/frontend/src/pages/DistrictVolumeTableUpload/index.tsx
@@ -33,7 +33,7 @@ import './index.scss';
  * @see {@link DistrictVolumeTableUpload} for the form component details
  *
  * @protected Requires ADMIN role with client access
- * @route /configuration/upload-district-volume
+ * @route /configuration/district-volume-tables/upload
  */
 const DistrictVolumeTableUploadPage: FC = () => {
   return (
@@ -46,7 +46,7 @@ const DistrictVolumeTableUploadPage: FC = () => {
       </Column>
 
       <Column lg={16} md={8} sm={4} className="create-ru-column__notification">
-        <PageNotification eventTarget="upload-district-volume" />
+        <PageNotification eventTarget="district-volume-tables-upload" />
       </Column>
 
       <DistrictVolumeTableUpload />

--- a/frontend/src/pages/DistrictVolumeTableUpload/index.tsx
+++ b/frontend/src/pages/DistrictVolumeTableUpload/index.tsx
@@ -46,7 +46,7 @@ const DistrictVolumeTableUploadPage: FC = () => {
       </Column>
 
       <Column lg={16} md={8} sm={4} className="create-ru-column__notification">
-        <PageNotification eventTarget="district-volume-tables-upload" />
+        <PageNotification eventTarget="upload-table" />
       </Column>
 
       <DistrictVolumeTableUpload />

--- a/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
@@ -120,7 +120,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
         'cognito:groups': ['WASTE_PLUS_ADMIN'],
       });
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       await expect(page).toHaveURL(/\/configuration\/upload-district-volume$/);
@@ -139,7 +139,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
         'cognito:groups': ['WASTE_PLUS_VIEWER_00147603'],
       });
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       await expect(page).toHaveURL(/\/unauthorized/);
@@ -155,7 +155,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
         'cognito:groups': ['WASTE_PLUS_VIEWER_00147603'],
       });
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       await expect(page).toHaveURL(/\/unauthorized/);
@@ -175,7 +175,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
         'cognito:groups': ['WASTE_PLUS_ADMIN'],
       });
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       // Upload a valid Interior spreadsheet
@@ -206,7 +206,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
         'cognito:groups': ['WASTE_PLUS_ADMIN'],
       });
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       // Select "Coast" first — the validator rejects files that don't match the selected area.
@@ -244,7 +244,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
         'cognito:groups': ['WASTE_PLUS_ADMIN'],
       });
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       const buffer = await buildWrongSheetNameBuffer();
@@ -268,7 +268,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
         'cognito:groups': ['WASTE_PLUS_ADMIN'],
       });
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       const buffer = await buildNonNumericDataBuffer();
@@ -289,7 +289,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
         'cognito:groups': ['WASTE_PLUS_ADMIN'],
       });
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       const buffer = await buildInvalidDistrictCodeBuffer();
@@ -310,7 +310,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
         'cognito:groups': ['WASTE_PLUS_ADMIN'],
       });
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       const buffer = await buildMissingHeliMultiplierBuffer();
@@ -336,7 +336,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
       // Register the POST mock (after beforeEach so it takes precedence)
       await mockCreateApi(page);
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       // Step 1: Upload a valid Interior spreadsheet
@@ -377,7 +377,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
 
       await mockCreateApi(page);
 
-      await page.goto('/configuration/upload-district-volume');
+      await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
       // Select "Coast" first — the validator rejects files that don't match the selected area.

--- a/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableUpload/upload.e2e.test.tsx
@@ -109,7 +109,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
 
       // Click the upload button
       await page.getByRole('button', { name: /Upload new volumes table/i }).click();
-      await expect(page).toHaveURL(/\/configuration\/upload-district-volume$/);
+      await expect(page).toHaveURL(/\/configuration\/district-volume-tables\/upload$/);
     });
 
     test('should land on upload page via direct URL @idir-only', async ({ page }, testInfo) => {
@@ -123,7 +123,7 @@ test.describe('District Volume Table Upload Page - E2E', () => {
       await page.goto('/configuration/district-volume-tables/upload');
       await page.waitForLoadState('domcontentloaded');
 
-      await expect(page).toHaveURL(/\/configuration\/upload-district-volume$/);
+      await expect(page).toHaveURL(/\/configuration\/district-volume-tables\/upload$/);
       await expect(page.getByRole('heading', { name: 'Upload new volumes table' })).toBeVisible();
     });
   });

--- a/frontend/src/pages/SpeciesCompositionUpload/index.tsx
+++ b/frontend/src/pages/SpeciesCompositionUpload/index.tsx
@@ -28,7 +28,7 @@ const SpeciesCompositionUploadPage: FC = () => {
       </Column>
 
       <Column lg={16} md={8} sm={4} className="species-composition-upload-column__notification">
-        <PageNotification eventTarget="upload-species-composition" />
+        <PageNotification eventTarget="species-composition-upload" />
       </Column>
 
       {/* Upload form — populated in #1058 */}

--- a/frontend/src/routes/inTreePaths.ts
+++ b/frontend/src/routes/inTreePaths.ts
@@ -19,10 +19,10 @@ export type InTreePath =
   | '/reporting-units/create'
   | '/configuration'
   | '/configuration/district-volume-tables'
-  | '/configuration/upload-district-volume'
+  | '/configuration/district-volume-tables/upload'
   | `/configuration/district-volume-tables/${number}`
   | '/configuration/species-composition'
-  | '/configuration/upload-species-composition'
+  | '/configuration/species-composition/upload'
   | `/configuration/species-composition/${number}`;
 
 /**

--- a/frontend/src/routes/routePaths.tsx
+++ b/frontend/src/routes/routePaths.tsx
@@ -178,7 +178,7 @@ export const ROUTES: RouteDescription[] = [
     featureFlag: 'configuration-enabled',
   },
   {
-    path: '/configuration/upload-district-volume',
+    path: '/configuration/district-volume-tables/upload',
     id: 'Upload District Volume Table',
     component: () => (
       <Layout>

--- a/frontend/src/routes/routePaths.unit.test.tsx
+++ b/frontend/src/routes/routePaths.unit.test.tsx
@@ -258,13 +258,13 @@ describe('routePaths', () => {
 
     it('shouldDefineUploadDistrictVolumeRoute', () => {
       expect(
-        routePaths.ROUTES.some((r) => r.path === '/configuration/upload-district-volume'),
+        routePaths.ROUTES.some((r) => r.path === '/configuration/district-volume-tables/upload'),
       ).toBe(true);
     });
 
     it('shouldMarkUploadDistrictVolumeRouteAsProtectedAdmin', () => {
       const uploadRoute = routePaths.ROUTES.find(
-        (r) => r.path === '/configuration/upload-district-volume',
+        (r) => r.path === '/configuration/district-volume-tables/upload',
       )!;
       expect(uploadRoute.protected).toBe(true);
       expect(uploadRoute.roles).toEqual([{ role: Role.ADMIN, clients: [] }]);
@@ -272,7 +272,7 @@ describe('routePaths', () => {
 
     it('shouldRenderUploadDistrictVolumeRouteComponent_withoutThrowing', () => {
       const uploadRoute = routePaths.ROUTES.find(
-        (r) => r.path === '/configuration/upload-district-volume',
+        (r) => r.path === '/configuration/district-volume-tables/upload',
       )!;
       const Comp = uploadRoute.component;
       const { container } = render(<Comp />);
@@ -281,14 +281,14 @@ describe('routePaths', () => {
 
     it('shouldNotShowUploadRouteInSideMenu', () => {
       const uploadRoute = routePaths.ROUTES.find(
-        (r) => r.path === '/configuration/upload-district-volume',
+        (r) => r.path === '/configuration/district-volume-tables/upload',
       )!;
       expect(uploadRoute.isSideMenu).toBe(false);
     });
 
     it('shouldGateUploadRouteBehindConfigurationFeatureFlag', () => {
       const uploadRoute = routePaths.ROUTES.find(
-        (r) => r.path === '/configuration/upload-district-volume',
+        (r) => r.path === '/configuration/district-volume-tables/upload',
       )!;
       expect(uploadRoute.featureFlag).toBe('configuration-enabled');
     });


### PR DESCRIPTION
## Summary

Changes district volume upload route from `/configuration/upload-district-volume` to `/configuration/district-volume-tables/upload` to match the consistent `/<section>/<resource>/upload` pattern used by species composition routes.

### Consistent Route Pattern

| Resource | List | Detail | Upload |
|----------|------|--------|--------|
| District Volume Tables | `/configuration/district-volume-tables` | `/configuration/district-volume-tables/$id` | `/configuration/district-volume-tables/upload` ✓ |
| Species Composition | `/configuration/species-composition` | `/configuration/species-composition/$id` | `/configuration/species-composition/upload` ✓ |

### Changes

- `routePaths.tsx` — Route path updated
- `inTreePaths.ts` — `InTreePath` union type updated for both routes
- `DistrictVolumeTableUpload/index.tsx` — JSDoc route comment + `PageNotification eventTarget`
- `SpeciesCompositionUpload/index.tsx` — `PageNotification eventTarget`
- `ConfigurationDistrictVolumeList/index.tsx` — `navigateInTree` call
- `routePaths.unit.test.tsx` — 5 test assertions
- 4 E2E test files — URL references

### Dependency

⚠️ **Depends on:** [PR #1068](https://github.com/bcgov/nr-waste-plus/pull/1068) being merged first.

---

### Verification
- Lint: ✅ (no new issues)
- Tests: ✅ (1368 passed, 12 pre-existing env-related failures)

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-22-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)