### PR TITLE
fix(#1153): fixing security findings in cypress

### DIFF
--- a/cypress/package-lock.json
+++ b/cypress/package-lock.json
@@ -4285,9 +4285,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6058,9 +6058,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -8227,9 +8227,9 @@
       "license": "MIT"
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -55,7 +55,7 @@
   },
   "overrides": {
     "@babel/plugin-transform-modules-systemjs@<=7.29.3": "7.29.4",
-    "fast-uri@<=3.1.3": "3.1.4",
+    "fast-uri": "3.1.5",
     "postcss@<8.5.18": "8.5.18",
     "picomatch@^4.0.0": "^4.0.4",
     "serialize-javascript": "^7.0.5",
@@ -69,7 +69,8 @@
     "diff@^7.0.0": "9.0.0",
     "@opentelemetry/core@^1.30.1": "2.8.0",
     "ws@^7.0.0": "7.5.11",
-    "brace-expansion@^5.0.0": "5.0.8"
+    "brace-expansion@^5.0.0": "5.0.9",
+    "brace-expansion@2": "2.1.4"
   },
   "allowScripts": {
     "cypress@15.18.0": true,

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -55,7 +55,7 @@
   },
   "overrides": {
     "@babel/plugin-transform-modules-systemjs@<=7.29.3": "7.29.4",
-    "fast-uri": "3.1.5",
+    "fast-uri@<=3.1.4": "3.1.5",
     "postcss@<8.5.18": "8.5.18",
     "picomatch@^4.0.0": "^4.0.4",
     "serialize-javascript": "^7.0.5",
@@ -69,8 +69,8 @@
     "diff@^7.0.0": "9.0.0",
     "@opentelemetry/core@^1.30.1": "2.8.0",
     "ws@^7.0.0": "7.5.11",
-    "brace-expansion@^5.0.0": "5.0.9",
-    "brace-expansion@2": "2.1.4"
+    "brace-expansion@>=5.0.0 <5.0.9": "5.0.9",
+    "brace-expansion@>=2.0.0 <2.1.4": "2.1.4"
   },
   "allowScripts": {
     "cypress@15.18.0": true,


### PR DESCRIPTION
## Summary

Updates Cypress dependency overrides and lockfile resolutions for the reported high-severity vulnerabilities.

| Package | Requested patched version | Resolved version |
|---|---:|---:|
| `fast-uri` | 3.1.5 | 3.1.5 |
| `brace-expansion` v2 | 2.1.4 | 2.1.4 |
| `brace-expansion` v5 | 5.0.9 | 5.0.9 |

Validation:
- `npm audit` reports 0 vulnerabilities.
- `npm ls fast-uri brace-expansion` reports only patched versions.
- No unit-test script is defined in the Cypress package; browser E2E commands require the configured application environment.

Closes #1153

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-4-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)