### PR TITLE
fix(#1108): fixing security findings in frontend

### DIFF
--- a/.github/workflows/.automated-tests.yml
+++ b/.github/workflows/.automated-tests.yml
@@ -40,15 +40,20 @@ jobs:
           restore-keys: |
             cypress-binary-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Install cypress dependencies
+        working-directory: cypress
+        run: npm install --prefer-offline --no-audit --no-fund
+
+      - name: Install Cypress binary
+        working-directory: cypress
+        run: npx cypress install
+
       - name: Run Cypress End-to-End
         uses: cypress-io/github-action@v7.4.1
         with:
           working-directory: cypress
           browser: chrome
-          # Use `npm install --prefer-offline` (not `npm ci`) so the restored node_modules
-          # cache is actually leveraged. `npm ci` wipes node_modules and defeats the cache.
-          # See plan b3-cache-node-modules.md (#1083).
-          install-command: npm install --prefer-offline --no-audit --no-fund
+          install: false
         env:
           CYPRESS_baseUrl: https://${{ inputs.url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}          

--- a/.github/workflows/.automated-tests.yml
+++ b/.github/workflows/.automated-tests.yml
@@ -32,6 +32,14 @@ jobs:
             cypress-node_modules-b3v1-
             cypress-node_modules-
 
+      - name: Cache Cypress binary
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-binary-${{ hashFiles('cypress/package-lock.json') }}
+          restore-keys: |
+            cypress-binary-
+
       - name: Run Cypress End-to-End
         uses: cypress-io/github-action@v7.4.1
         with:

--- a/.github/workflows/.automated-tests.yml
+++ b/.github/workflows/.automated-tests.yml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/Cypress
-          key: cypress-binary-${{ hashFiles('cypress/package-lock.json') }}
+          key: cypress-binary-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cypress/package-lock.json') }}
           restore-keys: |
-            cypress-binary-
+            cypress-binary-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run Cypress End-to-End
         uses: cypress-io/github-action@v7.4.1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3442,9 +3442,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
       "funding": [
         {
           "type": "github",
@@ -8496,9 +8496,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -8529,9 +8529,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
-      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
       "funding": [
         {
           "type": "github",
@@ -8540,7 +8540,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.2.0",
+        "@nodable/entities": "^3.0.0",
         "fast-xml-builder": "^1.2.0",
         "is-unsafe": "^2.0.0",
         "path-expression-matcher": "^1.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -108,7 +108,7 @@
     "serialize-javascript": "^7.0.5",
     "rollup": "^4.54.0",
     "uuid": "^14.0.0",
-    "fast-uri@<=3.1.3": "3.1.4",
-    "fast-xml-parser@^5.9.3": "5.10.1"
+    "fast-uri@>=3.0.0 <=3.1.3": "3.1.4",
+    "fast-xml-parser@>=5.9.3 <5.10.1": "5.10.1"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -107,6 +107,8 @@
     "immutable": "^5.1.5",
     "serialize-javascript": "^7.0.5",
     "rollup": "^4.54.0",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "fast-uri@<=3.1.3": "3.1.4",
+    "fast-xml-parser@^5.9.3": "5.10.1"
   }
 }


### PR DESCRIPTION
Security vulnerability remediation for the `frontend` dependency group.

**Fixed vulnerabilities:**
- **CVE-2026-16221, CVE-2026-13676** (fast-uri) — host confusion via literal backslash authority delimiter and failed IDN canonicalization. Vulnerable range: `3.0.0 - 3.1.3`. Resolved to `3.1.4`.
- **GHSA-8r6m-32jq-jx6q** (fast-xml-parser) — repeated DOCTYPE declarations reset entity expansion limits. Vulnerable range: `5.9.3 - 5.10.0`. Resolved to `5.10.1`.

**Dependency changes:**
| Package | Before | After | Mechanism |
|---|---|---|---|
| fast-uri | 3.1.3 | 3.1.4 | npm override |
| fast-xml-parser | 5.10.0 | 5.10.1 | npm override |

**CI workflow fix:**
- Added Cypress binary cache (`~/.cache/Cypress`) to `.automated-tests.yml` to fix CI failures caused by missing Cypress binary in GitHub Actions runners.

**Note on Code Scanning alerts #118-120:**
- Alerts #118, #119 (brace-expansion CVE-2026-13149): Installed versions `5.0.7` and `2.1.2` are outside the vulnerable range (`>= 3.0.0, < 5.0.7`). These are false positives or already resolved.
- Alert #120 (js-yaml CVE-2026-59869): Installed version `4.3.0` is outside the vulnerable range (`4.0.0 - 4.2.0`). Already resolved.

Fixes #1108

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] No new tests are required

Verified with `npm audit` — 0 vulnerabilities remaining in the frontend workspace.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Feature-Flag Controlled Changes (Required if applicable)

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR

## Further comments

Override-only changes for security remediation plus CI workflow fix to cache Cypress binary.

---

Thanks for the PR!

Deployments, as required, will be available below:

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-9-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)