### PR TITLE
fix(ci): install actions github for sbom submission

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           # Use official dependency-submission-toolkit directly (fixes evryfs action bug: .values() on array,
           # avoids deprecated node16 runtime). Handles both array and .components forms of metadata.tools.
-          npm install --global @github/dependency-submission-toolkit@1.2.7 @cyclonedx/cyclonedx-library@1.8.0
+          npm install --global @actions/github@7.0.2 @github/dependency-submission-toolkit@1.2.7 @cyclonedx/cyclonedx-library@1.8.0
           node --input-type=module << 'NODE_EOF'
           import fs from 'fs';
           import path from 'path';
@@ -315,7 +315,18 @@ jobs:
   # ==========================================================================
   results:
     name: Analysis Results
-    needs: [tests-java, tests-frontend, tests-frontend-ex, trivy, cve-lite, npm-audit, sbom-node, sbom-java, sbom-submit]
+    needs:
+      [
+        tests-java,
+        tests-frontend,
+        tests-frontend-ex,
+        trivy,
+        cve-lite,
+        npm-audit,
+        sbom-node,
+        sbom-java,
+        sbom-submit,
+      ]
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 1

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -316,17 +316,15 @@ jobs:
   results:
     name: Analysis Results
     needs:
-      [
-        tests-java,
-        tests-frontend,
-        tests-frontend-ex,
-        trivy,
-        cve-lite,
-        npm-audit,
-        sbom-node,
-        sbom-java,
-        sbom-submit,
-      ]
+      - tests-java
+      - tests-frontend
+      - tests-frontend-ex
+      - trivy
+      - cve-lite
+      - npm-audit
+      - sbom-node
+      - sbom-java
+      - sbom-submit
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Adds the missing `@actions/github` runtime dependency to the SBOM submission step in `.github/workflows/analysis.yml`.

This fixes the `ERR_MODULE_NOT_FOUND` failure from [GitHub Actions run 32392000619](https://github.com/bcgov/nr-waste-plus/actions/runs/32392000619), which caused the aggregate `Analysis Results` job to fail on `main`.

Dependency changes: pins `@actions/github` to `7.0.2` in the workflow install command.

Fixes #1206

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

- [x] No new tests are required
- [x] Manual tests (description below)

Validation performed:
- Parsed `.github/workflows/analysis.yml` successfully with Ruby YAML parser.
- Verified the imported `@actions/github` package matches the package installed by the workflow.
- Ran `git diff --check`.
- `actionlint` could not be run because the requested npm package did not expose an executable.

The GitHub Actions workflow will provide the final verification by running `sbom-submit` and `Analysis Results`.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Feature-Flag Controlled Changes (Required if applicable)

- [x] Not applicable: no feature-flag-controlled behavior changed in this PR

## Further comments

This is a one-file CI-only change. The `results.needs` formatting is unchanged semantically; the workflow formatter expanded the existing list while editing.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-7-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)