### PR TITLE
fix(#1182): add volume detail back button

### DIFF
--- a/frontend/src/pages/DistrictVolumeTableDetail/index.scss
+++ b/frontend/src/pages/DistrictVolumeTableDetail/index.scss
@@ -7,6 +7,7 @@
 .district-volume {
   &-detail-column__notification,
   &-detail-column__banner,
+  &-detail-column__actions,
   &-detail__start-date,
   &-detail__end-date,
   &-detail__table-level-factor,

--- a/frontend/src/pages/DistrictVolumeTableDetail/index.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/index.tsx
@@ -1,5 +1,6 @@
-import { Column } from '@carbon/react';
-import { useParams } from '@tanstack/react-router';
+import { ArrowLeft } from '@carbon/icons-react';
+import { Button, Column } from '@carbon/react';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { type FC } from 'react';
 
 import PageNotification from '@/components/core/PageNotification';
@@ -7,6 +8,7 @@ import PageTitle from '@/components/core/PageTitle';
 import DistrictVolumeDetailView from '@/components/waste/DistrictVolumeDetail';
 import DistrictVolumeDetailSkeleton from '@/components/waste/DistrictVolumeDetail/DistrictVolumeDetailSkeleton';
 import { useDistrictVolumeTableDetailQuery } from '@/config/react-query/hooks';
+import { navigateInTree } from '@/routes/inTreePaths';
 
 import './index.scss';
 
@@ -24,6 +26,7 @@ import './index.scss';
  * @returns The District Volume Table Detail page.
  */
 const DistrictVolumeTableDetailPage: FC = () => {
+  const navigate = useNavigate();
   const params = useParams({ strict: false });
   const id = Number(params.id);
 
@@ -69,7 +72,15 @@ const DistrictVolumeTableDetailPage: FC = () => {
             { name: 'Configuration', path: '/configuration' },
             { name: 'District average volumes', path: '/configuration/district-volume-tables' },
           ]}
-        />
+        >
+          <Button
+            kind="ghost"
+            onClick={() => navigateInTree(navigate, '/configuration/district-volume-tables')}
+            renderIcon={ArrowLeft}
+          >
+            Back
+          </Button>
+        </PageTitle>
       </Column>
       <Column lg={16} md={8} sm={4} className="district-volume-detail-column__notification">
         <PageNotification eventTarget="district-volume-detail" />

--- a/frontend/src/pages/DistrictVolumeTableDetail/index.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/index.tsx
@@ -58,6 +58,21 @@ const DistrictVolumeTableDetailPage: FC = () => {
         <Column lg={16} md={8} sm={4} className="district-volume-detail-column__notification">
           <PageNotification eventTarget="district-volume-detail" />
         </Column>
+        <Column
+          lg={16}
+          md={8}
+          sm={4}
+          className="district-volume-detail-column__actions"
+          data-testid="district-volume-detail-actions"
+        >
+          <Button
+            kind="secondary"
+            onClick={() => navigateInTree(navigate, '/configuration/district-volume-tables')}
+            renderIcon={ArrowLeft}
+          >
+            Back
+          </Button>
+        </Column>
       </>
     );
   }
@@ -72,20 +87,27 @@ const DistrictVolumeTableDetailPage: FC = () => {
             { name: 'Configuration', path: '/configuration' },
             { name: 'District average volumes', path: '/configuration/district-volume-tables' },
           ]}
-        >
-          <Button
-            kind="ghost"
-            onClick={() => navigateInTree(navigate, '/configuration/district-volume-tables')}
-            renderIcon={ArrowLeft}
-          >
-            Back
-          </Button>
-        </PageTitle>
+        />
       </Column>
       <Column lg={16} md={8} sm={4} className="district-volume-detail-column__notification">
         <PageNotification eventTarget="district-volume-detail" />
       </Column>
       <DistrictVolumeDetailView data={data} />
+      <Column
+        lg={16}
+        md={8}
+        sm={4}
+        className="district-volume-detail-column__actions"
+        data-testid="district-volume-detail-actions"
+      >
+        <Button
+          kind="secondary"
+          onClick={() => navigateInTree(navigate, '/configuration/district-volume-tables')}
+          renderIcon={ArrowLeft}
+        >
+          Back
+        </Button>
+      </Column>
     </>
   );
 };

--- a/frontend/src/pages/DistrictVolumeTableDetail/index.unit.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/index.unit.test.tsx
@@ -142,6 +142,23 @@ describe('DistrictVolumeTableDetailPage', () => {
     expect(screen.queryByTestId('district-volume-detail-view')).toBeNull();
   });
 
+  it('should navigate back from the error state', async () => {
+    vi.mocked(useDistrictVolumeTableDetailQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof useDistrictVolumeTableDetailQuery>);
+
+    const user = userEvent.setup();
+    render(<DistrictVolumeTableDetailPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/configuration/district-volume-tables',
+    });
+  });
+
   it('should render page title with normalized Interior data and DistrictVolumeDetailView', () => {
     const data = createData('INTERIOR', 1);
     vi.mocked(useDistrictVolumeTableDetailQuery).mockReturnValue({
@@ -227,6 +244,20 @@ describe('DistrictVolumeTableDetailPage', () => {
     expect(screen.getByTestId('breadcrumb-District average volumes').getAttribute('href')).toBe(
       '/configuration/district-volume-tables',
     );
+  });
+
+  it('should pass the numeric route id and notification target to the query hook', () => {
+    vi.mocked(useDistrictVolumeTableDetailQuery).mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useDistrictVolumeTableDetailQuery>);
+
+    render(<DistrictVolumeTableDetailPage />);
+
+    expect(useDistrictVolumeTableDetailQuery).toHaveBeenCalledWith(1, {
+      notificationTarget: 'district-volume-detail',
+    });
   });
 
   it('should render a Back button that navigates to the district volume list', async () => {

--- a/frontend/src/pages/DistrictVolumeTableDetail/index.unit.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/index.unit.test.tsx
@@ -237,8 +237,9 @@ describe('DistrictVolumeTableDetailPage', () => {
       isError: false,
     } as ReturnType<typeof useDistrictVolumeTableDetailQuery>);
 
+    const user = userEvent.setup();
     render(<DistrictVolumeTableDetailPage />);
-    await userEvent.click(screen.getByRole('button', { name: 'Back' }));
+    await user.click(screen.getByRole('button', { name: 'Back' }));
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: '/configuration/district-volume-tables',

--- a/frontend/src/pages/DistrictVolumeTableDetail/index.unit.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/index.unit.test.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from '@tanstack/react-router';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -239,10 +239,22 @@ describe('DistrictVolumeTableDetailPage', () => {
 
     const user = userEvent.setup();
     render(<DistrictVolumeTableDetailPage />);
-    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    await user.click(backButton);
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: '/configuration/district-volume-tables',
     });
+
+    // The Back button is placed at the bottom of the page, not in the page title.
+    expect(
+      within(screen.getByTestId('page-title')).queryByRole('button', { name: 'Back' }),
+    ).toBeNull();
+    expect(
+      within(screen.getByTestId('district-volume-detail-actions')).getByRole('button', {
+        name: 'Back',
+      }),
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/pages/DistrictVolumeTableDetail/index.unit.test.tsx
+++ b/frontend/src/pages/DistrictVolumeTableDetail/index.unit.test.tsx
@@ -1,4 +1,6 @@
+import { useNavigate } from '@tanstack/react-router';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import DistrictVolumeTableDetailPage from './index';
@@ -13,6 +15,7 @@ import { useDistrictVolumeTableDetailQuery } from '@/config/react-query/hooks';
 
 vi.mock('@tanstack/react-router', () => ({
   useParams: vi.fn().mockReturnValue({ id: '1' }),
+  useNavigate: vi.fn(),
 }));
 
 vi.mock('@/config/react-query/hooks', () => ({
@@ -36,10 +39,12 @@ vi.mock('@/components/core/PageTitle', () => ({
     title,
     subtitle,
     breadCrumbs,
+    children,
   }: {
     title: string;
     subtitle?: string;
     breadCrumbs?: Array<{ name: string; path: string }>;
+    children?: React.ReactNode;
   }) => (
     <div data-testid="page-title">
       <span data-testid="page-title-text">{title}</span>
@@ -49,6 +54,7 @@ vi.mock('@/components/core/PageTitle', () => ({
           {crumb.name}
         </a>
       ))}
+      {children}
     </div>
   ),
 }));
@@ -84,8 +90,11 @@ const createData = (area: 'INTERIOR' | 'COASTAL', id = 1): DistrictVolumeDetail 
 // ============================================================================
 
 describe('DistrictVolumeTableDetailPage', () => {
+  const mockNavigate = vi.fn();
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useNavigate).mockReturnValue(mockNavigate);
   });
 
   it('should render DistrictVolumeDetailSkeleton when isLoading is true', () => {
@@ -218,5 +227,21 @@ describe('DistrictVolumeTableDetailPage', () => {
     expect(screen.getByTestId('breadcrumb-District average volumes').getAttribute('href')).toBe(
       '/configuration/district-volume-tables',
     );
+  });
+
+  it('should render a Back button that navigates to the district volume list', async () => {
+    const data = createData('INTERIOR');
+    vi.mocked(useDistrictVolumeTableDetailQuery).mockReturnValue({
+      data,
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useDistrictVolumeTableDetailQuery>);
+
+    render(<DistrictVolumeTableDetailPage />);
+    await userEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/configuration/district-volume-tables',
+    });
   });
 });

--- a/frontend/src/pages/SpeciesCompositionDetail/index.tsx
+++ b/frontend/src/pages/SpeciesCompositionDetail/index.tsx
@@ -47,8 +47,8 @@ const SpeciesCompositionDetailPage: FC = () => {
       <>
         <Column lg={16} md={8} sm={4} className="species-composition-detail-column__banner">
           <PageTitle
-            title={isError || !data ? 'Species composition not found' : 'Species composition table'}
-            subtitle={isError || !data ? undefined : 'View species composition table details'}
+            title="Species composition not found"
+            subtitle={undefined}
             breadCrumbs={[
               { name: 'Configuration', path: '/configuration' },
               { name: 'Species composition', path: '/configuration/species-composition' },

--- a/frontend/src/pages/SpeciesCompositionDetail/index.tsx
+++ b/frontend/src/pages/SpeciesCompositionDetail/index.tsx
@@ -53,18 +53,25 @@ const SpeciesCompositionDetailPage: FC = () => {
               { name: 'Configuration', path: '/configuration' },
               { name: 'Species composition', path: '/configuration/species-composition' },
             ]}
-          >
-            <Button
-              kind="ghost"
-              onClick={() => navigateInTree(navigate, '/configuration/species-composition')}
-              renderIcon={ArrowLeft}
-            >
-              Back
-            </Button>
-          </PageTitle>
+          />
         </Column>
         <Column lg={16} md={8} sm={4} className="species-composition-detail-column__notification">
           <PageNotification eventTarget="species-composition-detail" />
+        </Column>
+        <Column
+          lg={16}
+          md={8}
+          sm={4}
+          className="species-composition-detail-column__actions"
+          data-testid="species-composition-detail-actions"
+        >
+          <Button
+            kind="secondary"
+            onClick={() => navigateInTree(navigate, '/configuration/species-composition')}
+            renderIcon={ArrowLeft}
+          >
+            Back
+          </Button>
         </Column>
       </>
     );
@@ -80,20 +87,27 @@ const SpeciesCompositionDetailPage: FC = () => {
             { name: 'Configuration', path: '/configuration' },
             { name: 'Species composition', path: '/configuration/species-composition' },
           ]}
-        >
-          <Button
-            kind="ghost"
-            onClick={() => navigateInTree(navigate, '/configuration/species-composition')}
-            renderIcon={ArrowLeft}
-          >
-            Back
-          </Button>
-        </PageTitle>
+        />
       </Column>
       <Column lg={16} md={8} sm={4} className="species-composition-detail-column__notification">
         <PageNotification eventTarget="species-composition-detail" />
       </Column>
       <SpeciesCompositionDetailView data={data} />
+      <Column
+        lg={16}
+        md={8}
+        sm={4}
+        className="species-composition-detail-column__actions"
+        data-testid="species-composition-detail-actions"
+      >
+        <Button
+          kind="secondary"
+          onClick={() => navigateInTree(navigate, '/configuration/species-composition')}
+          renderIcon={ArrowLeft}
+        >
+          Back
+        </Button>
+      </Column>
     </>
   );
 };

--- a/frontend/src/pages/SpeciesCompositionDetail/index.tsx
+++ b/frontend/src/pages/SpeciesCompositionDetail/index.tsx
@@ -1,5 +1,6 @@
-import { Column } from '@carbon/react';
-import { useParams } from '@tanstack/react-router';
+import { ArrowLeft } from '@carbon/icons-react';
+import { Button, Column } from '@carbon/react';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { type FC } from 'react';
 
 import PageNotification from '@/components/core/PageNotification';
@@ -7,6 +8,7 @@ import PageTitle from '@/components/core/PageTitle';
 import SpeciesCompositionDetailView from '@/components/waste/SpeciesCompositionDetailView';
 import SpeciesCompositionDetailSkeleton from '@/components/waste/SpeciesCompositionDetailView/SpeciesCompositionDetailSkeleton';
 import { useSpeciesCompositionDetailQuery } from '@/config/react-query/hooks';
+import { navigateInTree } from '@/routes/inTreePaths';
 
 import './index.scss';
 
@@ -24,6 +26,7 @@ import './index.scss';
  * @returns The Species Composition Detail page.
  */
 const SpeciesCompositionDetailPage: FC = () => {
+  const navigate = useNavigate();
   const params = useParams({ strict: false });
   const id = Number(params.id);
 
@@ -50,7 +53,15 @@ const SpeciesCompositionDetailPage: FC = () => {
               { name: 'Configuration', path: '/configuration' },
               { name: 'Species composition', path: '/configuration/species-composition' },
             ]}
-          />
+          >
+            <Button
+              kind="ghost"
+              onClick={() => navigateInTree(navigate, '/configuration/species-composition')}
+              renderIcon={ArrowLeft}
+            >
+              Back
+            </Button>
+          </PageTitle>
         </Column>
         <Column lg={16} md={8} sm={4} className="species-composition-detail-column__notification">
           <PageNotification eventTarget="species-composition-detail" />
@@ -69,7 +80,15 @@ const SpeciesCompositionDetailPage: FC = () => {
             { name: 'Configuration', path: '/configuration' },
             { name: 'Species composition', path: '/configuration/species-composition' },
           ]}
-        />
+        >
+          <Button
+            kind="ghost"
+            onClick={() => navigateInTree(navigate, '/configuration/species-composition')}
+            renderIcon={ArrowLeft}
+          >
+            Back
+          </Button>
+        </PageTitle>
       </Column>
       <Column lg={16} md={8} sm={4} className="species-composition-detail-column__notification">
         <PageNotification eventTarget="species-composition-detail" />

--- a/frontend/src/pages/SpeciesCompositionDetail/index.unit.test.tsx
+++ b/frontend/src/pages/SpeciesCompositionDetail/index.unit.test.tsx
@@ -1,5 +1,7 @@
-import { useParams } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import SpeciesCompositionDetailPage from './index';
@@ -13,6 +15,7 @@ import { useSpeciesCompositionDetailQuery } from '@/config/react-query/hooks';
 // ============================================================================
 
 vi.mock('@tanstack/react-router', () => ({
+  useNavigate: vi.fn(),
   useParams: vi.fn().mockReturnValue({ id: '42' }),
 }));
 
@@ -37,10 +40,12 @@ vi.mock('@/components/core/PageTitle', () => ({
     title,
     subtitle,
     breadCrumbs,
+    children,
   }: {
     title: string;
     subtitle?: string;
     breadCrumbs?: Array<{ name: string; path: string }>;
+    children?: ReactNode;
   }) => (
     <div data-testid="page-title">
       <span data-testid="page-title-text">{title}</span>
@@ -50,6 +55,7 @@ vi.mock('@/components/core/PageTitle', () => ({
           {crumb.name}
         </a>
       ))}
+      {children}
     </div>
   ),
 }));
@@ -109,8 +115,11 @@ const createData = (id = 42): SpeciesCompositionDetail =>
 // ============================================================================
 
 describe('SpeciesCompositionDetailPage', () => {
+  const mockNavigate = vi.fn();
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useNavigate).mockReturnValue(mockNavigate);
   });
 
   it('should render SpeciesCompositionDetailSkeleton when isLoading is true', () => {
@@ -202,6 +211,21 @@ describe('SpeciesCompositionDetailPage', () => {
     expect(screen.getByTestId('breadcrumb-Species composition').getAttribute('href')).toBe(
       '/configuration/species-composition',
     );
+  });
+
+  it('should render a Back button that navigates to the species composition list', async () => {
+    vi.mocked(useSpeciesCompositionDetailQuery).mockReturnValue({
+      data: createData(),
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useSpeciesCompositionDetailQuery>);
+
+    const user = userEvent.setup();
+    render(<SpeciesCompositionDetailPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/configuration/species-composition' });
   });
 
   it('passes the numeric id derived from route params to the query hook', () => {

--- a/frontend/src/pages/SpeciesCompositionDetail/index.unit.test.tsx
+++ b/frontend/src/pages/SpeciesCompositionDetail/index.unit.test.tsx
@@ -163,6 +163,21 @@ describe('SpeciesCompositionDetailPage', () => {
     expect(screen.queryByTestId('species-composition-detail-view')).toBeNull();
   });
 
+  it('should navigate back from the error state', async () => {
+    vi.mocked(useSpeciesCompositionDetailQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as ReturnType<typeof useSpeciesCompositionDetailQuery>);
+
+    const user = userEvent.setup();
+    render(<SpeciesCompositionDetailPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/configuration/species-composition' });
+  });
+
   it('should render page title with data and SpeciesCompositionDetailView', () => {
     const data = createData(42);
     vi.mocked(useSpeciesCompositionDetailQuery).mockReturnValue({

--- a/frontend/src/pages/SpeciesCompositionDetail/index.unit.test.tsx
+++ b/frontend/src/pages/SpeciesCompositionDetail/index.unit.test.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useParams } from '@tanstack/react-router';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -223,9 +223,20 @@ describe('SpeciesCompositionDetailPage', () => {
     const user = userEvent.setup();
     render(<SpeciesCompositionDetailPage />);
 
-    await user.click(screen.getByRole('button', { name: 'Back' }));
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    await user.click(backButton);
 
     expect(mockNavigate).toHaveBeenCalledWith({ to: '/configuration/species-composition' });
+
+    // The Back button is placed at the bottom of the page, not in the page title.
+    expect(
+      within(screen.getByTestId('page-title')).queryByRole('button', { name: 'Back' }),
+    ).toBeNull();
+    expect(
+      within(screen.getByTestId('species-composition-detail-actions')).getByRole('button', {
+        name: 'Back',
+      }),
+    ).toBeTruthy();
   });
 
   it('passes the numeric id derived from route params to the query hook', () => {


### PR DESCRIPTION
<!-- generated-by: opencode-skill pull-request-description-generator; created-at: 2026-08-13T21:27:45.765653Z -->

## Description

Adds the missing Back button to the district volume data detail screen so users can return to the district volume list as specified in issue #1182 and the linked Figma design.

Closes #1182

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing

- `npm run test:unit -- --run src/pages/DistrictVolumeTableDetail/index.unit.test.tsx` (9 tests passed)
- `npx tsc --noEmit` (passed)
- `git diff --check` (passed)
- Full lint was run; it reports pre-existing warnings in unrelated files. The changed files have no lint diagnostics.

## Checklist

- [x] The change includes a regression test.
- [x] The change follows the existing Carbon and TanStack Router patterns.
- [x] No database or configuration migration is required.

## Risks and Rollout Notes

Low risk. The button uses the existing typed navigation helper and only changes navigation from the detail screen to the district volume list.

## Further Comments

The Team Alliance project item was set to **In progress** with an estimate of **1**.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-34-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)