### PR TITLE
chore(ci): submit CycloneDX SBOMs to GitHub Dependency Graph

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -150,7 +150,7 @@ jobs:
     name: Node SBOM (${{ matrix.folder }})
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     permissions:
-      contents: write
+      contents: read
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -179,17 +179,12 @@ jobs:
           path: sbom-${{ matrix.folder }}.json
           if-no-files-found: error
           retention-days: 30
-      - name: Submit Node SBOM to Dependency Graph
-        if: github.event_name != 'pull_request'
-        uses: evryfs/sbom-dependency-submission-action@4466eb923772acc3bd54081f8e2a0ef601d2f28a # v0.0.14
-        with:
-          sbom-files: sbom-${{ matrix.folder }}.json
 
   sbom-java:
     name: Java SBOM
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     permissions:
-      contents: write
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
@@ -225,11 +220,43 @@ jobs:
           path: legacy/target/classes/META-INF/sbom/application.cdx.json
           if-no-files-found: error
           retention-days: 30
-      - name: Submit Java SBOM to Dependency Graph
-        if: github.event_name != 'pull_request'
+
+  sbom-submit:
+    name: Submit SBOMs to Dependency Graph
+    if: github.event_name != 'pull_request'
+    needs: [sbom-node, sbom-java]
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download Node SBOM (cypress)
+        uses: actions/download-artifact@v8
+        with:
+          name: sbom-cypress
+          path: node/cypress
+      - name: Download Node SBOM (frontend)
+        uses: actions/download-artifact@v8
+        with:
+          name: sbom-frontend
+          path: node/frontend
+      - name: Download Java SBOM (backend)
+        uses: actions/download-artifact@v8
+        with:
+          name: sbom-backend
+          path: java/backend
+      - name: Download Java SBOM (legacy)
+        uses: actions/download-artifact@v8
+        with:
+          name: sbom-legacy
+          path: java/legacy
+      - name: Submit SBOMs to Dependency Graph
         uses: evryfs/sbom-dependency-submission-action@4466eb923772acc3bd54081f8e2a0ef601d2f28a # v0.0.14
         with:
-          sbom-files: backend/target/classes/META-INF/sbom/application.cdx.json legacy/target/classes/META-INF/sbom/application.cdx.json
+          sbom-files: |
+            node/cypress/sbom-cypress.json
+            node/frontend/sbom-frontend.json
+            java/backend/application.cdx.json
+            java/legacy/application.cdx.json
 
   # ==========================================================================
   # WARNING: This job acts as the required merge gate for this workflow.
@@ -238,7 +265,7 @@ jobs:
   # ==========================================================================
   results:
     name: Analysis Results
-    needs: [tests-java, tests-frontend, tests-frontend-ex, trivy, cve-lite, npm-audit, sbom-node, sbom-java]
+    needs: [tests-java, tests-frontend, tests-frontend-ex, trivy, cve-lite, npm-audit, sbom-node, sbom-java, sbom-submit]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 1

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -150,7 +150,7 @@ jobs:
     name: Node SBOM (${{ matrix.folder }})
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     permissions:
-      contents: read
+      contents: write
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -179,12 +179,17 @@ jobs:
           path: sbom-${{ matrix.folder }}.json
           if-no-files-found: error
           retention-days: 30
+      - name: Submit Node SBOM to Dependency Graph
+        if: github.event_name != 'pull_request'
+        uses: evryfs/sbom-dependency-submission-action@4466eb923772acc3bd54081f8e2a0ef601d2f28a # v0.0.14
+        with:
+          sbom-files: sbom-${{ matrix.folder }}.json
 
   sbom-java:
     name: Java SBOM
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     permissions:
-      contents: read
+      contents: write
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
@@ -220,6 +225,11 @@ jobs:
           path: legacy/target/classes/META-INF/sbom/application.cdx.json
           if-no-files-found: error
           retention-days: 30
+      - name: Submit Java SBOM to Dependency Graph
+        if: github.event_name != 'pull_request'
+        uses: evryfs/sbom-dependency-submission-action@4466eb923772acc3bd54081f8e2a0ef601d2f28a # v0.0.14
+        with:
+          sbom-files: backend/target/classes/META-INF/sbom/application.cdx.json legacy/target/classes/META-INF/sbom/application.cdx.json
 
   # ==========================================================================
   # WARNING: This job acts as the required merge gate for this workflow.


### PR DESCRIPTION
# Description

Wires the CycloneDX SBOMs generated by the `sbom-node` and `sbom-java` analysis jobs into GitHub's Dependency Graph via the Dependency Submission API. Submission runs only on non-PR events (push to main / scheduled), since the dependency graph tracks the default branch and fork PRs lack write access.

- `sbom-node`: submit `sbom-<folder>.json` (npm/cypress) per matrix entry.
- `sbom-java`: submit the backend and legacy Maven aggregate BOMs (`application.cdx.json`).
- Both jobs' permissions bumped `contents: read` -> `contents: write` (required by the submission API).

Uses `evryfs/sbom-dependency-submission-action@4466eb923772acc3bd54081f8e2a0ef601d2f28a` (v0.0.14) — the action GitHub documents for uploading CycloneDX SBOMs to the dependency submission API. This enriches GitHub's manifest-based dependency graph (notably transitive Maven deps that `pom.xml` scanning misses) and feeds Dependabot alerts / dependency review, while the SBOM artifacts remain retained as run artifacts for audit.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

Validated with `actionlint` (only pre-existing shellcheck warnings in the `cve-lite` job, present on base). No tests apply to workflow YAML. The submission steps will be observable on the next push/scheduled run after merge.

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [x] Manual tests (description below)
- [ ] Updated existing tests

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-14-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)