### PR TITLE
fix(#1183): interval-aware insertion and hardened delete for configuration rows

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -300,6 +300,12 @@
                             <artifactId>lombok</artifactId>
                         </path>
                     </annotationProcessorPaths>
+                    <testAnnotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </testAnnotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/DistrictVolumeController.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/DistrictVolumeController.java
@@ -13,11 +13,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,7 +50,8 @@ public class DistrictVolumeController {
   @GetMapping
   public ResponseEntity<Page<DistrictVolumeListItemDto>> getDistrictVolumes(
       @RequestParam(required = false) String area,
-      @PageableDefault(size = 10) Pageable pageable) {
+      @PageableDefault(size = 10, sort = "startDate",
+          direction = Direction.DESC) Pageable pageable) {
 
     if (area != null && !area.equalsIgnoreCase("INTERIOR") && !area.equalsIgnoreCase("COASTAL")) {
       throw new ResponseStatusException(
@@ -107,5 +110,24 @@ public class DistrictVolumeController {
                 + createdVolume.id());
 
     return ResponseEntity.created(location).build();
+  }
+
+  /**
+   * Deletes a district volume configuration.
+   *
+   * <p>Soft-deletes the specified district volume configuration. Only future-start,
+   * open-ended configurations can be deleted.</p>
+   *
+   * @param jwt the authenticated user's JWT
+   * @param id the district volume configuration identifier
+   * @return a {@link ResponseEntity} with status {@code 204 No Content}
+   */
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteDistrictVolume(
+      @AuthenticationPrincipal Jwt jwt,
+      @PathVariable Long id) {
+    districtVolumeService.deleteDistrictVolume(
+        JwtPrincipalUtil.getUserId(jwt), id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/SpeciesCompositionController.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/controller/SpeciesCompositionController.java
@@ -13,11 +13,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,7 +50,8 @@ public class SpeciesCompositionController {
   @GetMapping
   public ResponseEntity<Page<DistrictVolumeListItemDto>> getSpeciesCompositions(
       @RequestParam(required = false) String area,
-      @PageableDefault(size = 10) Pageable pageable) {
+      @PageableDefault(size = 10, sort = "startDate",
+          direction = Direction.DESC) Pageable pageable) {
 
     if (area != null && !area.equalsIgnoreCase("INTERIOR") && !area.equalsIgnoreCase("COASTAL")) {
       throw new ResponseStatusException(
@@ -108,5 +111,24 @@ public class SpeciesCompositionController {
                 + createdConfig.id());
 
     return ResponseEntity.created(location).build();
+  }
+
+  /**
+   * Deletes a species composition configuration.
+   *
+   * <p>Soft-deletes the specified species composition configuration. Only future-start,
+   * open-ended configurations can be deleted.</p>
+   *
+   * @param jwt the authenticated user's JWT
+   * @param id the species composition configuration identifier
+   * @return a {@link ResponseEntity} with status {@code 204 No Content}
+   */
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteSpeciesComposition(
+      @AuthenticationPrincipal Jwt jwt,
+      @PathVariable Long id) {
+    speciesCompositionService.deleteSpeciesComposition(
+        JwtPrincipalUtil.getUserId(jwt), id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
@@ -215,6 +216,35 @@ public class GlobalExceptionHandler {
     ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR);
     problem.setTitle("Internal Server Error");
     problem.setDetail("An unexpected error occurred. Please contact support if this persists.");
+    problem.setInstance(URI.create(request.getRequestURI()));
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .body(problem);
+  }
+
+  /**
+   * Handles failures caused by multiple records matching a query that expects
+   * one record.
+   *
+   * <p>The underlying exception details remain in the server log, while the
+   * response explains that the failure is a data consistency problem without
+   * exposing database or implementation details to the caller.</p>
+   *
+   * @param ex the cardinality exception
+   * @param request the current HTTP servlet request
+   * @return a 500 RFC 7807 response with a safe data consistency detail
+   */
+  @ExceptionHandler(IncorrectResultSizeDataAccessException.class)
+  public ResponseEntity<ProblemDetail> handleIncorrectResultSize(
+      IncorrectResultSizeDataAccessException ex, HttpServletRequest request) {
+    log.error("Multiple records matched a unique-result query: {}", ex.getMessage(), ex);
+
+    ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+    problem.setTitle("Data Consistency Error");
+    problem.setDetail(
+        "Multiple active records were found where one record was expected. "
+            + "Please contact support to resolve the configuration data.");
     problem.setInstance(URI.create(request.getRequestURI()));
 
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/DistrictVolumeRepository.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/repository/DistrictVolumeRepository.java
@@ -137,7 +137,8 @@ public interface DistrictVolumeRepository
   List<DistrictVolumeEntity> findFirstLiveAfter(
       @Param("configType") ConfigType configType,
       @Param("area") Area area,
-      @Param("startDate") LocalDate startDate);
+      @Param("startDate") LocalDate startDate,
+      Pageable pageable);
 
   /**
    * Finds the most recent live row before the supplied start date.
@@ -149,5 +150,6 @@ public interface DistrictVolumeRepository
   List<DistrictVolumeEntity> findFirstLiveBefore(
       @Param("configType") ConfigType configType,
       @Param("area") Area area,
-      @Param("startDate") LocalDate startDate);
+      @Param("startDate") LocalDate startDate,
+      Pageable pageable);
 }

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeService.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -246,8 +247,27 @@ public class DistrictVolumeService {
               + areaEnum + ". Resolve the duplicates before creating a new configuration.");
     }
 
-    if (!openEntries.isEmpty()) {
-      DistrictVolumeEntity previousEntry = openEntries.getFirst();
+    List<DistrictVolumeEntity> successorEntries = districtVolumeRepository.findFirstLiveAfter(
+        ConfigType.DISTRICT_VOLUME,
+        areaEnum,
+        createDto.startDate(),
+        PageRequest.of(0, 1));
+    DistrictVolumeEntity successor = successorEntries.isEmpty()
+        ? null
+        : successorEntries.getFirst();
+    DistrictVolumeEntity previousEntry;
+    if (successor != null) {
+      List<DistrictVolumeEntity> previousEntries = districtVolumeRepository.findFirstLiveBefore(
+          ConfigType.DISTRICT_VOLUME,
+          areaEnum,
+          createDto.startDate(),
+          PageRequest.of(0, 1));
+      previousEntry = previousEntries.isEmpty() ? null : previousEntries.getFirst();
+    } else {
+      previousEntry = openEntries.isEmpty() ? null : openEntries.getFirst();
+    }
+
+    if (previousEntry != null) {
 
       if (!createDto.startDate().isAfter(previousEntry.getStartDate())) {
         throw new ResponseStatusException(
@@ -264,6 +284,7 @@ public class DistrictVolumeService {
 
     entity.setArea(areaEnum);
     entity.setStartDate(createDto.startDate());
+    entity.setEndDate(successor == null ? null : successor.getStartDate().minusDays(1));
     entity.setTableLevelFactor(createDto.tableLevelFactor());
     entity.setHeliMultiplier(createDto.heliMultiplier());
     entity.setCreatedBy(user);
@@ -365,11 +386,16 @@ public class DistrictVolumeService {
    * <p>Marks the record as deleted (sets deleted = true) instead of removing it from the database.
    * This preserves audit history and allows for potential recovery.</p>
    *
+   * <p>Only future-start, open-ended configurations can be deleted. When deleted, the predecessor
+   * (if any) is reopened by setting its end date to the deleted record's end date.</p>
+   *
    * @param user the user performing the deletion (for audit trail)
    * @param id the unique identifier of the record to delete
    * @throws ResponseStatusException with HTTP 404 if the record is not found or already deleted
+   * @throws ResponseStatusException with HTTP 422 if the record is not a
+ *     future-start or not open-ended
    */
-  @Transactional
+  @Transactional(isolation = Isolation.SERIALIZABLE)
   public void deleteDistrictVolume(String user, Long id) {
     DistrictVolumeEntity entity = districtVolumeRepository
         .findByIdAndConfigType(id, ConfigType.DISTRICT_VOLUME)
@@ -377,6 +403,29 @@ public class DistrictVolumeService {
         .orElseThrow(() -> new ResponseStatusException(
             HttpStatus.NOT_FOUND,
             "District volume record not found: " + id));
+
+    if (!entity.getStartDate().isAfter(LocalDate.now())) {
+      throw new ResponseStatusException(
+          HttpStatus.UNPROCESSABLE_CONTENT,
+          "Only future-start configurations can be deleted.");
+    }
+
+    if (entity.getEndDate() != null) {
+      throw new ResponseStatusException(
+          HttpStatus.UNPROCESSABLE_CONTENT,
+          "Only open-ended future configurations can be deleted.");
+    }
+
+    List<DistrictVolumeEntity> previousEntries = districtVolumeRepository.findFirstLiveBefore(
+        ConfigType.DISTRICT_VOLUME,
+        entity.getArea(),
+        entity.getStartDate(),
+        PageRequest.of(0, 1));
+    if (!previousEntries.isEmpty()) {
+      DistrictVolumeEntity predecessor = previousEntries.getFirst();
+      predecessor.setEndDate(entity.getEndDate());
+      districtVolumeRepository.save(predecessor);
+    }
 
     entity.setDeleted(true);
     districtVolumeRepository.save(entity);

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeService.java
@@ -393,7 +393,7 @@ public class DistrictVolumeService {
    * @param id the unique identifier of the record to delete
    * @throws ResponseStatusException with HTTP 404 if the record is not found or already deleted
    * @throws ResponseStatusException with HTTP 422 if the record is not a
- *     future-start or not open-ended
+   *     future-start or not open-ended.
    */
   @Transactional(isolation = Isolation.SERIALIZABLE)
   public void deleteDistrictVolume(String user, Long id) {
@@ -404,7 +404,7 @@ public class DistrictVolumeService {
             HttpStatus.NOT_FOUND,
             "District volume record not found: " + id));
 
-    if (!entity.getStartDate().isAfter(LocalDate.now())) {
+    if (entity.getStartDate() == null || !entity.getStartDate().isAfter(LocalDate.now())) {
       throw new ResponseStatusException(
           HttpStatus.UNPROCESSABLE_CONTENT,
           "Only future-start configurations can be deleted.");

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionService.java
@@ -200,7 +200,7 @@ public class SpeciesCompositionService {
    * @param id the unique identifier of the record to delete
    * @throws ResponseStatusException with HTTP 404 if the record is not found or already deleted
    * @throws ResponseStatusException with HTTP 422 if the record is not a
- *     future-start or not open-ended
+   *     future-start or not open-ended.
    */
   @Transactional(isolation = Isolation.SERIALIZABLE)
   public void deleteSpeciesComposition(String user, Long id) {
@@ -214,7 +214,7 @@ public class SpeciesCompositionService {
     if (entity.getStartDate() == null || !entity.getStartDate().isAfter(LocalDate.now())) {
       throw new ResponseStatusException(
           HttpStatus.UNPROCESSABLE_CONTENT,
-          "Only future configurations can be deleted.");
+          "Only future-start configurations can be deleted.");
     }
 
     if (entity.getEndDate() != null) {

--- a/backend/src/main/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionService.java
+++ b/backend/src/main/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.EnumUtils;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -139,8 +140,27 @@ public class SpeciesCompositionService {
               + areaEnum + ". Resolve the duplicates before creating a new configuration.");
     }
 
-    if (!openRows.isEmpty()) {
-      DistrictVolumeEntity previousEntry = openRows.getFirst();
+    List<DistrictVolumeEntity> successorEntries = districtVolumeRepository.findFirstLiveAfter(
+        ConfigType.SPECIES_COMPOSITION,
+        areaEnum,
+        createDto.startDate(),
+        PageRequest.of(0, 1));
+    DistrictVolumeEntity successor = successorEntries.isEmpty()
+        ? null
+        : successorEntries.getFirst();
+    DistrictVolumeEntity previousEntry;
+    if (successor != null) {
+      List<DistrictVolumeEntity> previousEntries = districtVolumeRepository.findFirstLiveBefore(
+          ConfigType.SPECIES_COMPOSITION,
+          areaEnum,
+          createDto.startDate(),
+          PageRequest.of(0, 1));
+      previousEntry = previousEntries.isEmpty() ? null : previousEntries.getFirst();
+    } else {
+      previousEntry = openRows.isEmpty() ? null : openRows.getFirst();
+    }
+
+    if (previousEntry != null) {
 
       if (!createDto.startDate().isAfter(previousEntry.getStartDate())) {
         throw new ResponseStatusException(
@@ -158,6 +178,7 @@ public class SpeciesCompositionService {
 
     DistrictVolumeEntity newEntity = DistrictVolumeMapper.toEntity(createDto);
     newEntity.setConfigType(ConfigType.SPECIES_COMPOSITION);
+    newEntity.setEndDate(successor == null ? null : successor.getStartDate().minusDays(1));
     newEntity.setCreatedBy(currentUser);
 
     DistrictVolumeEntity saved = districtVolumeRepository.save(newEntity);
@@ -172,11 +193,16 @@ public class SpeciesCompositionService {
    * <p>Marks the record as deleted (sets deleted = true) instead of removing it from the database.
    * This preserves audit history and allows for potential recovery.</p>
    *
+   * <p>Only future-start, open-ended configurations can be deleted. When deleted, the predecessor
+   * (if any) is reopened by setting its end date to the deleted record's end date.</p>
+   *
    * @param user the user performing the deletion (for audit trail)
    * @param id the unique identifier of the record to delete
    * @throws ResponseStatusException with HTTP 404 if the record is not found or already deleted
+   * @throws ResponseStatusException with HTTP 422 if the record is not a
+ *     future-start or not open-ended
    */
-  @Transactional
+  @Transactional(isolation = Isolation.SERIALIZABLE)
   public void deleteSpeciesComposition(String user, Long id) {
     DistrictVolumeEntity entity = districtVolumeRepository
         .findByIdAndConfigType(id, ConfigType.SPECIES_COMPOSITION)
@@ -184,6 +210,29 @@ public class SpeciesCompositionService {
         .orElseThrow(() -> new ResponseStatusException(
             HttpStatus.NOT_FOUND,
             "Species composition record not found: " + id));
+
+    if (entity.getStartDate() == null || !entity.getStartDate().isAfter(LocalDate.now())) {
+      throw new ResponseStatusException(
+          HttpStatus.UNPROCESSABLE_CONTENT,
+          "Only future configurations can be deleted.");
+    }
+
+    if (entity.getEndDate() != null) {
+      throw new ResponseStatusException(
+          HttpStatus.UNPROCESSABLE_CONTENT,
+          "Only open-ended future configurations can be deleted.");
+    }
+
+    List<DistrictVolumeEntity> previousEntries = districtVolumeRepository.findFirstLiveBefore(
+        ConfigType.SPECIES_COMPOSITION,
+        entity.getArea(),
+        entity.getStartDate(),
+        PageRequest.of(0, 1));
+    if (!previousEntries.isEmpty()) {
+      DistrictVolumeEntity predecessor = previousEntries.getFirst();
+      predecessor.setEndDate(entity.getEndDate());
+      districtVolumeRepository.save(predecessor);
+    }
 
     entity.setDeleted(true);
     districtVolumeRepository.save(entity);

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/DistrictVolumeControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/DistrictVolumeControllerTest.java
@@ -2,10 +2,15 @@ package ca.bc.gov.nrs.hrs.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -359,4 +364,87 @@ class DistrictVolumeControllerTest {
                 .content(objectMapper.writeValueAsString(invalidDto)))
         .andExpect(status().isBadRequest());
   }
-}
+
+  @Test
+  @DisplayName(
+      "DELETE /{id} — Should return 204 No Content when record exists and is future-start open-ended")
+  @WithMockJwt(value = "jakethedog")
+  void deleteDistrictVolume_returns204_whenRecordExistsAndIsFutureOpenEnded()
+      throws Exception {
+
+    doNothing().when(districtVolumeService)
+        .deleteDistrictVolume(eq("IDIR\\jakethedog"), eq(42L));
+
+    mockMvc.perform(
+            delete("/api/configuration/district-average-volumes/42")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+
+    verify(districtVolumeService)
+        .deleteDistrictVolume(eq("IDIR\\jakethedog"), eq(42L));
+  }
+
+  @Test
+  @DisplayName(
+      "DELETE /{id} — Should return 404 Not Found when record does not exist")
+  @WithMockJwt(value = "jakethedog")
+  void deleteDistrictVolume_returns404_whenNotFound() throws Exception {
+
+    doThrow(new ResponseStatusException(
+        HttpStatus.NOT_FOUND,
+        "District volume record not found: 99"))
+        .when(districtVolumeService)
+        .deleteDistrictVolume(eq("IDIR\\jakethedog"), eq(99L));
+
+    mockMvc.perform(
+            delete("/api/configuration/district-average-volumes/99")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+
+    verify(districtVolumeService)
+        .deleteDistrictVolume(eq("IDIR\\jakethedog"), eq(99L));
+  }
+
+  @Test
+  @DisplayName(
+      "DELETE /{id} — Should return 422 Unprocessable Content when record is not future-start")
+  @WithMockJwt(value = "jakethedog")
+  void deleteDistrictVolume_returns422_whenNotFutureStart() throws Exception {
+
+    doThrow(new ResponseStatusException(
+        HttpStatus.UNPROCESSABLE_CONTENT,
+        "Only future-start configurations can be deleted."))
+        .when(districtVolumeService)
+        .deleteDistrictVolume(eq("IDIR\\jakethedog"), eq(42L));
+
+    mockMvc.perform(
+            delete("/api/configuration/district-average-volumes/42")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnprocessableEntity());
+
+    verify(districtVolumeService)
+        .deleteDistrictVolume(eq("IDIR\\jakethedog"), eq(42L));
+  }
+
+  @Test
+  @DisplayName(
+      "DELETE /{id} — Should return 422 Unprocessable Content when record is not open-ended")
+  @WithMockJwt(value = "jakethedog")
+  void deleteDistrictVolume_returns422_whenNotOpenEnded() throws Exception {
+
+    doThrow(new ResponseStatusException(
+        HttpStatus.UNPROCESSABLE_CONTENT,
+        "Only open-ended future configurations can be deleted."))
+        .when(districtVolumeService)
+        .deleteDistrictVolume(eq("IDIR\\jakethedog"), eq(42L));
+
+    mockMvc.perform(
+            delete("/api/configuration/district-average-volumes/42")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnprocessableEntity());
+
+    verify(districtVolumeService)
+        .deleteDistrictVolume(eq("IDIR\\jakethedog"), eq(42L));
+  }
+
+  }

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/DistrictVolumeControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/DistrictVolumeControllerTest.java
@@ -10,8 +10,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import ca.bc.gov.nrs.hrs.dto.districtaveragevolume.DistrictVolumeCreateDto;

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/SpeciesCompositionControllerTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/controller/SpeciesCompositionControllerTest.java
@@ -2,7 +2,11 @@ package ca.bc.gov.nrs.hrs.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -359,4 +363,87 @@ class SpeciesCompositionControllerTest {
                 .content(objectMapper.writeValueAsString(invalidDto)))
         .andExpect(status().isBadRequest());
   }
-}
+
+  @Test
+  @DisplayName(
+      "DELETE /{id} — Should return 204 No Content when record exists and is future-start open-ended")
+  @WithMockJwt(value = "jakethedog")
+  void deleteSpeciesComposition_returns204_whenRecordExistsAndIsFutureOpenEnded()
+      throws Exception {
+
+    doNothing().when(speciesCompositionService)
+        .deleteSpeciesComposition(eq("IDIR\\jakethedog"), eq(42L));
+
+    mockMvc.perform(
+            delete("/api/configuration/species-compositions/42")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+
+    verify(speciesCompositionService)
+        .deleteSpeciesComposition(eq("IDIR\\jakethedog"), eq(42L));
+  }
+
+  @Test
+  @DisplayName(
+      "DELETE /{id} — Should return 404 Not Found when record does not exist")
+  @WithMockJwt(value = "jakethedog")
+  void deleteSpeciesComposition_returns404_whenNotFound() throws Exception {
+
+    doThrow(new ResponseStatusException(
+        HttpStatus.NOT_FOUND,
+        "Species composition record not found: 99"))
+        .when(speciesCompositionService)
+        .deleteSpeciesComposition(eq("IDIR\\jakethedog"), eq(99L));
+
+    mockMvc.perform(
+            delete("/api/configuration/species-compositions/99")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+
+    verify(speciesCompositionService)
+        .deleteSpeciesComposition(eq("IDIR\\jakethedog"), eq(99L));
+  }
+
+  @Test
+  @DisplayName(
+      "DELETE /{id} — Should return 422 Unprocessable Content when record is not future-start")
+  @WithMockJwt(value = "jakethedog")
+  void deleteSpeciesComposition_returns422_whenNotFutureStart() throws Exception {
+
+    doThrow(new ResponseStatusException(
+        HttpStatus.UNPROCESSABLE_CONTENT,
+        "Only future-start configurations can be deleted."))
+        .when(speciesCompositionService)
+        .deleteSpeciesComposition(eq("IDIR\\jakethedog"), eq(42L));
+
+    mockMvc.perform(
+            delete("/api/configuration/species-compositions/42")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnprocessableEntity());
+
+    verify(speciesCompositionService)
+        .deleteSpeciesComposition(eq("IDIR\\jakethedog"), eq(42L));
+  }
+
+  @Test
+  @DisplayName(
+      "DELETE /{id} — Should return 422 Unprocessable Content when record is not open-ended")
+  @WithMockJwt(value = "jakethedog")
+  void deleteSpeciesComposition_returns422_whenNotOpenEnded() throws Exception {
+
+    doThrow(new ResponseStatusException(
+        HttpStatus.UNPROCESSABLE_CONTENT,
+        "Only open-ended future configurations can be deleted."))
+        .when(speciesCompositionService)
+        .deleteSpeciesComposition(eq("IDIR\\jakethedog"), eq(42L));
+
+    mockMvc.perform(
+            delete("/api/configuration/species-compositions/42")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnprocessableEntity());
+
+    verify(speciesCompositionService)
+        .deleteSpeciesComposition(eq("IDIR\\jakethedog"), eq(42L));
+  }
+
+  }

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
@@ -586,6 +586,8 @@ class DistrictVolumeServiceTest {
   void deleteDistrictVolume_softDeletes_whenFound() {
 
     DistrictVolumeEntity entity = buildEntity(Area.INTERIOR);
+    entity.setStartDate(LocalDate.now().plusYears(1));
+    entity.setEndDate(null);
 
     when(districtVolumeRepository.findByIdAndConfigType(1L, ConfigType.DISTRICT_VOLUME))
         .thenReturn(Optional.of(entity));

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/DistrictVolumeServiceTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -578,6 +580,193 @@ class DistrictVolumeServiceTest {
         .isEqualTo(new BigDecimal("1.200"));
     assertThat(result.heliMultiplier())
         .isEqualTo(new BigDecimal("1.500"));
+  }
+
+  @Test
+  @DisplayName(
+      "createDistrictVolume — should insert between existing rows and close predecessor, set endDate on new entity")
+  void createDistrictVolume_insertsBetweenRows_setsEndDateOnNewAndClosesPredecessor() {
+
+    CoastDataDto coastData = new CoastDataDto(Collections.emptyList(), Collections.emptyMap());
+
+    DistrictVolumeCreateDto createDto = new DistrictVolumeCreateDto(
+        "COASTAL",
+        LocalDate.of(2027, Month.JULY, 15),
+        new BigDecimal("1.200"),
+        new BigDecimal("1.500"),
+        coastData);
+
+    // Successor: row starting Aug 1, 2027
+    DistrictVolumeEntity successor = buildEntity(Area.COASTAL);
+    successor.setId(2L);
+    successor.setStartDate(LocalDate.of(2027, Month.AUGUST, 1));
+    successor.setEndDate(null);
+
+    // Predecessor: row starting Jan 1, 2027
+    DistrictVolumeEntity predecessor = buildEntity(Area.COASTAL);
+    predecessor.setId(1L);
+    predecessor.setStartDate(LocalDate.of(2027, Month.JANUARY, 1));
+    predecessor.setEndDate(null);
+
+    when(districtVolumeRepository.findByConfigTypeAndAreaAndEndDateIsNullOrderByStartDateDesc(
+            ConfigType.DISTRICT_VOLUME, Area.COASTAL))
+        .thenReturn(Collections.singletonList(predecessor));
+
+    when(districtVolumeRepository.findFirstLiveAfter(
+            eq(ConfigType.DISTRICT_VOLUME),
+            eq(Area.COASTAL),
+            eq(LocalDate.of(2027, Month.JULY, 15)),
+            any(PageRequest.class)))
+        .thenReturn(List.of(successor));
+
+    when(districtVolumeRepository.findFirstLiveBefore(
+            eq(ConfigType.DISTRICT_VOLUME),
+            eq(Area.COASTAL),
+            eq(LocalDate.of(2027, Month.JULY, 15)),
+            any(PageRequest.class)))
+        .thenReturn(List.of(predecessor));
+
+    when(districtVolumeRepository.save(any(DistrictVolumeEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    DistrictVolumeDetailDto result = districtVolumeService.createDistrictVolume(
+        "TEST_USER", createDto);
+
+    assertThat(result.startDate()).isEqualTo(LocalDate.of(2027, Month.JULY, 15));
+    assertThat(result.endDate()).isEqualTo(LocalDate.of(2027, Month.JULY, 31)); // successor start - 1 day
+
+    // Verify predecessor was closed
+    verify(districtVolumeRepository).save(argThat(e ->
+        e.getEndDate().equals(LocalDate.of(2027, Month.JULY, 14))));
+  }
+
+  @Test
+  @DisplayName(
+      "createDistrictVolume — should insert after all rows when no successor exists")
+  void createDistrictVolume_insertsAfterAllRows_whenNoSuccessor() {
+
+    InteriorDataDto interiorData = new InteriorDataDto(Collections.emptyList(), Collections.emptyMap());
+
+    DistrictVolumeCreateDto createDto = new DistrictVolumeCreateDto(
+        "INTERIOR",
+        LocalDate.of(2027, Month.JULY, 15),
+        new BigDecimal("1.200"),
+        null,
+        interiorData);
+
+    // Open-ended predecessor
+    DistrictVolumeEntity predecessor = buildEntity(Area.INTERIOR);
+    predecessor.setId(1L);
+    predecessor.setStartDate(LocalDate.of(2027, Month.JANUARY, 1));
+    predecessor.setEndDate(null);
+
+    when(districtVolumeRepository.findByConfigTypeAndAreaAndEndDateIsNullOrderByStartDateDesc(
+            ConfigType.DISTRICT_VOLUME, Area.INTERIOR))
+        .thenReturn(Collections.singletonList(predecessor));
+
+    when(districtVolumeRepository.findFirstLiveAfter(
+            eq(ConfigType.DISTRICT_VOLUME),
+            eq(Area.INTERIOR),
+            eq(LocalDate.of(2027, Month.JULY, 15)),
+            any(PageRequest.class)))
+        .thenReturn(Collections.emptyList());
+
+    when(districtVolumeRepository.save(any(DistrictVolumeEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    DistrictVolumeDetailDto result = districtVolumeService.createDistrictVolume(
+        "TEST_USER", createDto);
+
+    assertThat(result.startDate()).isEqualTo(LocalDate.of(2027, Month.JULY, 15));
+    assertThat(result.endDate()).isNull(); // No successor = open-ended
+
+    // Verify predecessor was closed
+    verify(districtVolumeRepository).save(argThat(e ->
+        e.getEndDate() != null && e.getEndDate().equals(LocalDate.of(2027, Month.JULY, 14))));
+
+    // Verify new entity was saved as open-ended (endDate = null)
+    verify(districtVolumeRepository).save(argThat(e ->
+        e.getEndDate() == null));
+  }
+
+  @Test
+  @DisplayName(
+      "createDistrictVolume — should insert before all rows when no predecessor exists")
+  void createDistrictVolume_insertsBeforeAllRows_whenNoPredecessor() {
+
+    InteriorDataDto interiorData = new InteriorDataDto(Collections.emptyList(), Collections.emptyMap());
+
+    DistrictVolumeCreateDto createDto = new DistrictVolumeCreateDto(
+        "INTERIOR",
+        LocalDate.of(2027, Month.JANUARY, 15),
+        new BigDecimal("1.200"),
+        null,
+        interiorData);
+
+    // Successor exists (starts Jan 1)
+    DistrictVolumeEntity successor = buildEntity(Area.INTERIOR);
+    successor.setId(1L);
+    successor.setStartDate(LocalDate.of(2027, Month.JANUARY, 1));
+    successor.setEndDate(null);
+
+    when(districtVolumeRepository.findByConfigTypeAndAreaAndEndDateIsNullOrderByStartDateDesc(
+            ConfigType.DISTRICT_VOLUME, Area.INTERIOR))
+        .thenReturn(Collections.emptyList());
+
+    when(districtVolumeRepository.findFirstLiveAfter(
+            eq(ConfigType.DISTRICT_VOLUME),
+            eq(Area.INTERIOR),
+            eq(LocalDate.of(2027, Month.JANUARY, 15)),
+            any(PageRequest.class)))
+        .thenReturn(List.of(successor));
+
+    when(districtVolumeRepository.findFirstLiveBefore(
+            eq(ConfigType.DISTRICT_VOLUME),
+            eq(Area.INTERIOR),
+            eq(LocalDate.of(2027, Month.JANUARY, 15)),
+            any(PageRequest.class)))
+        .thenReturn(Collections.emptyList());
+
+    when(districtVolumeRepository.save(any(DistrictVolumeEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    DistrictVolumeDetailDto result = districtVolumeService.createDistrictVolume(
+        "TEST_USER", createDto);
+
+    assertThat(result.startDate()).isEqualTo(LocalDate.of(2027, Month.JANUARY, 15));
+    // successor starts Jan 1, so endDate = Dec 31, 2026
+    assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, Month.DECEMBER, 31));
+
+    // No predecessor to close — only the new entity is saved (with endDate != null)
+    verify(districtVolumeRepository, times(1)).save(any(DistrictVolumeEntity.class));
+  }
+
+  @Test
+  @DisplayName(
+      "createDistrictVolume — should create open-ended when no existing rows")
+  void createDistrictVolume_createsOpenEnded_whenNoExistingRows() {
+
+    InteriorDataDto interiorData = new InteriorDataDto(Collections.emptyList(), Collections.emptyMap());
+
+    DistrictVolumeCreateDto createDto = new DistrictVolumeCreateDto(
+        "INTERIOR",
+        LocalDate.of(2027, Month.JANUARY, 15),
+        new BigDecimal("1.200"),
+        null,
+        interiorData);
+
+    when(districtVolumeRepository.findByConfigTypeAndAreaAndEndDateIsNullOrderByStartDateDesc(
+            ConfigType.DISTRICT_VOLUME, Area.INTERIOR))
+        .thenReturn(Collections.emptyList());
+
+    when(districtVolumeRepository.save(any(DistrictVolumeEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    DistrictVolumeDetailDto result = districtVolumeService.createDistrictVolume(
+        "TEST_USER", createDto);
+
+    assertThat(result.startDate()).isEqualTo(LocalDate.of(2027, Month.JANUARY, 15));
+    assertThat(result.endDate()).isNull(); // Open-ended
   }
 
   @Test

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionServiceTest.java
@@ -848,4 +848,97 @@ class SpeciesCompositionServiceTest {
 
     verify(districtVolumeRepository, never()).save(any(DistrictVolumeEntity.class));
   }
+
+  @Test
+  @DisplayName(
+      "deleteSpeciesComposition — should throw 422 when record start date is not in the future")
+  void deleteSpeciesComposition_throws422_whenNotFutureStart() {
+
+    DistrictVolumeEntity entity = buildEntity(Area.INTERIOR);
+    entity.setStartDate(LocalDate.now().minusDays(1));
+    entity.setEndDate(null);
+
+    when(districtVolumeRepository.findByIdAndConfigType(1L, ConfigType.SPECIES_COMPOSITION))
+        .thenReturn(Optional.of(entity));
+
+    assertThatThrownBy(
+          () -> speciesCompositionService.deleteSpeciesComposition("TEST_USER", 1L))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Only future-start configurations can be deleted.");
+
+    verify(districtVolumeRepository, never()).save(any(DistrictVolumeEntity.class));
+  }
+
+  @Test
+  @DisplayName(
+      "deleteSpeciesComposition — should throw 422 when record start date is null")
+  void deleteSpeciesComposition_throws422_whenStartDateNull() {
+
+    DistrictVolumeEntity entity = buildEntity(Area.INTERIOR);
+    entity.setStartDate(null);
+    entity.setEndDate(null);
+
+    when(districtVolumeRepository.findByIdAndConfigType(1L, ConfigType.SPECIES_COMPOSITION))
+        .thenReturn(Optional.of(entity));
+
+    assertThatThrownBy(
+          () -> speciesCompositionService.deleteSpeciesComposition("TEST_USER", 1L))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Only future-start configurations can be deleted.");
+
+    verify(districtVolumeRepository, never()).save(any(DistrictVolumeEntity.class));
+  }
+
+  @Test
+  @DisplayName(
+      "deleteSpeciesComposition — should throw 422 when record is not open-ended")
+  void deleteSpeciesComposition_throws422_whenNotOpenEnded() {
+
+    DistrictVolumeEntity entity = buildEntity(Area.INTERIOR);
+    entity.setStartDate(LocalDate.now().plusYears(1));
+    entity.setEndDate(LocalDate.now().plusDays(10));
+
+    when(districtVolumeRepository.findByIdAndConfigType(1L, ConfigType.SPECIES_COMPOSITION))
+        .thenReturn(Optional.of(entity));
+
+    assertThatThrownBy(
+          () -> speciesCompositionService.deleteSpeciesComposition("TEST_USER", 1L))
+        .isInstanceOf(ResponseStatusException.class)
+        .hasMessageContaining("Only open-ended future configurations can be deleted.");
+
+    verify(districtVolumeRepository, never()).save(any(DistrictVolumeEntity.class));
+  }
+
+  @Test
+  @DisplayName(
+      "deleteSpeciesComposition — should reopen predecessor when deleting open-ended record")
+  void deleteSpeciesComposition_reopensPredecessor_whenOpenEndedDeleted() {
+
+    DistrictVolumeEntity entity = buildEntity(Area.INTERIOR);
+    entity.setId(2L);
+    entity.setStartDate(LocalDate.now().plusYears(1));
+    entity.setEndDate(null);
+
+    DistrictVolumeEntity predecessor = buildEntity(Area.INTERIOR);
+    predecessor.setId(1L);
+    predecessor.setStartDate(LocalDate.now().plusMonths(6));
+    predecessor.setEndDate(null);
+
+    when(districtVolumeRepository.findByIdAndConfigType(2L, ConfigType.SPECIES_COMPOSITION))
+        .thenReturn(Optional.of(entity));
+    when(districtVolumeRepository.findFirstLiveBefore(
+            eq(ConfigType.SPECIES_COMPOSITION),
+            eq(Area.INTERIOR),
+            eq(entity.getStartDate()),
+            any(PageRequest.class)))
+        .thenReturn(List.of(predecessor));
+    when(districtVolumeRepository.save(any(DistrictVolumeEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    speciesCompositionService.deleteSpeciesComposition("TEST_USER", 2L);
+
+    assertThat(entity.isDeleted()).isTrue();
+    verify(districtVolumeRepository).save(argThat(e ->
+        e.getId() == 1L && e.getEndDate() == null));
+  }
 }

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionServiceTest.java
@@ -662,9 +662,9 @@ class SpeciesCompositionServiceTest {
     verify(districtVolumeRepository).save(argThat(e ->
         e.getEndDate() != null && e.getEndDate().equals(LocalDate.of(2027, Month.JULY, 14))));
 
-    // Verify new entity was saved as open-ended (endDate = null)
+    // Verify new entity was saved with endDate = successor.startDate - 1 day = July 31
     verify(districtVolumeRepository).save(argThat(e ->
-        e.getEndDate() == null));
+        e.getEndDate() != null && e.getEndDate().equals(LocalDate.of(2027, Month.JULY, 31))));
   }
 
   @Test

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionServiceTest.java
@@ -609,6 +609,8 @@ class SpeciesCompositionServiceTest {
   void deleteSpeciesComposition_softDeletes_whenFound() {
 
     DistrictVolumeEntity entity = buildEntity(Area.INTERIOR);
+    entity.setStartDate(LocalDate.now().plusYears(1));
+    entity.setEndDate(null);
 
     when(districtVolumeRepository.findByIdAndConfigType(1L, ConfigType.SPECIES_COMPOSITION))
         .thenReturn(Optional.of(entity));

--- a/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionServiceTest.java
+++ b/backend/src/test/java/ca/bc/gov/nrs/hrs/service/SpeciesCompositionServiceTest.java
@@ -3,6 +3,8 @@ package ca.bc.gov.nrs.hrs.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -601,6 +603,197 @@ class SpeciesCompositionServiceTest {
         .isEqualTo(new BigDecimal("1.200"));
     assertThat(result.heliMultiplier())
         .isEqualTo(new BigDecimal("1.500"));
+  }
+
+  @Test
+  @DisplayName(
+      "createSpeciesComposition — should insert between existing rows and close predecessor, set endDate on new entity")
+  void createSpeciesComposition_insertsBetweenRows_setsEndDateOnNewAndClosesPredecessor() {
+
+    CoastDataDto coastData = new CoastDataDto(Collections.emptyList(), Collections.emptyMap());
+
+    DistrictVolumeCreateDto createDto = new DistrictVolumeCreateDto(
+        "COASTAL",
+        LocalDate.of(2027, Month.JULY, 15),
+        new BigDecimal("1.200"),
+        new BigDecimal("1.500"),
+        coastData);
+
+    // Successor: row starting Aug 1, 2027
+    DistrictVolumeEntity successor = buildEntity(Area.COASTAL);
+    successor.setId(2L);
+    successor.setStartDate(LocalDate.of(2027, Month.AUGUST, 1));
+    successor.setEndDate(null);
+
+    // Predecessor: row starting Jan 1, 2027
+    DistrictVolumeEntity predecessor = buildEntity(Area.COASTAL);
+    predecessor.setId(1L);
+    predecessor.setStartDate(LocalDate.of(2027, Month.JANUARY, 1));
+    predecessor.setEndDate(null);
+
+    when(districtVolumeRepository.findByConfigTypeAndAreaAndEndDateIsNullOrderByStartDateDesc(
+            ConfigType.SPECIES_COMPOSITION, Area.COASTAL))
+        .thenReturn(Collections.singletonList(predecessor));
+
+    when(districtVolumeRepository.findFirstLiveAfter(
+            eq(ConfigType.SPECIES_COMPOSITION),
+            eq(Area.COASTAL),
+            eq(LocalDate.of(2027, Month.JULY, 15)),
+            any(PageRequest.class)))
+        .thenReturn(List.of(successor));
+
+    when(districtVolumeRepository.findFirstLiveBefore(
+            eq(ConfigType.SPECIES_COMPOSITION),
+            eq(Area.COASTAL),
+            eq(LocalDate.of(2027, Month.JULY, 15)),
+            any(PageRequest.class)))
+        .thenReturn(List.of(predecessor));
+
+    when(districtVolumeRepository.save(any(DistrictVolumeEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    DistrictVolumeDetailDto result = speciesCompositionService.createSpeciesComposition(
+        "TEST_USER", createDto);
+
+    assertThat(result.startDate()).isEqualTo(LocalDate.of(2027, Month.JULY, 15));
+    assertThat(result.endDate()).isEqualTo(LocalDate.of(2027, Month.JULY, 31)); // successor start - 1 day
+
+    // Verify predecessor was closed
+    verify(districtVolumeRepository).save(argThat(e ->
+        e.getEndDate() != null && e.getEndDate().equals(LocalDate.of(2027, Month.JULY, 14))));
+
+    // Verify new entity was saved as open-ended (endDate = null)
+    verify(districtVolumeRepository).save(argThat(e ->
+        e.getEndDate() == null));
+  }
+
+  @Test
+  @DisplayName(
+      "createSpeciesComposition — should insert after all rows when no successor exists")
+  void createSpeciesComposition_insertsAfterAllRows_whenNoSuccessor() {
+
+    CoastDataDto coastData = new CoastDataDto(Collections.emptyList(), Collections.emptyMap());
+
+    DistrictVolumeCreateDto createDto = new DistrictVolumeCreateDto(
+        "COASTAL",
+        LocalDate.of(2027, Month.JULY, 15),
+        new BigDecimal("1.200"),
+        new BigDecimal("1.500"),
+        coastData);
+
+    // Open-ended predecessor
+    DistrictVolumeEntity predecessor = buildEntity(Area.COASTAL);
+    predecessor.setId(1L);
+    predecessor.setStartDate(LocalDate.of(2027, Month.JANUARY, 1));
+    predecessor.setEndDate(null);
+
+    when(districtVolumeRepository.findByConfigTypeAndAreaAndEndDateIsNullOrderByStartDateDesc(
+            ConfigType.SPECIES_COMPOSITION, Area.COASTAL))
+        .thenReturn(Collections.singletonList(predecessor));
+
+    when(districtVolumeRepository.findFirstLiveAfter(
+            eq(ConfigType.SPECIES_COMPOSITION),
+            eq(Area.COASTAL),
+            eq(LocalDate.of(2027, Month.JULY, 15)),
+            any(PageRequest.class)))
+        .thenReturn(Collections.emptyList());
+
+    when(districtVolumeRepository.save(any(DistrictVolumeEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    DistrictVolumeDetailDto result = speciesCompositionService.createSpeciesComposition(
+        "TEST_USER", createDto);
+
+    assertThat(result.startDate()).isEqualTo(LocalDate.of(2027, Month.JULY, 15));
+    assertThat(result.endDate()).isNull(); // No successor = open-ended
+
+    // Verify predecessor was closed
+    verify(districtVolumeRepository).save(argThat(e ->
+        e.getEndDate() != null && e.getEndDate().equals(LocalDate.of(2027, Month.JULY, 14))));
+
+    // Verify new entity was saved as open-ended (endDate = null)
+    verify(districtVolumeRepository).save(argThat(e ->
+        e.getEndDate() == null));
+  }
+
+  @Test
+  @DisplayName(
+      "createSpeciesComposition — should insert before all rows when no predecessor exists")
+  void createSpeciesComposition_insertsBeforeAllRows_whenNoPredecessor() {
+
+    CoastDataDto coastData = new CoastDataDto(Collections.emptyList(), Collections.emptyMap());
+
+    DistrictVolumeCreateDto createDto = new DistrictVolumeCreateDto(
+        "COASTAL",
+        LocalDate.of(2027, Month.JULY, 15),
+        new BigDecimal("1.200"),
+        new BigDecimal("1.500"),
+        coastData);
+
+    // Successor exists (starts Aug 1)
+    DistrictVolumeEntity successor = buildEntity(Area.COASTAL);
+    successor.setId(1L);
+    successor.setStartDate(LocalDate.of(2027, Month.AUGUST, 1));
+    successor.setEndDate(null);
+
+    when(districtVolumeRepository.findByConfigTypeAndAreaAndEndDateIsNullOrderByStartDateDesc(
+            ConfigType.SPECIES_COMPOSITION, Area.COASTAL))
+        .thenReturn(Collections.emptyList());
+
+    when(districtVolumeRepository.findFirstLiveAfter(
+            eq(ConfigType.SPECIES_COMPOSITION),
+            eq(Area.COASTAL),
+            eq(LocalDate.of(2027, Month.JULY, 15)),
+            any(PageRequest.class)))
+        .thenReturn(List.of(successor));
+
+    when(districtVolumeRepository.findFirstLiveBefore(
+            eq(ConfigType.SPECIES_COMPOSITION),
+            eq(Area.COASTAL),
+            eq(LocalDate.of(2027, Month.JULY, 15)),
+            any(PageRequest.class)))
+        .thenReturn(Collections.emptyList());
+
+    when(districtVolumeRepository.save(any(DistrictVolumeEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    DistrictVolumeDetailDto result = speciesCompositionService.createSpeciesComposition(
+        "TEST_USER", createDto);
+
+    assertThat(result.startDate()).isEqualTo(LocalDate.of(2027, Month.JULY, 15));
+    // successor starts Aug 1, so endDate = July 31
+    assertThat(result.endDate()).isEqualTo(LocalDate.of(2027, Month.JULY, 31));
+
+    // No predecessor to close - only the new entity is saved (with endDate != null)
+    verify(districtVolumeRepository, times(1)).save(any(DistrictVolumeEntity.class));
+  }
+
+  @Test
+  @DisplayName(
+      "createSpeciesComposition — should create open-ended when no existing rows")
+  void createSpeciesComposition_createsOpenEnded_whenNoExistingRows() {
+
+    CoastDataDto coastData = new CoastDataDto(Collections.emptyList(), Collections.emptyMap());
+
+    DistrictVolumeCreateDto createDto = new DistrictVolumeCreateDto(
+        "COASTAL",
+        LocalDate.of(2027, Month.JULY, 15),
+        new BigDecimal("1.200"),
+        new BigDecimal("1.500"),
+        coastData);
+
+    when(districtVolumeRepository.findByConfigTypeAndAreaAndEndDateIsNullOrderByStartDateDesc(
+            ConfigType.SPECIES_COMPOSITION, Area.COASTAL))
+        .thenReturn(Collections.emptyList());
+
+    when(districtVolumeRepository.save(any(DistrictVolumeEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    DistrictVolumeDetailDto result = speciesCompositionService.createSpeciesComposition(
+        "TEST_USER", createDto);
+
+    assertThat(result.startDate()).isEqualTo(LocalDate.of(2027, Month.JULY, 15));
+    assertThat(result.endDate()).isNull(); // Open-ended
   }
 
   @Test

--- a/frontend/src/components/waste/DistrictVolumeListTable/DistrictVolumeListTable.unit.test.tsx
+++ b/frontend/src/components/waste/DistrictVolumeListTable/DistrictVolumeListTable.unit.test.tsx
@@ -470,8 +470,8 @@ describe('DistrictVolumeListTable', () => {
       await renderWithAppAsync(<DistrictVolumeListTable />);
 
       await screen.findByTestId('district-volume-list');
-      screen.getByRole('button', { name: 'Delete district volume starting 2026-09-01' });
-      expect(screen.queryByText('Delete district volume starting 2025-01-01')).toBeNull();
+      // Delete button should be visible for future-dated rows
+      screen.getByRole('button', { name: 'Delete district average volume entry' });
     });
 
     it('does not render a Delete action for current or past rows', async () => {
@@ -485,7 +485,9 @@ describe('DistrictVolumeListTable', () => {
       await renderWithAppAsync(<DistrictVolumeListTable />);
 
       await screen.findByTestId('district-volume-list');
-      expect(screen.queryByText(/Delete district volume starting/)).toBeNull();
+      expect(
+        screen.queryByRole('button', { name: 'Delete district average volume entry' }),
+      ).toBeNull();
     });
   });
 
@@ -500,9 +502,9 @@ describe('DistrictVolumeListTable', () => {
       } as any);
       await renderWithAppAsync(<DistrictVolumeListTable />);
 
-      await screen.findByRole('button', { name: 'Delete district volume starting 2026-09-01' });
+      await screen.findByRole('button', { name: 'Delete district average volume entry' });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete district volume starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete district average volume entry' }),
       );
 
       expect(screen.getByTestId('delete-confirm-modal')).toBeTruthy();
@@ -526,9 +528,9 @@ describe('DistrictVolumeListTable', () => {
       } as any);
       await renderWithAppAsync(<DistrictVolumeListTable />);
 
-      await screen.findByRole('button', { name: 'Delete district volume starting 2026-09-01' });
+      await screen.findByRole('button', { name: 'Delete district average volume entry' });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete district volume starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete district average volume entry' }),
       );
       await userEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
 
@@ -551,9 +553,9 @@ describe('DistrictVolumeListTable', () => {
       } as any);
       await renderWithAppAsync(<DistrictVolumeListTable />);
 
-      await screen.findByRole('button', { name: 'Delete district volume starting 2026-09-01' });
+      await screen.findByRole('button', { name: 'Delete district average volume entry' });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete district volume starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete district average volume entry' }),
       );
 
       expect(
@@ -578,15 +580,15 @@ describe('DistrictVolumeListTable', () => {
       } as any);
       await renderWithAppAsync(<DistrictVolumeListTable />);
 
-      await screen.findByRole('button', { name: 'Delete district volume starting 2026-09-01' });
+      await screen.findByRole('button', { name: 'Delete district average volume entry' });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete district volume starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete district average volume entry' }),
       );
       await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
       expect(mutate).not.toHaveBeenCalled();
       expect(screen.queryByTestId('delete-confirm-modal')).toBeNull();
-      screen.getByRole('button', { name: 'Delete district volume starting 2026-09-01' });
+      screen.getByRole('button', { name: 'Delete district average volume entry' });
     });
 
     it('refreshes the list and shows a success toast after a successful delete', async () => {
@@ -605,9 +607,9 @@ describe('DistrictVolumeListTable', () => {
       } as any);
       await renderWithAppAsync(<DistrictVolumeListTable />);
 
-      await screen.findByRole('button', { name: 'Delete district volume starting 2026-09-01' });
+      await screen.findByRole('button', { name: 'Delete district average volume entry' });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete district volume starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete district average volume entry' }),
       );
       await userEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
 
@@ -640,13 +642,13 @@ describe('DistrictVolumeListTable', () => {
       } as any);
       await renderWithAppAsync(<DistrictVolumeListTable />);
 
-      await screen.findByRole('button', { name: 'Delete district volume starting 2026-09-01' });
+      await screen.findByRole('button', { name: 'Delete district average volume entry' });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete district volume starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete district average volume entry' }),
       );
       await userEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
 
-      screen.getByRole('button', { name: 'Delete district volume starting 2026-09-01' });
+      screen.getByRole('button', { name: 'Delete district average volume entry' });
       expect(sendToastEvent).not.toHaveBeenCalled();
     });
 
@@ -667,9 +669,9 @@ describe('DistrictVolumeListTable', () => {
       } as any);
       await renderWithAppAsync(<DistrictVolumeListTable />);
 
-      await screen.findByRole('button', { name: 'Delete district volume starting 2026-09-01' });
+      await screen.findByRole('button', { name: 'Delete district average volume entry' });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete district volume starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete district average volume entry' }),
       );
       // Close the modal so the confirm handler now closes over a cleared row.
       await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));

--- a/frontend/src/components/waste/DistrictVolumeListTable/actions.tsx
+++ b/frontend/src/components/waste/DistrictVolumeListTable/actions.tsx
@@ -25,5 +25,6 @@ export const useDistrictVolumeListRowActions = (
     routePath: '/configuration/district-volume-tables/{id}',
     onDeleteClick,
     getStartDate: (row) => row.startDate,
+    deleteActionLabel: 'district average volume entry',
   });
 };

--- a/frontend/src/components/waste/DistrictVolumeListTable/actions.unit.test.tsx
+++ b/frontend/src/components/waste/DistrictVolumeListTable/actions.unit.test.tsx
@@ -115,7 +115,7 @@ describe('useDistrictVolumeListRowActions', () => {
       const actions = result.current(row);
 
       expect(resolveTableRowActionValue(actions[1].label, row)).toBe(
-        'Delete district volume starting 2026-09-01',
+        'Delete district average volume entry',
       );
     });
 

--- a/frontend/src/components/waste/SpeciesCompositionListTable/actions.tsx
+++ b/frontend/src/components/waste/SpeciesCompositionListTable/actions.tsx
@@ -25,5 +25,6 @@ export const useSpeciesCompositionListRowActions = (
     routePath: '/configuration/species-composition/{id}',
     onDeleteClick,
     getStartDate: (row) => row.startDate,
+    deleteActionLabel: 'species composition entry',
   });
 };

--- a/frontend/src/components/waste/SpeciesCompositionListTable/actions.unit.test.tsx
+++ b/frontend/src/components/waste/SpeciesCompositionListTable/actions.unit.test.tsx
@@ -114,7 +114,7 @@ describe('useSpeciesCompositionListRowActions', () => {
       const actions = result.current(row);
 
       expect(resolveTableRowActionValue(actions[1].label, row)).toBe(
-        'Delete species composition starting 2026-09-01',
+        'Delete species composition entry',
       );
     });
 

--- a/frontend/src/components/waste/SpeciesCompositionListTable/index.unit.test.tsx
+++ b/frontend/src/components/waste/SpeciesCompositionListTable/index.unit.test.tsx
@@ -521,8 +521,10 @@ describe('SpeciesCompositionListTable', () => {
       await renderWithAppAsync(<SpeciesCompositionListTable />);
 
       await screen.findByTestId('species-composition-list');
-      screen.getByRole('button', { name: 'Delete species composition starting 2026-09-01' });
-      expect(screen.queryByText('Delete species composition starting 2025-01-01')).toBeNull();
+      // Delete button should be visible for future-dated rows
+      screen.getByRole('button', { name: 'Delete species composition entry' });
+      // The text should also be present
+      screen.getByText('Delete species composition entry');
     });
 
     it('does not render a Delete action for current or past rows', async () => {
@@ -536,7 +538,7 @@ describe('SpeciesCompositionListTable', () => {
       await renderWithAppAsync(<SpeciesCompositionListTable />);
 
       await screen.findByTestId('species-composition-list');
-      expect(screen.queryByText(/Delete species composition starting/)).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Delete species composition entry' })).toBeNull();
     });
   });
 
@@ -552,10 +554,10 @@ describe('SpeciesCompositionListTable', () => {
       await renderWithAppAsync(<SpeciesCompositionListTable />);
 
       await screen.findByRole('button', {
-        name: 'Delete species composition starting 2026-09-01',
+        name: 'Delete species composition entry',
       });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete species composition starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete species composition entry' }),
       );
 
       expect(screen.getByTestId('delete-confirm-modal')).toBeTruthy();
@@ -580,10 +582,10 @@ describe('SpeciesCompositionListTable', () => {
       await renderWithAppAsync(<SpeciesCompositionListTable />);
 
       await screen.findByRole('button', {
-        name: 'Delete species composition starting 2026-09-01',
+        name: 'Delete species composition entry',
       });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete species composition starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete species composition entry' }),
       );
       await userEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
 
@@ -607,10 +609,10 @@ describe('SpeciesCompositionListTable', () => {
       await renderWithAppAsync(<SpeciesCompositionListTable />);
 
       await screen.findByRole('button', {
-        name: 'Delete species composition starting 2026-09-01',
+        name: 'Delete species composition entry',
       });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete species composition starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete species composition entry' }),
       );
 
       expect(
@@ -636,16 +638,16 @@ describe('SpeciesCompositionListTable', () => {
       await renderWithAppAsync(<SpeciesCompositionListTable />);
 
       await screen.findByRole('button', {
-        name: 'Delete species composition starting 2026-09-01',
+        name: 'Delete species composition entry',
       });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete species composition starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete species composition entry' }),
       );
       await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
       expect(mutate).not.toHaveBeenCalled();
       expect(screen.queryByTestId('delete-confirm-modal')).toBeNull();
-      screen.getByRole('button', { name: 'Delete species composition starting 2026-09-01' });
+      screen.getByRole('button', { name: 'Delete species composition entry' });
     });
 
     it('refreshes the list and shows a success toast after a successful delete', async () => {
@@ -665,10 +667,10 @@ describe('SpeciesCompositionListTable', () => {
       await renderWithAppAsync(<SpeciesCompositionListTable />);
 
       await screen.findByRole('button', {
-        name: 'Delete species composition starting 2026-09-01',
+        name: 'Delete species composition entry',
       });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete species composition starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete species composition entry' }),
       );
       await userEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
 
@@ -702,14 +704,14 @@ describe('SpeciesCompositionListTable', () => {
       await renderWithAppAsync(<SpeciesCompositionListTable />);
 
       await screen.findByRole('button', {
-        name: 'Delete species composition starting 2026-09-01',
+        name: 'Delete species composition entry',
       });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete species composition starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete species composition entry' }),
       );
       await userEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
 
-      screen.getByRole('button', { name: 'Delete species composition starting 2026-09-01' });
+      screen.getByRole('button', { name: 'Delete species composition entry' });
       expect(sendToastEvent).not.toHaveBeenCalled();
     });
 
@@ -731,10 +733,10 @@ describe('SpeciesCompositionListTable', () => {
       await renderWithAppAsync(<SpeciesCompositionListTable />);
 
       await screen.findByRole('button', {
-        name: 'Delete species composition starting 2026-09-01',
+        name: 'Delete species composition entry',
       });
       await userEvent.click(
-        screen.getByRole('button', { name: 'Delete species composition starting 2026-09-01' }),
+        screen.getByRole('button', { name: 'Delete species composition entry' }),
       );
       // Close the modal so the confirm handler now closes over a cleared row.
       await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));

--- a/frontend/src/components/waste/useListTableRowActions.tsx
+++ b/frontend/src/components/waste/useListTableRowActions.tsx
@@ -21,7 +21,9 @@ interface UseListTableRowActionsConfig<TRow> {
  * Shared hook for list table row actions (view details, delete).
  * Eliminates duplication between DistrictVolumeListTable and SpeciesCompositionListTable.
  */
-export const useListTableRowActions = <TRow extends { id: string | number }>(
+export const useListTableRowActions = <
+  TRow extends { id: string | number; endDate?: string | null },
+>(
   config: UseListTableRowActionsConfig<TRow>,
 ) => {
   const navigate = useNavigate();
@@ -40,7 +42,7 @@ export const useListTableRowActions = <TRow extends { id: string | number }>(
         },
       ];
 
-      if (isFutureDated(config.getStartDate(row))) {
+      if (isFutureDated(config.getStartDate(row)) && !row.endDate) {
         actions.push({
           id: 'delete',
           label: (selectedRow) =>

--- a/frontend/src/components/waste/useListTableRowActions.tsx
+++ b/frontend/src/components/waste/useListTableRowActions.tsx
@@ -13,8 +13,10 @@ interface UseListTableRowActionsConfig<TRow> {
   routePath: string;
   /** Callback invoked when user clicks delete */
   onDeleteClick: (row: TRow) => void;
-  /** Function to get the start date from a row for the delete label */
+  /** Function to get the start date from a row for the delete guard */
   getStartDate: (row: TRow) => string;
+  /** Custom label for the delete action (e.g., "district average volume entry") */
+  deleteActionLabel: string;
 }
 
 /**
@@ -45,8 +47,7 @@ export const useListTableRowActions = <
       if (isFutureDated(config.getStartDate(row)) && !row.endDate) {
         actions.push({
           id: 'delete',
-          label: (selectedRow) =>
-            `Delete ${config.configType} starting ${config.getStartDate(selectedRow)}`,
+          label: `Delete ${config.deleteActionLabel}`,
           icon: <TrashCan />,
           onClick: (selectedRow) => {
             config.onDeleteClick(selectedRow);

--- a/frontend/src/config/react-query/hooks.unit.test.ts
+++ b/frontend/src/config/react-query/hooks.unit.test.ts
@@ -1310,4 +1310,208 @@ describe('react-query hooks', () => {
       expect(sendEvent).not.toHaveBeenCalled();
     });
   });
+
+  describe('useDistrictVolumeTableDeleteMutation', () => {
+    it('should call deleteDistrictVolume with the id on mutate', async () => {
+      const { result } = renderHook(() => useDistrictVolumeTableDeleteMutation(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await result.current.mutateAsync(42);
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(API.districtVolume.deleteDistrictVolume).toHaveBeenCalledWith(42);
+    });
+
+    it('should invoke onSuccess callback after delete completes', async () => {
+      const onSuccessMock = vi.fn();
+      const { result } = renderHook(
+        () => useDistrictVolumeTableDeleteMutation({ onSuccess: onSuccessMock }),
+        { wrapper: createWrapper() },
+      );
+
+      await act(async () => {
+        await result.current.mutateAsync(42);
+      });
+
+      expect(onSuccessMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle mutation errors without throwing', async () => {
+      const mockError = new Error('Delete failed');
+      vi.mocked(API.districtVolume.deleteDistrictVolume).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useDistrictVolumeTableDeleteMutation(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        try {
+          await result.current.mutateAsync(42);
+        } catch (_e) {
+          // Error is expected and caught
+        }
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+
+    it('should support notificationTarget for problem-detail errors', async () => {
+      const mockError = new Error('Delete failed');
+      (mockError as unknown as { body: { detail: string; title: string } }).body = {
+        detail: 'Entry is not future-dated',
+        title: 'Unprocessable Entity',
+      };
+      vi.mocked(API.districtVolume.deleteDistrictVolume).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(
+        () =>
+          useDistrictVolumeTableDeleteMutation({
+            notificationTarget: 'district-volume-list',
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await act(async () => {
+        try {
+          await result.current.mutateAsync(42);
+        } catch (_e) {
+          // expected
+        }
+      });
+
+      await waitFor(() => expect(sendEvent).toHaveBeenCalled());
+      expect(sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'error',
+          eventTarget: 'district-volume-list',
+          description: 'Entry is not future-dated',
+        }),
+      );
+    });
+
+    it('should not dispatch notification when notificationTarget is omitted', async () => {
+      const mockError = new Error('Delete failed');
+      vi.mocked(API.districtVolume.deleteDistrictVolume).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useDistrictVolumeTableDeleteMutation(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        try {
+          await result.current.mutateAsync(42);
+        } catch (_e) {
+          // expected
+        }
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(sendEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useSpeciesCompositionDeleteMutation', () => {
+    it('should call deleteSpeciesComposition with the id on mutate', async () => {
+      const { result } = renderHook(() => useSpeciesCompositionDeleteMutation(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await result.current.mutateAsync(42);
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(API.speciesComposition.deleteSpeciesComposition).toHaveBeenCalledWith(42);
+    });
+
+    it('should invoke onSuccess callback after delete completes', async () => {
+      const onSuccessMock = vi.fn();
+      const { result } = renderHook(
+        () => useSpeciesCompositionDeleteMutation({ onSuccess: onSuccessMock }),
+        { wrapper: createWrapper() },
+      );
+
+      await act(async () => {
+        await result.current.mutateAsync(42);
+      });
+
+      expect(onSuccessMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle mutation errors without throwing', async () => {
+      const mockError = new Error('Delete failed');
+      vi.mocked(API.speciesComposition.deleteSpeciesComposition).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useSpeciesCompositionDeleteMutation(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        try {
+          await result.current.mutateAsync(42);
+        } catch (_e) {
+          // Error is expected and caught
+        }
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+
+    it('should support notificationTarget for problem-detail errors', async () => {
+      const mockError = new Error('Delete failed');
+      (mockError as unknown as { body: { detail: string; title: string } }).body = {
+        detail: 'Entry is not future-dated',
+        title: 'Unprocessable Entity',
+      };
+      vi.mocked(API.speciesComposition.deleteSpeciesComposition).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(
+        () =>
+          useSpeciesCompositionDeleteMutation({
+            notificationTarget: 'species-composition-list',
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await act(async () => {
+        try {
+          await result.current.mutateAsync(42);
+        } catch (_e) {
+          // expected
+        }
+      });
+
+      await waitFor(() => expect(sendEvent).toHaveBeenCalled());
+      expect(sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'error',
+          eventTarget: 'species-composition-list',
+          description: 'Entry is not future-dated',
+        }),
+      );
+    });
+
+    it('should not dispatch notification when notificationTarget is omitted', async () => {
+      const mockError = new Error('Delete failed');
+      vi.mocked(API.speciesComposition.deleteSpeciesComposition).mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useSpeciesCompositionDeleteMutation(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        try {
+          await result.current.mutateAsync(42);
+        } catch (_e) {
+          // expected
+        }
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(sendEvent).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/config/react-query/hooks.unit.test.ts
+++ b/frontend/src/config/react-query/hooks.unit.test.ts
@@ -9,6 +9,7 @@ import {
   useDistrictOptionsQuery,
   useDistrictVolumeListQuery,
   useDistrictVolumeTableCreateMutation,
+  useDistrictVolumeTableDeleteMutation,
   useForestClientsByNumbersQuery,
   useMyForestClientsQuery,
   useReportingUnitCreateMutation,
@@ -19,6 +20,7 @@ import {
   useSpeciesCompositionListQuery,
   useSpeciesCompositionDetailQuery,
   useSpeciesCompositionCreateMutation,
+  useSpeciesCompositionDeleteMutation,
 } from './hooks';
 import { queryKeys } from './queryKeys';
 
@@ -73,6 +75,7 @@ vi.mock('@/services/APIs', () => ({
         zones: [],
       }),
       createDistrictVolumeTable: vi.fn().mockResolvedValue(444),
+      deleteDistrictVolume: vi.fn().mockResolvedValue(undefined),
     },
     speciesComposition: {
       listSpeciesCompositions: vi.fn().mockResolvedValue({
@@ -96,6 +99,7 @@ vi.mock('@/services/APIs', () => ({
         tableData: { rows: [] },
       }),
       createSpeciesComposition: vi.fn().mockResolvedValue(555),
+      deleteSpeciesComposition: vi.fn().mockResolvedValue(undefined),
     },
   },
 }));

--- a/frontend/src/config/react-query/queryKeys.unit.test.ts
+++ b/frontend/src/config/react-query/queryKeys.unit.test.ts
@@ -146,6 +146,10 @@ describe('queryKeys', () => {
     it('should build detail key', () => {
       expect(queryKeys.districtVolume.detail(42)).toEqual(['district-volume', 'detail', 42]);
     });
+
+    it('should build delete key', () => {
+      expect(queryKeys.districtVolume.delete(42)).toEqual(['district-volume', 'delete', 42]);
+    });
   });
 
   describe('speciesComposition', () => {
@@ -169,6 +173,14 @@ describe('queryKeys', () => {
       expect(queryKeys.speciesComposition.detail(42)).toEqual([
         'species-composition',
         'detail',
+        42,
+      ]);
+    });
+
+    it('should build delete key', () => {
+      expect(queryKeys.speciesComposition.delete(42)).toEqual([
+        'species-composition',
+        'delete',
         42,
       ]);
     });


### PR DESCRIPTION
## Summary

Implements the core fix for Issue #1183: allows inserting configuration rows **between** existing rows (not just closing open-ended rows).

### Changes

**Backend:**
- **Interval-aware insertion** in `DistrictVolumeService.createDistrictVolume()` and `SpeciesCompositionService.createSpeciesComposition()`:
  - Detects successor row via `findFirstLiveAfter()` with `Pageable`
  - Detects predecessor row via `findFirstLiveBefore()` with `Pageable`
  - Sets new entity's `endDate = successor.startDate - 1 day` (or null if no successor)
  - Closes predecessor: `previousEntry.setEndDate(createDto.startDate() - 1 day)`

- **Hardened delete** in both services (`@Transactional(SERIALIZABLE)`):
  - 422 UNPROCESSABLE_CONTENT if not future-start: "Only future-start configurations can be deleted."
  - 422 UNPROCESSABLE_CONTENT if not open-ended: "Only open-ended future configurations can be deleted."
  - Reopens predecessor: `predecessor.setEndDate(entity.getEndDate())` (null → open-ended)

- **Controllers**: Added `@DeleteMapping("/{id}")` returning 204 on both controllers; added `@PageableDefault(sort="startDate", direction=DESC)` on GET lists

- **Repository**: `findFirstLiveAfter`/`findFirstLiveBefore` now accept `Pageable` parameter

- **GlobalExceptionHandler**: Added `IncorrectResultSizeDataAccessException` handler → 500 "Data Consistency Error" ProblemDetail

**Frontend:**
- Shared hook `useListTableRowActions.tsx`: delete guard now checks `isFutureDated(startDate) && !row.endDate` (matches backend rule: only open-ended future rows)
- Tests: added delete mutation tests in `hooks.unit.test.ts` and delete key tests in `queryKeys.unit.test.ts`

**Tests:**
- Updated service delete tests to use future start dates
- All 280 backend unit tests pass
- Checkstyle clean on all edited files

### Related
- Supersedes PR #1188 (which carried duplicate stack commits from PRs 1193/1194/1195/1198)
- Depends on: main already has Java 21 downgrade (PR 1193), audit framework (PR 1194), carbon footer fix (PR 1195)

Closes #1183

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-3-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)