### PR TITLE
fix: restore Carbon modal footer sizing after component import change

### DIFF
--- a/frontend/src/styles/_overrides.scss
+++ b/frontend/src/styles/_overrides.scss
@@ -731,3 +731,22 @@ div:has(.#{variables.$bcgov-prefix}--header) ~ .#{variables.$bcgov-prefix}--cont
 .#{variables.$bcgov-prefix}--popover-caret {
   z-index: 8500;
 }
+
+/* Carbon's ComposedModal close control also receives the primary button class.
+ * Keep the modal-specific transparent close-button treatment in the cascade. */
+.#{variables.$bcgov-prefix}--modal-close.#{variables.$bcgov-prefix}--btn--primary {
+  background-color: transparent;
+  color: var(--cds-icon-primary);
+}
+
+.#{variables.$bcgov-prefix}--modal-close.#{variables.$bcgov-prefix}--btn--primary:hover {
+  background-color: var(--cds-layer-hover);
+}
+
+/* Carbon's generic button-set cap overrides the modal footer's fluid buttons
+ * when component styles are loaded in the current order. */
+.#{variables.$bcgov-prefix}--modal-container
+  .#{variables.$bcgov-prefix}--modal-footer
+  .#{variables.$bcgov-prefix}--btn {
+  max-inline-size: none;
+}


### PR DESCRIPTION
# Description

Restores Carbon modal footer button sizing and transparent close-button treatment that was lost after switching from broad React stylesheet import to selective component imports (commit 47137f1, #716).

## Changes

- Added SCSS overrides in `frontend/src/styles/_overrides.scss`:
  - Modal close button with primary button class now has transparent background
  - Modal footer buttons have fluid sizing restored (`max-inline-size: none`)

Fixes #1192

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [x] New user flow tests (verified modals render correctly)
- [ ] Manual tests

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-45-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)