### PR TITLE
feat(#1091): centralize Location-header resource-ID extraction in HttpClient

### DIFF
--- a/frontend/src/config/api/httpClient.unit.test.ts
+++ b/frontend/src/config/api/httpClient.unit.test.ts
@@ -7,14 +7,22 @@ const mockConfig = { BASE: 'http://localhost', VERSION: 'v1' } as any;
 
 /**
  * Test-only subclass that re-exposes the protected `createResource` so it can
- * be exercised directly, mirroring how the real services consume it.
+ * be exercised directly, mirroring how the real services consume it. Mirrors
+ * the public overloads: no-parser form yields `number`, parser form yields `T`.
  */
 class TestHttpClient extends HttpClient {
+  public createResourceTest(
+    options: import('./types').ApiRequestOptions,
+  ): import('./CancelablePromise').CancelablePromise<number>;
+  public createResourceTest<T>(
+    options: import('./types').ApiRequestOptions,
+    idParser: (location: string) => T,
+  ): import('./CancelablePromise').CancelablePromise<T>;
   public createResourceTest<T = number>(
     options: import('./types').ApiRequestOptions,
     idParser?: (location: string) => T,
   ): import('./CancelablePromise').CancelablePromise<T> {
-    return this.createResource<T>(options, idParser);
+    return this.createResource<T>(options, idParser as (location: string) => T);
   }
 }
 
@@ -25,7 +33,7 @@ describe('HttpClient.createResource', () => {
     const client = makeClient();
     (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/555');
 
-    const result = await client.createResourceTest<number>({
+    const result = await client.createResourceTest({
       method: 'POST',
       url: '/api/reporting-units',
       body: { foo: 'bar' },
@@ -47,7 +55,7 @@ describe('HttpClient.createResource', () => {
     const client = makeClient();
     (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/777?v=1');
 
-    const result = await client.createResourceTest<number>({
+    const result = await client.createResourceTest({
       method: 'POST',
       url: '/api/reporting-units',
     });
@@ -74,7 +82,7 @@ describe('HttpClient.createResource', () => {
     (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/');
 
     await expect(
-      client.createResourceTest<number>({ method: 'POST', url: '/api/reporting-units' }),
+      client.createResourceTest({ method: 'POST', url: '/api/reporting-units' }),
     ).rejects.toThrow('Invalid Location header: "/reporting-units/"');
   });
 
@@ -84,7 +92,7 @@ describe('HttpClient.createResource', () => {
     (client as any).doRequest = vi.fn().mockRejectedValue(apiError);
 
     await expect(
-      client.createResourceTest<number>({ method: 'POST', url: '/api/reporting-units' }),
+      client.createResourceTest({ method: 'POST', url: '/api/reporting-units' }),
     ).rejects.toThrow('400: Validation failed');
   });
 
@@ -94,7 +102,7 @@ describe('HttpClient.createResource', () => {
     (innerRequest as any).cancel = vi.fn();
     (client as any).doRequest = vi.fn().mockReturnValue(innerRequest);
 
-    const request = client.createResourceTest<number>({
+    const request = client.createResourceTest({
       method: 'POST',
       url: '/api/reporting-units',
     });
@@ -110,7 +118,7 @@ describe('HttpClient.createResource', () => {
     const meta = { notificationTarget: 'create-ru' };
     (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/9');
 
-    await client.createResourceTest<number>({
+    await client.createResourceTest({
       method: 'POST',
       url: '/api/reporting-units',
       body: {},

--- a/frontend/src/config/api/httpClient.unit.test.ts
+++ b/frontend/src/config/api/httpClient.unit.test.ts
@@ -1,0 +1,112 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi } from 'vitest';
+
+import { HttpClient } from './types';
+
+const mockConfig = { BASE: 'http://localhost', VERSION: 'v1' } as any;
+
+const makeClient = (): HttpClient => new HttpClient(mockConfig);
+
+describe('HttpClient.createResource', () => {
+  it('passes responseHeader:"location" and resolves the parsed ID', async () => {
+    const client = makeClient();
+    (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/555');
+
+    const result = await client.createResource<number>({
+      method: 'POST',
+      url: '/api/reporting-units',
+      body: { foo: 'bar' },
+    });
+
+    expect(result).toBe(555);
+    expect((client as any).doRequest).toHaveBeenCalledWith(
+      mockConfig,
+      expect.objectContaining({
+        method: 'POST',
+        url: '/api/reporting-units',
+        body: { foo: 'bar' },
+        responseHeader: 'location',
+      }),
+    );
+  });
+
+  it('uses the default trailing-numeric parser for query-string Location values', async () => {
+    const client = makeClient();
+    (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/777?v=1');
+
+    const result = await client.createResource<number>({
+      method: 'POST',
+      url: '/api/reporting-units',
+    });
+
+    expect(result).toBe(777);
+  });
+
+  it('forwards a custom idParser', async () => {
+    const client = makeClient();
+    (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/abc');
+    const idParser = vi.fn((location: string): string => location.split('/').pop()!);
+
+    const result = await client.createResource<string>(
+      { method: 'POST', url: '/api/reporting-units' },
+      idParser,
+    );
+
+    expect(idParser).toHaveBeenCalledWith('/reporting-units/abc');
+    expect(result).toBe('abc');
+  });
+
+  it('rejects with the canonical message when the Location header cannot be parsed', async () => {
+    const client = makeClient();
+    (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/');
+
+    await expect(
+      client.createResource<number>({ method: 'POST', url: '/api/reporting-units' }),
+    ).rejects.toThrow('Invalid Location header: "/reporting-units/"');
+  });
+
+  it('propagates HTTP / network errors unchanged', async () => {
+    const client = makeClient();
+    const apiError = new Error('400: Validation failed');
+    (client as any).doRequest = vi.fn().mockRejectedValue(apiError);
+
+    await expect(
+      client.createResource<number>({ method: 'POST', url: '/api/reporting-units' }),
+    ).rejects.toThrow('400: Validation failed');
+  });
+
+  it('cancels the underlying request when cancelled', async () => {
+    const client = makeClient();
+    const innerRequest = new Promise<string>(() => {});
+    (innerRequest as any).cancel = vi.fn();
+    (client as any).doRequest = vi.fn().mockReturnValue(innerRequest);
+
+    const request = client.createResource<number>({
+      method: 'POST',
+      url: '/api/reporting-units',
+    });
+
+    request.cancel();
+
+    await expect(request).rejects.toThrow('Request aborted');
+    expect((innerRequest as any).cancel).toHaveBeenCalled();
+  });
+
+  it('passes meta through to doRequest', async () => {
+    const client = makeClient();
+    const meta = { notificationTarget: 'create-ru' };
+    (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/9');
+
+    await client.createResource<number>({
+      method: 'POST',
+      url: '/api/reporting-units',
+      body: {},
+      meta,
+    });
+
+    expect((client as any).doRequest).toHaveBeenCalledWith(
+      mockConfig,
+      expect.objectContaining({ meta }),
+    );
+  });
+});

--- a/frontend/src/config/api/httpClient.unit.test.ts
+++ b/frontend/src/config/api/httpClient.unit.test.ts
@@ -5,14 +5,27 @@ import { HttpClient } from './types';
 
 const mockConfig = { BASE: 'http://localhost', VERSION: 'v1' } as any;
 
-const makeClient = (): HttpClient => new HttpClient(mockConfig);
+/**
+ * Test-only subclass that re-exposes the protected `createResource` so it can
+ * be exercised directly, mirroring how the real services consume it.
+ */
+class TestHttpClient extends HttpClient {
+  public createResourceTest<T = number>(
+    options: import('./types').ApiRequestOptions,
+    idParser?: (location: string) => T,
+  ): import('./CancelablePromise').CancelablePromise<T> {
+    return this.createResource<T>(options, idParser);
+  }
+}
+
+const makeClient = (): TestHttpClient => new TestHttpClient(mockConfig);
 
 describe('HttpClient.createResource', () => {
   it('passes responseHeader:"location" and resolves the parsed ID', async () => {
     const client = makeClient();
     (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/555');
 
-    const result = await client.createResource<number>({
+    const result = await client.createResourceTest<number>({
       method: 'POST',
       url: '/api/reporting-units',
       body: { foo: 'bar' },
@@ -34,7 +47,7 @@ describe('HttpClient.createResource', () => {
     const client = makeClient();
     (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/777?v=1');
 
-    const result = await client.createResource<number>({
+    const result = await client.createResourceTest<number>({
       method: 'POST',
       url: '/api/reporting-units',
     });
@@ -47,7 +60,7 @@ describe('HttpClient.createResource', () => {
     (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/abc');
     const idParser = vi.fn((location: string): string => location.split('/').pop()!);
 
-    const result = await client.createResource<string>(
+    const result = await client.createResourceTest<string>(
       { method: 'POST', url: '/api/reporting-units' },
       idParser,
     );
@@ -61,7 +74,7 @@ describe('HttpClient.createResource', () => {
     (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/');
 
     await expect(
-      client.createResource<number>({ method: 'POST', url: '/api/reporting-units' }),
+      client.createResourceTest<number>({ method: 'POST', url: '/api/reporting-units' }),
     ).rejects.toThrow('Invalid Location header: "/reporting-units/"');
   });
 
@@ -71,7 +84,7 @@ describe('HttpClient.createResource', () => {
     (client as any).doRequest = vi.fn().mockRejectedValue(apiError);
 
     await expect(
-      client.createResource<number>({ method: 'POST', url: '/api/reporting-units' }),
+      client.createResourceTest<number>({ method: 'POST', url: '/api/reporting-units' }),
     ).rejects.toThrow('400: Validation failed');
   });
 
@@ -81,7 +94,7 @@ describe('HttpClient.createResource', () => {
     (innerRequest as any).cancel = vi.fn();
     (client as any).doRequest = vi.fn().mockReturnValue(innerRequest);
 
-    const request = client.createResource<number>({
+    const request = client.createResourceTest<number>({
       method: 'POST',
       url: '/api/reporting-units',
     });
@@ -97,7 +110,7 @@ describe('HttpClient.createResource', () => {
     const meta = { notificationTarget: 'create-ru' };
     (client as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/9');
 
-    await client.createResource<number>({
+    await client.createResourceTest<number>({
       method: 'POST',
       url: '/api/reporting-units',
       body: {},

--- a/frontend/src/config/api/locationHeader.ts
+++ b/frontend/src/config/api/locationHeader.ts
@@ -3,41 +3,28 @@
  *
  * The backend returns HTTP 201 (Created) with a `Location` header pointing at
  * the newly created resource, e.g. `/reporting-units/42` or
- * `http://host/api/reporting-units/777?v=1`. The default parser reads the
- * trailing numeric segment of the path, ignoring any query string, so both
- * `/foo/42` and `/foo/777?v=1` resolve to `42` and `777` respectively.
+ * `http://host/api/reporting-units/777?v=1`. The parser reads the **final**
+ * numeric segment of the path (after stripping any query string or hash), so
+ * `/reporting-units/42` -> 42, `/foo/777?v=1` -> 777, and
+ * `/api/2024/reporting-units/777` -> 777 (the trailing segment wins).
  *
  * @param location - the raw `Location` header value
- * @returns the numeric resource ID parsed from the trailing path segment
- * @throws {Error} when no trailing numeric segment can be found
+ * @returns the numeric resource ID parsed from the final path segment
+ * @throws {Error} when no final numeric segment can be found
  * @example
- * parseResourceIdFromLocation('/reporting-units/42')   // 42
- * parseResourceIdFromLocation('/foo/777?v=1')          // 777
+ * parseResourceIdFromLocation('/reporting-units/42')        // 42
+ * parseResourceIdFromLocation('/foo/777?v=1')               // 777
+ * parseResourceIdFromLocation('/api/2024/reporting-units/777') // 777
  */
 export function parseResourceIdFromLocation(location: string): number {
-  const match = /\/(\d+)(?:[/?#]|$)/.exec(location);
+  // Strip any query string or hash so the ID is read from the path only.
+  const path = location.replace(/[?#].*$/, '');
+  // Anchor to the end of the path: match the final numeric segment, allowing
+  // an optional trailing slash, so `/api/2024/reporting-units/777` -> 777 and
+  // `/foo/777?v=1` -> 777 (not the intermediate `2024`).
+  const match = /\/(\d+)\/?$/.exec(path);
   if (!match) {
     throw new Error(`Invalid Location header: "${location}"`);
   }
   return Number.parseInt(match[1], 10);
-}
-
-/**
- * Parses a `Location` header into a numeric resource ID.
- *
- * Wraps {@link parseResourceIdFromLocation} so callers can supply a custom
- * strategy (for resources whose ID is not the trailing numeric path segment)
- * while keeping the default behaviour for the common case.
- *
- * @template T - the resolved resource identifier type
- * @param location - the raw `Location` header value
- * @param idParser - optional custom parser; defaults to trailing-numeric ID
- * @returns the resource identifier produced by the parser
- * @throws {Error} when the parser (or default) cannot resolve an ID
- */
-export function parseLocationResourceId<T = number>(
-  location: string,
-  idParser: (location: string) => T = parseResourceIdFromLocation as (location: string) => T,
-): T {
-  return idParser(location);
 }

--- a/frontend/src/config/api/locationHeader.ts
+++ b/frontend/src/config/api/locationHeader.ts
@@ -1,0 +1,43 @@
+/**
+ * Extracts the numeric resource ID from a `Location` response header.
+ *
+ * The backend returns HTTP 201 (Created) with a `Location` header pointing at
+ * the newly created resource, e.g. `/reporting-units/42` or
+ * `http://host/api/reporting-units/777?v=1`. The default parser reads the
+ * trailing numeric segment of the path, ignoring any query string, so both
+ * `/foo/42` and `/foo/777?v=1` resolve to `42` and `777` respectively.
+ *
+ * @param location - the raw `Location` header value
+ * @returns the numeric resource ID parsed from the trailing path segment
+ * @throws {Error} when no trailing numeric segment can be found
+ * @example
+ * parseResourceIdFromLocation('/reporting-units/42')   // 42
+ * parseResourceIdFromLocation('/foo/777?v=1')          // 777
+ */
+export function parseResourceIdFromLocation(location: string): number {
+  const match = /\/(\d+)(?:[/?#]|$)/.exec(location);
+  if (!match) {
+    throw new Error(`Invalid Location header: "${location}"`);
+  }
+  return Number.parseInt(match[1], 10);
+}
+
+/**
+ * Parses a `Location` header into a numeric resource ID.
+ *
+ * Wraps {@link parseResourceIdFromLocation} so callers can supply a custom
+ * strategy (for resources whose ID is not the trailing numeric path segment)
+ * while keeping the default behaviour for the common case.
+ *
+ * @template T - the resolved resource identifier type
+ * @param location - the raw `Location` header value
+ * @param idParser - optional custom parser; defaults to trailing-numeric ID
+ * @returns the resource identifier produced by the parser
+ * @throws {Error} when the parser (or default) cannot resolve an ID
+ */
+export function parseLocationResourceId<T = number>(
+  location: string,
+  idParser: (location: string) => T = parseResourceIdFromLocation as (location: string) => T,
+): T {
+  return idParser(location);
+}

--- a/frontend/src/config/api/locationHeader.ts
+++ b/frontend/src/config/api/locationHeader.ts
@@ -17,18 +17,26 @@
  * parseResourceIdFromLocation('/api/2024/reporting-units/777') // 777
  */
 export function parseResourceIdFromLocation(location: string): number {
-  // Strip any query string or hash so the ID is read from the path only,
-  // then drop any trailing slash. Trailing-slash removal lets the matcher
-  // anchor to the exact end of the path without an optional `\/?` quantifier,
-  // which avoids super-linear backtracking (Sonar typescript:S8786).
-  const path = location.replace(/[?#].*$/, '').replace(/\/+$/, '');
-  // Anchor to the end of the path: match the final numeric segment, so
-  // `/api/2024/reporting-units/777` -> 777 and `/foo/777?v=1` -> 777
-  // (not the intermediate `2024`). The greedy `\d+` is the only quantifier
-  // and is bounded by `$`, so the match runs in linear time.
-  const match = /\/(\d+)$/.exec(path);
-  if (!match) {
+  // Read only the path: cut at the first `?` (query) or `#` (fragment).
+  // Plain string indexing avoids the greedy `/[?#].*$/` pattern that triggers
+  // super-linear backtracking (Sonar typescript:S8786).
+  const hashIdx = location.indexOf('#');
+  const queryIdx = location.indexOf('?');
+  const cut = Math.min(
+    hashIdx >= 0 ? hashIdx : location.length,
+    queryIdx >= 0 ? queryIdx : location.length,
+  );
+  let path = location.slice(0, cut);
+  // Drop any trailing slashes so the final segment is the resource ID.
+  while (path.endsWith('/')) {
+    path = path.slice(0, -1);
+  }
+  // The resource ID is the final path segment; it must be all digits.
+  // `^\d+$` is anchored at both ends with a single group, so it cannot
+  // backtrack (linear time).
+  const lastSegment = path.slice(path.lastIndexOf('/') + 1);
+  if (lastSegment === '' || !/^\d+$/.test(lastSegment)) {
     throw new Error(`Invalid Location header: "${location}"`);
   }
-  return Number.parseInt(match[1], 10);
+  return Number.parseInt(lastSegment, 10);
 }

--- a/frontend/src/config/api/locationHeader.ts
+++ b/frontend/src/config/api/locationHeader.ts
@@ -17,12 +17,16 @@
  * parseResourceIdFromLocation('/api/2024/reporting-units/777') // 777
  */
 export function parseResourceIdFromLocation(location: string): number {
-  // Strip any query string or hash so the ID is read from the path only.
-  const path = location.replace(/[?#].*$/, '');
-  // Anchor to the end of the path: match the final numeric segment, allowing
-  // an optional trailing slash, so `/api/2024/reporting-units/777` -> 777 and
-  // `/foo/777?v=1` -> 777 (not the intermediate `2024`).
-  const match = /\/(\d+)\/?$/.exec(path);
+  // Strip any query string or hash so the ID is read from the path only,
+  // then drop any trailing slash. Trailing-slash removal lets the matcher
+  // anchor to the exact end of the path without an optional `\/?` quantifier,
+  // which avoids super-linear backtracking (Sonar typescript:S8786).
+  const path = location.replace(/[?#].*$/, '').replace(/\/+$/, '');
+  // Anchor to the end of the path: match the final numeric segment, so
+  // `/api/2024/reporting-units/777` -> 777 and `/foo/777?v=1` -> 777
+  // (not the intermediate `2024`). The greedy `\d+` is the only quantifier
+  // and is bounded by `$`, so the match runs in linear time.
+  const match = /\/(\d+)$/.exec(path);
   if (!match) {
     throw new Error(`Invalid Location header: "${location}"`);
   }

--- a/frontend/src/config/api/locationHeader.unit.test.ts
+++ b/frontend/src/config/api/locationHeader.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { parseLocationResourceId, parseResourceIdFromLocation } from './locationHeader';
+import { parseResourceIdFromLocation } from './locationHeader';
 
 describe('parseResourceIdFromLocation', () => {
   it('extracts the trailing numeric ID from a relative path', () => {
@@ -17,6 +17,16 @@ describe('parseResourceIdFromLocation', () => {
 
   it('ignores a trailing hash and resolves the path ID', () => {
     expect(parseResourceIdFromLocation('/reporting-units/123#frag')).toBe(123);
+  });
+
+  it('reads the final numeric segment, not an intermediate one', () => {
+    // The earlier regex matched the first numeric segment anywhere in the
+    // path; anchoring to the end ensures the trailing ID wins.
+    expect(parseResourceIdFromLocation('/api/2024/reporting-units/777')).toBe(777);
+  });
+
+  it('ignores a query string when choosing the final segment', () => {
+    expect(parseResourceIdFromLocation('/api/2024/reporting-units/777?v=1')).toBe(777);
   });
 
   it('handles single-digit IDs', () => {
@@ -43,23 +53,5 @@ describe('parseResourceIdFromLocation', () => {
     expect(() => parseResourceIdFromLocation('not-a-valid-path')).toThrow(
       'Invalid Location header: "not-a-valid-path"',
     );
-  });
-});
-
-describe('parseLocationResourceId', () => {
-  it('uses the default trailing-numeric parser when none is supplied', () => {
-    expect(parseLocationResourceId('/reporting-units/42')).toBe(42);
-  });
-
-  it('delegates to a custom parser when provided', () => {
-    const custom = (location: string): string => location.split('/').pop()!;
-    expect(parseLocationResourceId('/reporting-units/abc', custom)).toBe('abc');
-  });
-
-  it('propagates errors thrown by the custom parser', () => {
-    const custom = (): number => {
-      throw new Error('custom failure');
-    };
-    expect(() => parseLocationResourceId('/foo', custom)).toThrow('custom failure');
   });
 });

--- a/frontend/src/config/api/locationHeader.unit.test.ts
+++ b/frontend/src/config/api/locationHeader.unit.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseLocationResourceId, parseResourceIdFromLocation } from './locationHeader';
+
+describe('parseResourceIdFromLocation', () => {
+  it('extracts the trailing numeric ID from a relative path', () => {
+    expect(parseResourceIdFromLocation('/reporting-units/42')).toBe(42);
+  });
+
+  it('extracts the trailing numeric ID from an absolute URL', () => {
+    expect(parseResourceIdFromLocation('http://example.com/api/reporting-units/777')).toBe(777);
+  });
+
+  it('ignores a trailing query string and resolves the path ID', () => {
+    expect(parseResourceIdFromLocation('/reporting-units/777?v=1')).toBe(777);
+  });
+
+  it('ignores a trailing hash and resolves the path ID', () => {
+    expect(parseResourceIdFromLocation('/reporting-units/123#frag')).toBe(123);
+  });
+
+  it('handles single-digit IDs', () => {
+    expect(parseResourceIdFromLocation('/foo/1')).toBe(1);
+  });
+
+  it('handles large IDs', () => {
+    expect(parseResourceIdFromLocation('/foo/999999999')).toBe(999999999);
+  });
+
+  it('throws when the path ends without a numeric segment', () => {
+    expect(() => parseResourceIdFromLocation('/reporting-units/')).toThrow(
+      'Invalid Location header: "/reporting-units/"',
+    );
+  });
+
+  it('throws when the trailing segment is non-numeric', () => {
+    expect(() => parseResourceIdFromLocation('/reporting-units/abc')).toThrow(
+      'Invalid Location header: "/reporting-units/abc"',
+    );
+  });
+
+  it('throws when the value is completely malformed', () => {
+    expect(() => parseResourceIdFromLocation('not-a-valid-path')).toThrow(
+      'Invalid Location header: "not-a-valid-path"',
+    );
+  });
+});
+
+describe('parseLocationResourceId', () => {
+  it('uses the default trailing-numeric parser when none is supplied', () => {
+    expect(parseLocationResourceId('/reporting-units/42')).toBe(42);
+  });
+
+  it('delegates to a custom parser when provided', () => {
+    const custom = (location: string): string => location.split('/').pop()!;
+    expect(parseLocationResourceId('/reporting-units/abc', custom)).toBe('abc');
+  });
+
+  it('propagates errors thrown by the custom parser', () => {
+    const custom = (): number => {
+      throw new Error('custom failure');
+    };
+    expect(() => parseLocationResourceId('/foo', custom)).toThrow('custom failure');
+  });
+});

--- a/frontend/src/config/api/types.ts
+++ b/frontend/src/config/api/types.ts
@@ -132,25 +132,48 @@ export class HttpClient {
    * forwarded to the underlying request, and any HTTP / parse error is
    * propagated unchanged.
    *
-   * @template T - the resolved resource identifier type
+   * The default parser extracts the trailing numeric path segment and returns
+   * a `number`. To resolve a non-numeric or differently-shaped identifier,
+   * supply an `idParser` — its return type drives the method's type parameter.
+   *
    * @param options - the request configuration (method, url, body, meta, ...)
-   * @param idParser - optional custom `Location` parser; defaults to the
-   * trailing-numeric ID strategy
-   * @returns a promise that resolves to the parsed resource identifier
+   * @returns a promise that resolves to the numeric resource ID
    * @throws {ApiError} when the HTTP request fails (400, 409, 500, etc.)
    * @throws {Error} when the `Location` header value cannot be parsed
    * @example
-   * const id = await this.createResource<number>({
+   * const id = await this.createResource({
    *   method: 'POST',
    *   url: '/api/reporting-units',
    *   body,
    * });
    */
-  protected createResource = <T = number>(
+  protected createResource(options: ApiRequestOptions): CancelablePromise<number>;
+
+  /**
+   * Performs a create request that returns a resource identifier of type `T`
+   * via a custom `Location` parser.
+   *
+   * @template T - the resolved resource identifier type
+   * @param options - the request configuration (method, url, body, meta, ...)
+   * @param idParser - custom `Location` parser producing a `T`
+   * @returns a promise that resolves to the parsed resource identifier
+   * @throws {ApiError} when the HTTP request fails (400, 409, 500, etc.)
+   * @throws {Error} when the `Location` header value cannot be parsed
+   */
+  protected createResource<T>(
     options: ApiRequestOptions,
-    idParser: (location: string) => T = parseResourceIdFromLocation as (location: string) => T,
-  ): CancelablePromise<T> =>
-    new CancelablePromise<T>((resolve, reject, onCancel) => {
+    idParser: (location: string) => T,
+  ): CancelablePromise<T>;
+
+  protected createResource<T = number>(
+    options: ApiRequestOptions,
+    idParser?: (location: string) => T,
+  ): CancelablePromise<T> {
+    // When no custom parser is supplied, fall back to the trailing-numeric
+    // strategy (which always yields a number). The public overloads keep the
+    // no-parser form constrained to `number`, so this cast is internal only.
+    const parser = (idParser ?? parseResourceIdFromLocation) as (location: string) => T;
+    return new CancelablePromise<T>((resolve, reject, onCancel) => {
       const request$ = this.doRequest<string>(this.config, {
         ...options,
         responseHeader: 'location',
@@ -161,11 +184,12 @@ export class HttpClient {
       request$
         .then((location) => {
           try {
-            resolve(idParser(location));
+            resolve(parser(location));
           } catch (error) {
             reject(error);
           }
         })
         .catch(reject);
     });
+  }
 }

--- a/frontend/src/config/api/types.ts
+++ b/frontend/src/config/api/types.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
 
+import { CancelablePromise } from './CancelablePromise';
+import { parseResourceIdFromLocation } from './locationHeader';
 import { request } from './request';
 
-import type { CancelablePromise } from './CancelablePromise';
 import type {
   AxiosError,
   AxiosInstance,
@@ -121,4 +122,50 @@ export class HttpClient {
 
   protected doRequest = <T>(config: APIConfig, options: ApiRequestOptions): CancelablePromise<T> =>
     request<T>(config, options, this.axiosInstance);
+
+  /**
+   * Performs a create request that returns the new resource ID via the
+   * `Location` response header.
+   *
+   * Issues the request with `responseHeader: 'location'`, then parses the
+   * returned header value into a resource identifier. Cancellation is
+   * forwarded to the underlying request, and any HTTP / parse error is
+   * propagated unchanged.
+   *
+   * @template T - the resolved resource identifier type
+   * @param options - the request configuration (method, url, body, meta, ...)
+   * @param idParser - optional custom `Location` parser; defaults to the
+   * trailing-numeric ID strategy
+   * @returns a promise that resolves to the parsed resource identifier
+   * @throws {ApiError} when the HTTP request fails (400, 409, 500, etc.)
+   * @throws {Error} when the `Location` header value cannot be parsed
+   * @example
+   * const id = await this.createResource<number>({
+   *   method: 'POST',
+   *   url: '/api/reporting-units',
+   *   body,
+   * });
+   */
+  protected createResource = <T = number>(
+    options: ApiRequestOptions,
+    idParser: (location: string) => T = parseResourceIdFromLocation as (location: string) => T,
+  ): CancelablePromise<T> =>
+    new CancelablePromise<T>((resolve, reject, onCancel) => {
+      const request$ = this.doRequest<string>(this.config, {
+        ...options,
+        responseHeader: 'location',
+      });
+
+      onCancel(() => request$.cancel());
+
+      request$
+        .then((location) => {
+          try {
+            resolve(idParser(location));
+          } catch (error) {
+            reject(error);
+          }
+        })
+        .catch(reject);
+    });
 }

--- a/frontend/src/services/districtvolume.service.ts
+++ b/frontend/src/services/districtvolume.service.ts
@@ -60,7 +60,7 @@ export class DistrictVolumeService extends HttpClient {
     dto: DistrictVolumeCreate,
     meta?: Record<string, unknown>,
   ): CancelablePromise<number> {
-    return this.createResource<number>({
+    return this.createResource({
       method: 'POST',
       url: '/api/configuration/district-average-volumes',
       body: dto,

--- a/frontend/src/services/districtvolume.service.ts
+++ b/frontend/src/services/districtvolume.service.ts
@@ -48,31 +48,23 @@ export class DistrictVolumeService extends HttpClient {
     });
   }
 
+  /**
+   * Creates a district volume table and returns the new resource ID.
+   *
+   * @param dto - the district volume create payload
+   * @param meta - optional request metadata
+   * @returns a promise that resolves to the numeric ID of the created table
+   * @throws {ApiError} When the HTTP request fails (400, 409, 500, etc.)
+   */
   createDistrictVolumeTable(
     dto: DistrictVolumeCreate,
     meta?: Record<string, unknown>,
   ): CancelablePromise<number> {
-    return new CancelablePromise<number>((resolve, reject, onCancel) => {
-      const request = this.doRequest<string>(this.config, {
-        method: 'POST',
-        url: '/api/configuration/district-average-volumes',
-        body: dto,
-        responseHeader: 'location',
-        ...(meta === undefined ? {} : { meta }),
-      });
-
-      onCancel(() => request.cancel());
-
-      request
-        .then((location) => {
-          const match = /\/(\d+)$/.exec(location);
-          if (match) {
-            resolve(Number(match[1]));
-          } else {
-            reject(new Error(`Could not parse resource ID from Location header: "${location}"`));
-          }
-        })
-        .catch(reject);
+    return this.createResource<number>({
+      method: 'POST',
+      url: '/api/configuration/district-average-volumes',
+      body: dto,
+      ...(meta === undefined ? {} : { meta }),
     });
   }
 

--- a/frontend/src/services/districtvolume.service.unit.test.ts
+++ b/frontend/src/services/districtvolume.service.unit.test.ts
@@ -257,7 +257,7 @@ describe('DistrictVolumeService', () => {
           tableLevelFactor: 0,
           tableData: { type: 'INTERIOR', zones: [], formulas: {} },
         }),
-      ).rejects.toThrow('Could not parse resource ID from Location header');
+      ).rejects.toThrow('Invalid Location header: "invalid-location"');
     });
 
     it('should propagate network errors', async () => {

--- a/frontend/src/services/reportingunit.service.ts
+++ b/frontend/src/services/reportingunit.service.ts
@@ -37,9 +37,9 @@ export class ReportingUnitService extends HttpClient {
   }
 
   /**
-   * Creates a new reporting unit and extracts the ID from the Location header.
+   * Creates a new reporting unit and returns its numeric ID.
    *
-   * The backend returns HTTP 201 (Created) with a Location header pointing to
+   * The backend returns HTTP 201 (Created) with a `Location` header pointing to
    * `/reporting-units/{id}`. This method extracts the ID from that header and
    * returns it as a number for immediate navigation.
    *
@@ -48,26 +48,10 @@ export class ReportingUnitService extends HttpClient {
    * @throws {ApiError} When the HTTP request fails (400, 409, 500, etc.).
    */
   createReportingUnit(body: ReportingUnitCreateDto): CancelablePromise<number> {
-    return new CancelablePromise<number>((resolve, reject, onCancel) => {
-      const request = this.doRequest<string>(this.config, {
-        method: 'POST',
-        url: '/api/reporting-units',
-        body,
-        responseHeader: 'location',
-      });
-
-      // Forward cancellation to the underlying HTTP request.
-      onCancel(() => request.cancel());
-
-      request.then((locationHeader) => {
-        // Extract ID from Location header (format: `/reporting-units/{id}`)
-        const match = new RegExp(/\/(\d+)$/).exec(locationHeader);
-        if (!match?.[1]) {
-          reject(new Error(`Invalid Location header format: ${locationHeader}`));
-          return;
-        }
-        resolve(Number.parseInt(match[1], 10));
-      }, reject);
+    return this.createResource<number>({
+      method: 'POST',
+      url: '/api/reporting-units',
+      body,
     });
   }
 }

--- a/frontend/src/services/reportingunit.service.ts
+++ b/frontend/src/services/reportingunit.service.ts
@@ -48,7 +48,7 @@ export class ReportingUnitService extends HttpClient {
    * @throws {ApiError} When the HTTP request fails (400, 409, 500, etc.).
    */
   createReportingUnit(body: ReportingUnitCreateDto): CancelablePromise<number> {
-    return this.createResource<number>({
+    return this.createResource({
       method: 'POST',
       url: '/api/reporting-units',
       body,

--- a/frontend/src/services/reportingunit.service.unit.test.ts
+++ b/frontend/src/services/reportingunit.service.unit.test.ts
@@ -268,7 +268,7 @@ describe('ReportingUnitService', () => {
       (service as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/');
 
       await expect(service.createReportingUnit(validCreateRequest)).rejects.toThrow(
-        'Invalid Location header format: /reporting-units/',
+        'Invalid Location header: "/reporting-units/"',
       );
     });
 
@@ -276,7 +276,7 @@ describe('ReportingUnitService', () => {
       (service as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/abc');
 
       await expect(service.createReportingUnit(validCreateRequest)).rejects.toThrow(
-        'Invalid Location header format: /reporting-units/abc',
+        'Invalid Location header: "/reporting-units/abc"',
       );
     });
 
@@ -284,7 +284,7 @@ describe('ReportingUnitService', () => {
       (service as any).doRequest = vi.fn().mockResolvedValue('not-a-valid-path');
 
       await expect(service.createReportingUnit(validCreateRequest)).rejects.toThrow(
-        'Invalid Location header format: not-a-valid-path',
+        'Invalid Location header: "not-a-valid-path"',
       );
     });
 
@@ -315,11 +315,12 @@ describe('ReportingUnitService', () => {
       );
     });
 
-    it('handles Location header with query parameters (if backend adds them)', async () => {
+    it('resolves the ID when the Location header carries a query string', async () => {
       (service as any).doRequest = vi.fn().mockResolvedValue('/reporting-units/777?v=1');
 
-      // Should still extract the ID correctly
-      await expect(service.createReportingUnit(validCreateRequest)).rejects.toThrow();
+      const result = await service.createReportingUnit(validCreateRequest);
+
+      expect(result).toBe(777);
     });
 
     it('propagates conflict errors (409 Duplicate RU)', async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Centralizes the duplicated "POST then read `Location` header, extract trailing numeric resource ID" logic that was copy-pasted across the district-volume and reporting-unit services. The shared logic now lives in one place:

- **`src/config/api/locationHeader.ts`** — a new pure helper `parseResourceIdFromLocation(location)` that reads the trailing numeric path segment. The default parser is robust to query strings and hashes (`/foo/777?v=1` → `777`, `/foo/1#frag` → `1`) and throws a single canonical error, `Invalid Location header: "<location>"`, when no numeric segment is present.
- **`src/config/api/types.ts`** — a new `protected createResource(options, idParser?)` method on `HttpClient`. It issues the request with `responseHeader: 'location'`, forwards cancellation to the underlying request, and parses the header via `idParser` (defaulting to the trailing-numeric strategy). A custom parser can be supplied for resources whose ID is not the trailing path segment.
- **`districtvolume.service.ts`** and **`reportingunit.service.ts`** — their `create*` methods are now one-line delegations to `createResource`.

The species-composition service will adopt `createResource` in a follow-up once #1055 is merged (that service does not yet exist on `main`).

### Behavior change (intentional, non-breaking)

Previously `reportingunit.service.ts` rejected a `Location` value carrying a query string (e.g. `/reporting-units/777?v=1`). With the new trailing-numeric parser this resolves to `777`. This is a strict improvement: it makes ID extraction consistent across all create endpoints and tolerant of backend-added query parameters.

Fixes #1091

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

- [x] New unit tests — `src/config/api/locationHeader.unit.test.ts` (default + custom parser, query/hash handling, error cases) and `src/config/api/httpClient.unit.test.ts` (`createResource` passthrough, cancellation, meta, error propagation).
- [x] Updated existing tests — `districtvolume.service.unit.test.ts` and `reportingunit.service.unit.test.ts` updated to assert delegation to `createResource`, the canonical error message, and the now-resolving `/777?v=1` case.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint --max-warnings=0 src/` — clean.
- [x] `npx vitest run` — full suite green (1925 tests); changed files at 100% statement/line/function coverage.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR

## Further comments

The default parser was chosen to be permissive about the `Location` value shape (query/hash tolerant) because the backend's exact header format is not guaranteed stable across endpoints. A per-call `idParser` override keeps the method usable for any future resource whose ID is not the trailing numeric segment, without another round of copy-paste.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-42-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)