### PR TITLE
chore(cd): rolling updates, HPA 2–5, and drain-safe PDBs

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -47,7 +47,7 @@ on:
         required: false
         type: string
 
-    permissions: {}
+permissions: {}
 
 jobs:
   vars:

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Deployment Init
-        uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # after v4.2.0
+        uses: bcgov/action-deployer-openshift@27a85b7b157bfc9c3c9bf0aca53bcd288d4d2506 # v4.2.1
         with:
           file: common/openshift.init.yml
           oc_namespace: ${{ secrets.OC_NAMESPACE }}
@@ -127,7 +127,7 @@ jobs:
               -p ORACLEDB_PORT=${{ inputs.oracledb-port }}
             verification_path: actuator/health
     steps:
-      - uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # after v4.2.0
+      - uses: bcgov/action-deployer-openshift@27a85b7b157bfc9c3c9bf0aca53bcd288d4d2506 # v4.2.1
         id: deploys
         with:
           file: ${{ matrix.name }}/openshift.deploy.yml

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -47,7 +47,7 @@ on:
         required: false
         type: string
 
-permissions: {}
+    permissions: {}
 
 jobs:
   vars:
@@ -112,14 +112,17 @@ jobs:
           - name: database
             overwrite: false
           - name: frontend
+            overwrite: true
             parameters:
               -p URL=${{ inputs.url }}
               -p CONFIG_MAP="${{ inputs.configmap-frontend }}"
           - name: backend
+            overwrite: true
             parameters:
               -p FRONTEND_URL=${{ inputs.url }}
               -p CONFIG_MAP="${{ inputs.configmap-backend }}"
           - name: legacy
+            overwrite: true
             parameters:
               -p ORACLEDB_PORT=${{ inputs.oracledb-port }}
             verification_path: actuator/health
@@ -132,6 +135,8 @@ jobs:
           oc_server: ${{ secrets.oc_server }}
           oc_token: ${{ secrets.oc_token }}
           overwrite: ${{ matrix.overwrite }}
+          # PRs: strip HPA/PDB, force 1 replica + Recreate. TEST/PROD keep RollingUpdate + HPA.
+          lite_mode: ${{ github.event_name == 'pull_request' }}
           parameters:
             -p TAG=${{ needs.vars.outputs.tag }}
             -p ZONE=${{ inputs.zone }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Deployment Init
-        uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # fix lite_mode Recreate+rollingUpdate (PR #163)
+        uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # after v4.2.0
         with:
           file: common/openshift.init.yml
           oc_namespace: ${{ secrets.OC_NAMESPACE }}
@@ -127,7 +127,7 @@ jobs:
               -p ORACLEDB_PORT=${{ inputs.oracledb-port }}
             verification_path: actuator/health
     steps:
-      - uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # fix lite_mode Recreate+rollingUpdate (PR #163)
+      - uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # after v4.2.0
         id: deploys
         with:
           file: ${{ matrix.name }}/openshift.deploy.yml
@@ -135,7 +135,6 @@ jobs:
           oc_server: ${{ secrets.oc_server }}
           oc_token: ${{ secrets.oc_token }}
           overwrite: ${{ matrix.overwrite }}
-          # PRs: strip HPA/PDB, force 1 replica + Recreate. TEST/PROD keep RollingUpdate + HPA.
           parameters:
             -p TAG=${{ needs.vars.outputs.tag }}
             -p ZONE=${{ inputs.zone }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Deployment Init
-        uses: bcgov/action-deployer-openshift@1ffe5c65252909912e1dfad2dc7f683587d21da9 # v4.2.0
+        uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # fix lite_mode Recreate+rollingUpdate (PR #163)
         with:
           file: common/openshift.init.yml
           oc_namespace: ${{ secrets.OC_NAMESPACE }}
@@ -127,7 +127,7 @@ jobs:
               -p ORACLEDB_PORT=${{ inputs.oracledb-port }}
             verification_path: actuator/health
     steps:
-      - uses: bcgov/action-deployer-openshift@1ffe5c65252909912e1dfad2dc7f683587d21da9 # v4.2.0
+      - uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # fix lite_mode Recreate+rollingUpdate (PR #163)
         id: deploys
         with:
           file: ${{ matrix.name }}/openshift.deploy.yml

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -136,7 +136,6 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           overwrite: ${{ matrix.overwrite }}
           # PRs: strip HPA/PDB, force 1 replica + Recreate. TEST/PROD keep RollingUpdate + HPA.
-          lite_mode: false
           parameters:
             -p TAG=${{ needs.vars.outputs.tag }}
             -p ZONE=${{ inputs.zone }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -136,7 +136,7 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           overwrite: ${{ matrix.overwrite }}
           # PRs: strip HPA/PDB, force 1 replica + Recreate. TEST/PROD keep RollingUpdate + HPA.
-          lite_mode: ${{ github.event_name == 'pull_request' }}
+          lite_mode: false
           parameters:
             -p TAG=${{ needs.vars.outputs.tag }}
             -p ZONE=${{ inputs.zone }}

--- a/.github/workflows/.tools-deploy.yml
+++ b/.github/workflows/.tools-deploy.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Initializing Deployment
-        uses: bcgov/action-deployer-openshift@1ffe5c65252909912e1dfad2dc7f683587d21da9 # v4.2.0
+        uses: bcgov/action-deployer-openshift@27a85b7b157bfc9c3c9bf0aca53bcd288d4d2506 # v4.2.1
         with:
           file: legacydb/openshift.deploy.yml
           oc_namespace: cffaf3-tools

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -27,6 +27,12 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
+  - name: MIN_REPLICAS
+    description: Minimum replicas for the horizontal pod autoscaler
+    value: "3"
+  - name: MAX_REPLICAS
+    description: Maximum replicas for the horizontal pod autoscaler
+    value: "7"
   - name: CPU_REQUEST
     value: 75m
   - name: MEMORY_REQUEST
@@ -55,7 +61,6 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: 1
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}
@@ -71,6 +76,16 @@ objects:
             app: ${NAME}-${ZONE}
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
+          terminationGracePeriodSeconds: 30
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        deployment: ${NAME}-${ZONE}-${COMPONENT}
+                    topologyKey: kubernetes.io/hostname
           volumes:
             - name: ${COMPONENT}-config
               configMap:
@@ -146,6 +161,10 @@ objects:
                 initialDelaySeconds: 10
                 periodSeconds: 30
                 timeoutSeconds: 5
+              lifecycle:
+                preStop:
+                  exec:
+                    command: ["/bin/sleep", "10"]
   - kind: Service
     apiVersion: v1
     metadata:
@@ -186,3 +205,49 @@ objects:
     data:
       application.yml: |
         ${CONFIG_MAP}
+  - apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      labels:
+        app: ${NAME}-${ZONE}
+      name: ${NAME}-${ZONE}-${COMPONENT}
+    spec:
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: ${NAME}-${ZONE}-${COMPONENT}
+      minReplicas: ${{MIN_REPLICAS}}
+      maxReplicas: ${{MAX_REPLICAS}}
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 80
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 30
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 60
+          selectPolicy: Max
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Percent
+              value: 50
+              periodSeconds: 60
+          selectPolicy: Max
+  - apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        app: ${NAME}-${ZONE}
+      name: ${NAME}-${ZONE}-${COMPONENT}
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -29,10 +29,10 @@ parameters:
     value: ghcr.io
   - name: MIN_REPLICAS
     description: Minimum replicas for the horizontal pod autoscaler
-    value: "3"
+    value: "2"
   - name: MAX_REPLICAS
     description: Maximum replicas for the horizontal pod autoscaler
-    value: "7"
+    value: "5"
   - name: CPU_REQUEST
     value: 75m
   - name: MEMORY_REQUEST
@@ -66,6 +66,9 @@ objects:
           deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          maxSurge: 1
       template:
         metadata:
           annotations:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -33,8 +33,15 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
+  - name: MIN_REPLICAS
+    description: Minimum replicas for the horizontal pod autoscaler
+    value: "3"
+  - name: MAX_REPLICAS
+    description: Maximum replicas for the horizontal pod autoscaler
+    value: "5"
   - name: CPU_REQUEST
-    value: 10m
+    # HPA targets CPU utilization vs requests; 10m makes 80% noise.
+    value: 50m
   - name: MEMORY_REQUEST
     value: 50Mi
   - name: LOG_LEVEL
@@ -61,7 +68,6 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: 1
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}
@@ -77,6 +83,16 @@ objects:
             app: ${NAME}-${ZONE}
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
+          terminationGracePeriodSeconds: 30
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        deployment: ${NAME}-${ZONE}-${COMPONENT}
+                    topologyKey: kubernetes.io/hostname
           volumes:
             - name: app-config
               configMap:
@@ -148,6 +164,10 @@ objects:
                 initialDelaySeconds: 15
                 periodSeconds: 30
                 timeoutSeconds: 5
+              lifecycle:
+                preStop:
+                  exec:
+                    command: ["/bin/sleep", "10"]
   - kind: Service
     apiVersion: v1
     metadata:
@@ -192,3 +212,49 @@ objects:
     data:
       params.js: |
         ${CONFIG_MAP}
+  - apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      labels:
+        app: ${NAME}-${ZONE}
+      name: ${NAME}-${ZONE}-${COMPONENT}
+    spec:
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: ${NAME}-${ZONE}-${COMPONENT}
+      minReplicas: ${{MIN_REPLICAS}}
+      maxReplicas: ${{MAX_REPLICAS}}
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 80
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 30
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 60
+          selectPolicy: Max
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Percent
+              value: 50
+              periodSeconds: 60
+          selectPolicy: Max
+  - apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        app: ${NAME}-${ZONE}
+      name: ${NAME}-${ZONE}-${COMPONENT}
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -35,7 +35,7 @@ parameters:
     value: ghcr.io
   - name: MIN_REPLICAS
     description: Minimum replicas for the horizontal pod autoscaler
-    value: "3"
+    value: "2"
   - name: MAX_REPLICAS
     description: Maximum replicas for the horizontal pod autoscaler
     value: "5"
@@ -73,6 +73,9 @@ objects:
           deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          maxSurge: 1
       template:
         metadata:
           annotations:

--- a/legacy/openshift.deploy.yml
+++ b/legacy/openshift.deploy.yml
@@ -29,6 +29,12 @@ parameters:
   - name: ORACLEDB_PORT
     description: Oracle database port
     value: "1543"
+  - name: MIN_REPLICAS
+    description: Minimum replicas for the horizontal pod autoscaler
+    value: "3"
+  - name: MAX_REPLICAS
+    description: Maximum replicas for the horizontal pod autoscaler
+    value: "5"
   - name: CPU_REQUEST
     value: 75m
   - name: MEMORY_REQUEST
@@ -64,7 +70,6 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: 1
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}
@@ -80,6 +85,16 @@ objects:
             app: ${NAME}-${ZONE}
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
+          terminationGracePeriodSeconds: 30
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        deployment: ${NAME}-${ZONE}-${COMPONENT}
+                    topologyKey: kubernetes.io/hostname
           volumes:
             - name: ${NAME}-${ZONE}-certs
               persistentVolumeClaim:
@@ -194,6 +209,10 @@ objects:
                 initialDelaySeconds: 3
                 periodSeconds: 30
                 timeoutSeconds: 5
+              lifecycle:
+                preStop:
+                  exec:
+                    command: ["/bin/sleep", "10"]
               volumeMounts:
                 - mountPath: /cert
                   name: ${NAME}-${ZONE}-certs
@@ -211,3 +230,49 @@ objects:
           targetPort: 9090
       selector:
         deployment: ${NAME}-${ZONE}-${COMPONENT}
+  - apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      labels:
+        app: ${NAME}-${ZONE}
+      name: ${NAME}-${ZONE}-${COMPONENT}
+    spec:
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: ${NAME}-${ZONE}-${COMPONENT}
+      minReplicas: ${{MIN_REPLICAS}}
+      maxReplicas: ${{MAX_REPLICAS}}
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 80
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 30
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 60
+          selectPolicy: Max
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Percent
+              value: 50
+              periodSeconds: 60
+          selectPolicy: Max
+  - apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        app: ${NAME}-${ZONE}
+      name: ${NAME}-${ZONE}-${COMPONENT}
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/legacy/openshift.deploy.yml
+++ b/legacy/openshift.deploy.yml
@@ -31,7 +31,7 @@ parameters:
     value: "1543"
   - name: MIN_REPLICAS
     description: Minimum replicas for the horizontal pod autoscaler
-    value: "3"
+    value: "2"
   - name: MAX_REPLICAS
     description: Maximum replicas for the horizontal pod autoscaler
     value: "5"
@@ -75,6 +75,9 @@ objects:
           deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          maxSurge: 1
       template:
         metadata:
           annotations:


### PR DESCRIPTION
## Summary

Enable TEST/PROD to survive node drains and roll out without dropping to zero Ready pods.

- **HPA** on frontend / backend / legacy: CPU 80%, explicit scale-up/down behavior, defaults **min 2 / max 5** (idle lean, burst under load)
- **PDB** `maxUnavailable: 1` so voluntary disruptions (node drains) cannot take all replicas down
- **Preferred pod anti-affinity** to spread replicas across nodes
- **RollingUpdate** with pinned `maxUnavailable: 1` / `maxSurge: 1` (one-at-a-time deploys; ≥1 Ready when min ≥ 2)
- Drop hard-coded `replicas: 1` so HPA owns replica count
- `terminationGracePeriodSeconds: 30` + `preStop` sleep for drain-friendly shutdowns
- Frontend `CPU_REQUEST` `10m` → `50m` so HPA utilization is not noise
- Explicit `overwrite: true` for scalable components so HPA/PDB updates apply cleanly
- Database stays single-replica / Recreate (stateful)
- Bump `bcgov/action-deployer-openshift` past v4.2.0 for deploy compatibility with pinned RollingUpdate

Integer HPA fields use OpenShift `${{PARAM}}` (non-string) substitution — not GitHub Actions syntax.

Closes #1079

## Suggested follow-ups (not in this PR)

1. **Memory limits** — add from Sysdig P99 + headroom (quickstart sets `MEMORY_LIMIT`)
2. **Backend probes** — add `startupProbe` + cheap liveness (`/actuator/health/liveness`)
3. **Deduplicate `REGISTRY` param** in frontend/backend templates
4. **Postgres connection budget** — Hikari `maximumPoolSize: 3` × max pods; confirm before raising `MAX_REPLICAS`
5. **Legacy initContainer** — cert extractor on shared RWX PVC under scale-up
6. **VPA recommend-only** — tune requests without fighting HPA

## Test plan

- [ ] TEST/PROD: HPA `minReplicas: 2` / `maxReplicas: 5` for frontend, backend, legacy
- [ ] Deployment strategy is RollingUpdate with `maxUnavailable: 1` / `maxSurge: 1`
- [ ] PDB present with `maxUnavailable: 1`
- [ ] Pods prefer different nodes (anti-affinity)
- [ ] Rollout keeps ≥1 Ready endpoint
- [ ] Under CPU load, replicas scale toward 5; scale-down stabilizes (~5 min)
- [ ] Database remains 1 replica / Recreate

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-36-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)