### PR TITLE
fix(cypress): update brace-expansion and postcss overrides for CVE-2026-14257 and GHSA-r28c-9q8g-f849

### DIFF
--- a/cypress/package-lock.json
+++ b/cypress/package-lock.json
@@ -4896,16 +4896,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -9471,9 +9471,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dev": true,
       "funding": [
         {

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -56,7 +56,7 @@
   "overrides": {
     "@babel/plugin-transform-modules-systemjs@<=7.29.3": "7.29.4",
     "fast-uri@<=3.1.3": "3.1.4",
-    "postcss@<8.5.10": "8.5.10",
+    "postcss@<8.5.18": "8.5.18",
     "picomatch@^4.0.0": "^4.0.4",
     "serialize-javascript": "^7.0.5",
     "lodash@^4.0.0": "^4.18.1",
@@ -69,7 +69,7 @@
     "diff@^7.0.0": "9.0.0",
     "@opentelemetry/core@^1.30.1": "2.8.0",
     "ws@^7.0.0": "7.5.11",
-    "brace-expansion@^5.0.0": "5.0.7"
+    "brace-expansion@^5.0.0": "5.0.8"
   },
   "allowScripts": {
     "cypress@15.18.0": true,


### PR DESCRIPTION
## Summary

Updates two npm overrides in the cypress lockfile to resolve Code Scanning security alerts.

## Changes

- **brace-expansion**: `5.0.7` → `5.0.8` (override `brace-expansion@^5.0.0`)
- **postcss**: `8.5.15` → `8.5.18` (override updated from `postcss@<8.5.10` to `postcss@<8.5.18`)

## Context

This addresses GitHub Code Scanning alerts #135, #136 (CVE-2026-14257 — brace-expansion DoS) and #137 (GHSA-r28c-9q8g-f849 — PostCSS path traversal) in the cypress directory.

## Notes

- `npm audit` reports 7 high-severity findings still present in nested dev dependencies (mocha → glob → minimatch → brace-expansion 1.x/2.x, @sentry/node → minimatch → brace-expansion). These require upstream dependency upgrades (mocha 12+, @sentry/node major bump) and are out of scope for this change.
- The brace-expansion@5.0.8 and postcss@8.5.18 overrides target the specific vulnerable ranges flagged in the alerts.

Closes #1125

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-26-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)