### PR TITLE
fix(database): qualify flyway migration table

### DIFF
--- a/backend/src/main/resources/db/migration/V1.0.4__add_config_type_to_district_volume.sql
+++ b/backend/src/main/resources/db/migration/V1.0.4__add_config_type_to_district_volume.sql
@@ -1,9 +1,9 @@
-ALTER TABLE district_volume
+ALTER TABLE hrs.district_volume
     ADD COLUMN IF NOT EXISTS config_type VARCHAR(50) NOT NULL DEFAULT 'DISTRICT_VOLUME';
 
-UPDATE district_volume
+UPDATE hrs.district_volume
     SET config_type = 'DISTRICT_VOLUME'
     WHERE config_type IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_district_volume_config_type
-    ON district_volume (config_type);
+    ON hrs.district_volume (config_type);


### PR DESCRIPTION
<!-- generated-by: opencode-skill pull-request-description-generator; created-at: 2026-08-12T22:47:54Z -->

# Description

Qualify the `district_volume` table references in Flyway migration V1.0.4 with
the `hrs` schema. The unqualified references could target the wrong schema when
the database search path did not include `hrs`, leaving the migration history
out of sync with the application tables.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [x] No new tests are required
- [x] Manual tests (database migration recovery in `cffaf3-test`)
- [ ] Updated existing tests

The migration was reapplied in the test namespace after clearing the disposable
Flyway history. Flyway completed versions V1.0.0 through V1.0.4 and recreated
the expected tables under `hrs`; both backend replicas became Ready. `git diff
--check` also passes.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR
- [ ] Canonical key follows `<domain>-<capability>-enabled`
- [ ] Frontend and backend use the same canonical key
- [ ] Default state is documented per environment
- [ ] Owner, rollout plan, and removal criteria are documented
- [ ] Tests cover enabled, disabled, and undefined behavior
- [ ] A removal target date is assigned for short-lived flags

## Further comments

The database migration fix is intentionally limited to schema qualification; no
application code or database resources are changed by this PR.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-26-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)