### PR TITLE
perf: optimize frontend unit tests, docker build cache, Cypress retries

### DIFF
--- a/.github/workflows/reusable-tests-fe.yml
+++ b/.github/workflows/reusable-tests-fe.yml
@@ -41,8 +41,6 @@ jobs:
     name: Frontend Unit Tests
     if: needs.detect-changes.outputs.triggered == 'true'
     needs: [detect-changes]
-    container:
-      image: mcr.microsoft.com/playwright:v1.61.1-noble
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/reusable-tests-fe.yml
+++ b/.github/workflows/reusable-tests-fe.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Fix safe.directory for GitHub Actions
-        run: git config --global --add safe.directory /__w/nr-waste-plus/nr-waste-plus
+        run: git config --global --add safe.directory '*'
 
       - name: Run frontend unit tests without sonar
         uses: bcgov/action-test-and-analyse@8f699e3fd3fadd9a6adf6f4b1f2638ef7ecfefb9 # v2.0.0
@@ -58,7 +58,7 @@ jobs:
           node_version: 24
           dep_scan: off
           commands: |
-            git config --global --add safe.directory /__w/nr-waste-plus/nr-waste-plus
+            git config --global --add safe.directory '*'
             npm ci
             npm run test:unit
           dir: frontend

--- a/.github/workflows/reusable-tests-fe.yml
+++ b/.github/workflows/reusable-tests-fe.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Fix safe.directory for GitHub Actions
-        run: git config --global --add safe.directory '*'
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run frontend unit tests without sonar
         uses: bcgov/action-test-and-analyse@8f699e3fd3fadd9a6adf6f4b1f2638ef7ecfefb9 # v2.0.0
@@ -58,7 +58,7 @@ jobs:
           node_version: 24
           dep_scan: off
           commands: |
-            git config --global --add safe.directory '*'
+            git config --global --add safe.directory "$GITHUB_WORKSPACE"
             npm ci
             npm run test:unit
           dir: frontend

--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -279,7 +279,7 @@ export default defineConfig({
   viewportHeight: 1080,
   viewportWidth: 1920,
   retries: {    
-    runMode: 1,
+    runMode: 2,
     openMode: 0,
   },
 });

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,6 @@ FROM node:24.18-bullseye-slim AS build
 
 # Cache npm dependencies by copying package files first
 WORKDIR /app
-# Cache npm dependencies by copying package files first
 COPY package*.json ./
 RUN npm ci --ignore-scripts
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24.18-bullseye-slim AS build
 
 # Cache npm dependencies by copying package files first
 WORKDIR /app
-COPY package*.json ./
+COPY package*.json .npmrc* ./
 RUN npm ci --ignore-scripts
 
 # Build static files

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,6 @@ COPY . .
 RUN npm run build && \
     rm -rf node_modules
 
-
 # Caddy
 FROM caddy:2.11.4-alpine
 ENV LOG_LEVEL=info

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,13 +1,12 @@
 FROM node:24.18-bullseye-slim AS build
 
-# Build static files
+# Cache npm dependencies by copying package files first
 WORKDIR /app
 COPY package*.json ./
-
 RUN npm ci --ignore-scripts
 
+# Build static files
 COPY . .
-
 RUN npm run build && \
     rm -rf node_modules
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,7 @@ FROM node:24.18-bullseye-slim AS build
 
 # Cache npm dependencies by copying package files first
 WORKDIR /app
+# Cache npm dependencies by copying package files first
 COPY package*.json ./
 RUN npm ci --ignore-scripts
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,11 +2,15 @@ FROM node:24.18-bullseye-slim AS build
 
 # Build static files
 WORKDIR /app
+COPY package*.json ./
+
+RUN npm ci --ignore-scripts
+
 COPY . .
 
-RUN npm ci --ignore-scripts && \
-    npm run build && \
+RUN npm run build && \
     rm -rf node_modules
+
 
 # Caddy
 FROM caddy:2.11.4-alpine

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,9 +18,8 @@ ENV LOG_LEVEL=info
 COPY --from=build /app/build/ /srv
 COPY Caddyfile /etc/caddy/Caddyfile
 
-# CA certs and Caddy format
-RUN apk add --no-cache ca-certificates && \
-    caddy fmt --overwrite /etc/caddy/Caddyfile
+# CA certs
+RUN apk add --no-cache ca-certificates
 
 # User, port and healthcheck
 USER 1001


### PR DESCRIPTION
### Goal
Optimize frontend build, test, and E2E workflow performance by removing unnecessary container overhead, caching node dependencies, and mitigating testing flakes.

### Proposed Changes
- **CI Workflows:**
  - Removed the heavy Playwright Docker container block from the frontend unit tests job in reusable-tests-fe.yml. Unit tests now run directly on the host VM (ubuntu-24.04).
  - Replaced the wildcard safe.directory configuration with "$GITHUB_WORKSPACE" to limit git trust mapping specifically to the active checkout directory on the runner host.
- **Docker Build Caching:**
  - Split the copy step in frontend/Dockerfile to copy package*.json and .npmrc* first. This leverages Docker layer caching to skip NPM package installation on subsequent builds unless package dependencies change.
  - Removed the redundant caddy fmt --overwrite instruction from the production image build to prevent formatting overhead in the final build stage.
- **E2E Stability:**
  - Increased Cypress testing retries (runMode) from 1 to 2 in cypress/cypress.config.ts to handle transient Lighthouse performance anomalies on GHA host runners.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-31-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)