### PR TITLE
feat(be:#1048): DB Schema — config_type discriminator on district_volume table

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/entity/districtaveragevolume/ConfigType.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/entity/districtaveragevolume/ConfigType.java
@@ -1,0 +1,15 @@
+package ca.bc.gov.nrs.hrs.entity.districtaveragevolume;
+
+/**
+ * Represents the type of configuration stored in the district volume table.
+ *
+ * <p>Supported config types include:
+ * <ul>
+ * <li>{@link #DISTRICT_VOLUME} - Standard district average volume configuration</li>
+ * <li>{@link #SPECIES_COMPOSITION} - Species composition configuration</li>
+ * </ul>
+ */
+public enum ConfigType {
+  DISTRICT_VOLUME,
+  SPECIES_COMPOSITION
+}

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/entity/districtaveragevolume/DistrictVolumeEntity.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/entity/districtaveragevolume/DistrictVolumeEntity.java
@@ -65,6 +65,10 @@ public class DistrictVolumeEntity {
 
   @Column(name = "heli_multiplier", precision = 10, scale = 3)
   private BigDecimal heliMultiplier;
+  
+  @Enumerated(EnumType.STRING)
+  @Column(name = "config_type", nullable = false, length = 50)
+  private ConfigType configType = ConfigType.DISTRICT_VOLUME;
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/src/main/resources/db/migration/V1.0.4__add_config_type_to_district_volume.sql
+++ b/backend/src/main/resources/db/migration/V1.0.4__add_config_type_to_district_volume.sql
@@ -1,7 +1,7 @@
 ALTER TABLE district_volume
-    ADD COLUMN config_type VARCHAR(50) NOT NULL DEFAULT 'DISTRICT_VOLUME';
+    ADD COLUMN IF NOT EXISTS config_type VARCHAR(50) NOT NULL DEFAULT 'DISTRICT_VOLUME';
 
 UPDATE district_volume SET config_type = 'DISTRICT_VOLUME';
 
-CREATE INDEX idx_district_volume_config_type
+CREATE INDEX IF NOT EXISTS idx_district_volume_config_type
     ON district_volume (config_type);

--- a/backend/src/main/resources/db/migration/V1.0.4__add_config_type_to_district_volume.sql
+++ b/backend/src/main/resources/db/migration/V1.0.4__add_config_type_to_district_volume.sql
@@ -1,7 +1,9 @@
 ALTER TABLE district_volume
     ADD COLUMN IF NOT EXISTS config_type VARCHAR(50) NOT NULL DEFAULT 'DISTRICT_VOLUME';
 
-UPDATE district_volume SET config_type = 'DISTRICT_VOLUME';
+UPDATE district_volume
+    SET config_type = 'DISTRICT_VOLUME'
+    WHERE config_type IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_district_volume_config_type
     ON district_volume (config_type);

--- a/backend/src/main/resources/db/migration/V1.0.4__add_config_type_to_district_volume.sql
+++ b/backend/src/main/resources/db/migration/V1.0.4__add_config_type_to_district_volume.sql
@@ -1,0 +1,7 @@
+ALTER TABLE district_volume
+    ADD COLUMN config_type VARCHAR(50) NOT NULL DEFAULT 'DISTRICT_VOLUME';
+
+UPDATE district_volume SET config_type = 'DISTRICT_VOLUME';
+
+CREATE INDEX idx_district_volume_config_type
+    ON district_volume (config_type);

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
@@ -6,12 +6,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import ca.bc.gov.nrs.hrs.dto.districtaveragevolume.CoastDataDto;
 import ca.bc.gov.nrs.hrs.dto.districtaveragevolume.DistrictVolumeCreateDto;
 import ca.bc.gov.nrs.hrs.dto.districtaveragevolume.DistrictVolumeDetailDto;
 import ca.bc.gov.nrs.hrs.dto.districtaveragevolume.InteriorDataDto;
 import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.Area;
+import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.ConfigType;
 import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.DistrictVolumeEntity;
 import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.TableData;
 import ca.bc.gov.nrs.hrs.repository.DistrictVolumeRepository;
@@ -406,6 +406,8 @@ class DistrictVolumeServiceTest {
     assertThat(savedEntities.get(1).getStartDate()).isEqualTo(newStartDate);
     assertThat(savedEntities.get(1).getEndDate()).isNull();
     assertThat(savedEntities.get(1).getCreatedBy()).isEqualTo("TEST_USER");
+    assertThat(savedEntities.get(1).getConfigType())
+        .isEqualTo(ConfigType.DISTRICT_VOLUME);
     assertThat(savedEntities.get(1).getTableLevelFactor())
         .isEqualTo(new BigDecimal("1.150"));
 

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
@@ -531,5 +531,4 @@ class DistrictVolumeServiceTest {
     assertThat(result.heliMultiplier())
         .isEqualTo(new BigDecimal("1.500"));
   }
-  
 }

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import ca.bc.gov.nrs.hrs.dto.districtaveragevolume.CoastDataDto;
 import ca.bc.gov.nrs.hrs.dto.districtaveragevolume.DistrictVolumeCreateDto;
 import ca.bc.gov.nrs.hrs.dto.districtaveragevolume.DistrictVolumeDetailDto;

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
@@ -531,4 +531,5 @@ class DistrictVolumeServiceTest {
     assertThat(result.heliMultiplier())
         .isEqualTo(new BigDecimal("1.500"));
   }
+  
 }


### PR DESCRIPTION
## Task Summary

Add a `config_type` discriminator column to the existing `district_volume` table via a Flyway migration, backfill all existing rows to `DISTRICT_VOLUME`, and introduce a `ConfigType` enum on `DistrictVolumeEntity` so the same table can later store both district volume and species composition data.

---

## Background

Part of the **District Level Species Composition Tables** epic ([[#1046](https://github.com/bcgov/nr-waste-plus/issues/1046)](https://github.com/bcgov/nr-waste-plus/issues/1046)). This task has no blockers and is the foundation for follow-on work — it unblocks [[#1049](https://github.com/bcgov/nr-waste-plus/issues/1049)](https://github.com/bcgov/nr-waste-plus/issues/1049) (DTOs + JSONB records + TypeScript types) and [[#1051](https://github.com/bcgov/nr-waste-plus/issues/1051)](https://github.com/bcgov/nr-waste-plus/issues/1051) (`SpeciesCompositionRepository`).

---

### Verification

- Run the migration against a Dev database and confirm all existing `district_volume` rows are backfilled to `DISTRICT_VOLUME`.
- Confirm the new `idx_district_volume_config_type` index is created.
- Confirm `DistrictVolumeEntity` reads/writes `configType` correctly and defaults new rows to `DISTRICT_VOLUME` when not explicitly set.
- Run existing backend tests to confirm no regressions from the new non-null column with a default.

---

## Acceptance Criteria

- [ ] Flyway migration `V1.0.4__add_config_type_to_district_volume.sql` adds `config_type` as `NOT NULL DEFAULT 'DISTRICT_VOLUME'`
- [ ] All existing rows are backfilled to `DISTRICT_VOLUME` via explicit `UPDATE`
- [ ] Index `idx_district_volume_config_type` is created on the new column
- [ ] `ConfigType` enum (`DISTRICT_VOLUME`, `SPECIES_COMPOSITION`) is added under `entity.districtaveragevolume`
- [ ] `DistrictVolumeEntity.configType` is mapped with `@Enumerated(EnumType.STRING)` and defaults to `DISTRICT_VOLUME`
- [ ] Migration and entity changes verified in Development
- [ ] Existing backend test suite passes with no regressions

---

## Affected Environments

- [x] Development
- [ ] Test
- [ ] Production

---

## Notes

- No business logic changes — this is purely a schema/entity change to prepare `district_volume` as a shared table for both district volume and (future) species composition data.
- Files touched: `ConfigType.java` (new), `DistrictVolumeEntity.java`, `V1.0.4__add_config_type_to_district_volume.sql` (new).
- Reference: PR [[#1076](https://github.com/bcgov/nr-waste-plus/pull/1076)](https://github.com/bcgov/nr-waste-plus/pull/1076) — `feat(be:#1048): DB Schema — config_type discriminator on district_volume table`, closes issue [[#1048](https://github.com/bcgov/nr-waste-plus/issues/1048)](https://github.com/bcgov/nr-waste-plus/issues/1048).

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-26-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)