### PR TITLE
feat(be:#1051): Added new methods for species composition

### DIFF
--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/DistrictVolumeRepository.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/DistrictVolumeRepository.java
@@ -1,10 +1,12 @@
 package ca.bc.gov.nrs.hrs.repository;
 
 import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.Area;
+import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.ConfigType;
 import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.DistrictVolumeEntity;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,7 +16,7 @@ import org.springframework.stereotype.Repository;
 
 /**
  * Repository for managing {@link DistrictVolumeEntity} records.
- * 
+ *
  * <p>Provides standard JPA operations together with custom queries used by
  * district volume business logic.
  */
@@ -57,7 +59,7 @@ public interface DistrictVolumeRepository
   Optional<DistrictVolumeEntity> findActiveByArea(
       @Param("area") Area area,
       @Param("currentDate") LocalDate currentDate);
-  
+
   /**
    * Finds all open-ended district volume entries for the specified area, ordered by most recent
    * start date first.
@@ -66,4 +68,30 @@ public interface DistrictVolumeRepository
    * @return ordered list of open-ended entries for the area
    */
   List<DistrictVolumeEntity> findByAreaAndEndDateIsNullOrderByStartDateDesc(Area area);
+
+  /**
+   * Retrieves a paginated list of district volume records filtered by config type.
+   *
+   * <p>Used to scope queries to a specific configuration (e.g. district volume vs
+   * species composition), since both share the same underlying table and entity.
+   *
+   * @param configType config type filter
+   * @param pageable pagination and sorting information
+   * @return paginated list of matching district volume entities
+   */
+  Page<DistrictVolumeEntity> findAllByConfigType(ConfigType configType, Pageable pageable);
+
+  /**
+   * Retrieves a single district volume record by id, scoped to the specified config type.
+   *
+   * <p>Ensures records of one config type (e.g. species composition) cannot be looked up
+   * or returned as if they belonged to another.
+   *
+   * @param id record identifier
+   * @param configType config type the record must match
+   * @return the matching entity, or an empty {@link Optional} if not found or if the
+   *     config type does not match
+   */
+  Optional<DistrictVolumeEntity> findByIdAndConfigType(Long id, ConfigType configType);
+
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/DistrictVolumeRepository.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/DistrictVolumeRepository.java
@@ -6,7 +6,6 @@ import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.DistrictVolumeEntity;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/repository/DistrictVolumeRepositoryTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/repository/DistrictVolumeRepositoryTest.java
@@ -1,20 +1,21 @@
 package ca.bc.gov.nrs.hrs.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import ca.bc.gov.nrs.hrs.extensions.AbstractTestContainerIntegrationTest;
 import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.Area;
+import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.ConfigType;
 import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.DistrictVolumeEntity;
 import ca.bc.gov.nrs.hrs.entity.districtaveragevolume.TableData;
+import ca.bc.gov.nrs.hrs.extensions.AbstractTestContainerIntegrationTest;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
-public class DistrictVolumeRepositoryTest 
+public class DistrictVolumeRepositoryTest
     extends AbstractTestContainerIntegrationTest {
 
   @Autowired
@@ -26,8 +27,7 @@ public class DistrictVolumeRepositoryTest
     // Ensure auditing picks up a principal so NOT NULL audit columns are populated
     JwtAuthenticationToken token = new JwtAuthenticationToken(
         this.jwt,
-        AuthorityUtils.createAuthorityList()
-    );
+        AuthorityUtils.createAuthorityList());
     SecurityContextHolder.getContext().setAuthentication(token);
 
     DistrictVolumeEntity first = new DistrictVolumeEntity();
@@ -49,5 +49,70 @@ public class DistrictVolumeRepositoryTest
 
     assertThat(opt).isPresent();
     assertThat(opt.get().getStartDate()).isEqualTo(second.getStartDate());
+  }
+
+  @Test
+  void findAllByConfigType_returnsOnlyMatchingConfigType() {
+
+    JwtAuthenticationToken token = new JwtAuthenticationToken(
+        this.jwt,
+        AuthorityUtils.createAuthorityList());
+    SecurityContextHolder.getContext().setAuthentication(token);
+
+    DistrictVolumeEntity districtVolume = new DistrictVolumeEntity();
+    districtVolume.setArea(Area.INTERIOR);
+    districtVolume.setStartDate(LocalDate.now().plusDays(1));
+    districtVolume.setTableData(new TableData(null, null, java.util.Map.of()));
+    districtVolume.setTableLevelFactor(new BigDecimal("1.000").setScale(3));
+    districtVolume.setConfigType(ConfigType.DISTRICT_VOLUME);
+
+    DistrictVolumeEntity speciesComposition = new DistrictVolumeEntity();
+    speciesComposition.setArea(Area.INTERIOR);
+    speciesComposition.setStartDate(LocalDate.now().plusDays(2));
+    speciesComposition.setTableData(new TableData(null, null, java.util.Map.of()));
+    speciesComposition.setTableLevelFactor(new BigDecimal("2.000").setScale(3));
+    speciesComposition.setConfigType(ConfigType.SPECIES_COMPOSITION);
+
+    repository.save(districtVolume);
+    repository.save(speciesComposition);
+
+    var result = repository.findAllByConfigType(
+        ConfigType.SPECIES_COMPOSITION,
+        PageRequest.of(0, 10));
+
+    assertThat(result.getContent())
+        .hasSize(1)
+        .allMatch(
+            entity -> entity.getConfigType() == ConfigType.SPECIES_COMPOSITION);
+  }
+
+  @Test
+  void findByIdAndConfigType_returnsEmpty_whenConfigTypeDoesNotMatch() {
+
+    JwtAuthenticationToken token = new JwtAuthenticationToken(
+        this.jwt,
+        AuthorityUtils.createAuthorityList());
+    SecurityContextHolder.getContext().setAuthentication(token);
+
+    DistrictVolumeEntity districtVolume = new DistrictVolumeEntity();
+    districtVolume.setArea(Area.INTERIOR);
+    districtVolume.setStartDate(LocalDate.now().plusDays(1));
+    districtVolume.setTableData(new TableData(null, null, java.util.Map.of()));
+    districtVolume.setTableLevelFactor(new BigDecimal("1.000").setScale(3));
+    districtVolume.setConfigType(ConfigType.DISTRICT_VOLUME);
+
+    DistrictVolumeEntity saved = repository.save(districtVolume);
+
+    assertThat(
+        repository.findByIdAndConfigType(
+            saved.getId(),
+            ConfigType.DISTRICT_VOLUME))
+        .isPresent();
+
+    assertThat(
+        repository.findByIdAndConfigType(
+            saved.getId(),
+            ConfigType.SPECIES_COMPOSITION))
+        .isEmpty();
   }
 }


### PR DESCRIPTION
## Task Summary

Add repository support for filtering `DistrictVolumeEntity` records by `configType`, so species composition records (added in #1048) can be queried alongside — but distinctly from — regular district volume records.

Closes #1051

---

## Background

#1048 added a `configType` discriminator column to `district_volume`, distinguishing `DISTRICT_VOLUME` and `SPECIES_COMPOSITION` records within the same table. #1051 asks for the repository layer to support querying species composition records by this discriminator, ahead of the service layer work in #1053.

---

## **Implementation Notes**

Two deliberate deviations from the issue's original code snippet — see PR comment for full reasoning:

- **No new `SpeciesCompositionRepository`.** The two new methods were added directly to the existing `DistrictVolumeRepository`, since both config types share the same entity/table and a second interface would add naming clarity but no functional separation.
- **`Long id`, not `UUID id`.** `DistrictVolumeEntity`'s primary key is `Long` (confirmed via the existing repository's generic type and existing test usage). The issue's snippet used `UUID`, which appears to be a stale template artifact.

### Methods added

```java
Page<DistrictVolumeEntity> findAllByConfigType(ConfigType configType, Pageable pageable);

Optional<DistrictVolumeEntity> findByIdAndConfigType(Long id, ConfigType configType);
```

---

## Acceptance Criteria

- [x] Repository supports paginated lookup of records by `configType`
- [x] Repository supports single-record lookup scoped to a `configType`
- [x] Javadocs added for new methods, consistent with existing style

---

## Notes

- `SpeciesCompositionService` (#1053) should inject `DistrictVolumeRepository`, not a separate `SpeciesCompositionRepository` — flagging here so that ticket's description can be updated if needed.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-30-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)