### PR TITLE
fix(cypress): improve CI deployment reliability

### DIFF
--- a/.github/workflows/.automated-tests.yml
+++ b/.github/workflows/.automated-tests.yml
@@ -23,15 +23,6 @@ jobs:
         with:
           node-version: 24
 
-      - name: Cache cypress node_modules
-        uses: actions/cache@v6
-        with:
-          path: cypress/node_modules
-          key: cypress-node_modules-b3v1-${{ hashFiles('cypress/package-lock.json') }}
-          restore-keys: |
-            cypress-node_modules-b3v1-
-            cypress-node_modules-
-
       - name: Cache Cypress binary
         uses: actions/cache@v6
         with:
@@ -40,13 +31,36 @@ jobs:
           restore-keys: |
             cypress-binary-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Install cypress dependencies
+      - name: Install Cypress dependencies
         working-directory: cypress
-        run: npm install --prefer-offline --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
 
       - name: Install Cypress binary
         working-directory: cypress
         run: npx cypress install
+
+      - name: Wait for frontend deployment
+        env:
+          FRONTEND_URL: https://${{ inputs.url }}
+        run: |
+          set -euo pipefail
+
+          max_attempts=30
+          for attempt in $(seq 1 "${max_attempts}"); do
+            if response=$(curl --fail --silent --show-error --location --max-time 10 "$FRONTEND_URL/"); then
+              if [[ "$response" == *'id="root"'* ]]; then
+                echo "Frontend is ready on attempt ${attempt}."
+                exit 0
+              fi
+                echo "Frontend responded without the application root on attempt ${attempt}."
+            else
+              echo "Frontend readiness check failed on attempt ${attempt}."
+            fi
+            sleep 10
+          done
+
+          echo "Frontend did not become ready after ${max_attempts} attempts: ${FRONTEND_URL}"
+          exit 1
 
       - name: Run Cypress End-to-End
         uses: cypress-io/github-action@v7.4.2
@@ -56,7 +70,7 @@ jobs:
           install: false
         env:
           CYPRESS_baseUrl: https://${{ inputs.url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}          
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_idir_password: ${{ secrets.IDIR_UAT_PASSWORD }}
           CYPRESS_idir_username: ${{ secrets.IDIR_UAT_USERNAME }}
           MOCHAWESOME_REPORT: true
@@ -72,7 +86,7 @@ jobs:
       - name: Add summary to GitHub Action
         working-directory: cypress
         if: always()
-        run: cat summary.md >> $GITHUB_STEP_SUMMARY
+        run: cat summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Persist Cypress RunResult and flaky summary
         if: always()
@@ -90,20 +104,20 @@ jobs:
         run: |
           if [ -d "cypress/cypress/screenshots" ] && [ "$(ls -A cypress/cypress/screenshots)" ]; then
             echo "Screenshots folder is not empty, uploading artifacts."
-            echo "screenshots=true" >> $GITHUB_OUTPUT
+            echo "screenshots=true" >> "$GITHUB_OUTPUT"
 
           else
             echo "Screenshots folder is empty or does not exist."
-            echo "screenshots=false" >> $GITHUB_OUTPUT
+            echo "screenshots=false" >> "$GITHUB_OUTPUT"
           fi
 
           if [ -d "cypress/cypress/videos" ] && [ "$(ls -A cypress/cypress/videos)" ]; then
             echo "Videos folder is not empty, uploading artifacts."
-            echo "videos=true" >> $GITHUB_OUTPUT
+            echo "videos=true" >> "$GITHUB_OUTPUT"
 
           else
             echo "Videos folder is empty or does not exist."
-            echo "videos=false" >> $GITHUB_OUTPUT
+            echo "videos=false" >> "$GITHUB_OUTPUT"
           fi
         id: check_artifacts
 

--- a/cypress/cypress/support/e2e.ts
+++ b/cypress/cypress/support/e2e.ts
@@ -1,30 +1,129 @@
-import './commands'
-import '@testing-library/cypress/add-commands';
-import 'cypress-axe';
-import 'cypress-real-events';
+import "./commands";
+import "@testing-library/cypress/add-commands";
+import "cypress-axe";
+import "cypress-real-events";
 
-Cypress.on('window:before:load', (win) => {
-  // Listen to browser console logs and pass them to the Cypress console
+type PageDiagnostic = {
+  kind: string;
+  message: string;
+};
+
+let currentPage: Window | undefined;
+let pageDiagnostics: PageDiagnostic[] = [];
+
+const stringify = (value: unknown): string => {
+  try {
+    return typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const recordDiagnostic = (kind: string, message: string) => {
+  pageDiagnostics.push({ kind, message });
+};
+
+const getPageState = () => {
+  if (!currentPage) {
+    return { url: "unavailable" };
+  }
+
+  const navigation = currentPage.performance.getEntriesByType(
+    "navigation",
+  )[0] as PerformanceNavigationTiming | undefined;
+
+  return {
+    url: currentPage.location.href,
+    readyState: currentPage.document.readyState,
+    title: currentPage.document.title,
+    bodyTextLength: currentPage.document.body?.innerText.length ?? 0,
+    bodyHtml: currentPage.document.body?.innerHTML.slice(0, 2000) ?? "",
+    resourceCount: currentPage.performance.getEntriesByType("resource").length,
+    navigation: navigation
+      ? {
+          domContentLoaded: navigation.domContentLoadedEventEnd,
+          loadEventEnd: navigation.loadEventEnd,
+          responseEnd: navigation.responseEnd,
+          transferSize: navigation.transferSize,
+        }
+      : undefined,
+  };
+};
+
+Cypress.on("window:before:load", (win) => {
+  currentPage = win;
+  pageDiagnostics = [];
+
+  // Preserve browser console output and retain warnings/errors for failure diagnostics.
   const originalConsoleLog = win.console.log;
+  const originalConsoleWarn = win.console.warn;
+  const originalConsoleError = win.console.error;
+
   win.console.log = (...args) => {
     originalConsoleLog(...args);
-    // Pass logs to Cypress terminal
     Cypress.log({
-      name: 'console.log',
-      message: [...args],
+      name: "console.log",
+      message: args.map(stringify),
     });
   };
+
+  win.console.warn = (...args) => {
+    originalConsoleWarn(...args);
+    recordDiagnostic("console.warn", args.map(stringify).join(" "));
+  };
+
+  win.console.error = (...args) => {
+    originalConsoleError(...args);
+    recordDiagnostic("console.error", args.map(stringify).join(" "));
+  };
+
+  win.addEventListener("error", (event) => {
+    recordDiagnostic("window.error", event.message || "Unknown browser error");
+  });
+
+  win.addEventListener("unhandledrejection", (event) => {
+    recordDiagnostic("unhandledrejection", stringify(event.reason));
+  });
 });
 
-Cypress.on('uncaught:exception', (err, runnable) => {
-  console.log(err);
+beforeEach(() => {
+  cy.intercept({ url: "**", middleware: true }, (request) => {
+    request.on("response", (response) => {
+      if (response.statusCode >= 400) {
+        recordDiagnostic(
+          "http",
+          `${response.statusCode} ${request.method} ${request.url}`,
+        );
+      }
+    });
+
+    request.continue();
+  });
+});
+
+Cypress.on("uncaught:exception", (err, runnable) => {
+  recordDiagnostic("uncaught:exception", err.message);
+  console.error(`[uncaught:exception] ${err.message}`);
 
   // Only ignore known, non-breaking third-party errors.
   // Adjust the condition below to match specific benign errors in your app.
-  if (err?.message?.includes('ResizeObserver')) {
+  if (err?.message?.includes("ResizeObserver")) {
     return false;
   }
 
   // Let all other errors fail the test so real regressions are not hidden.
   return true;
-})
+});
+
+Cypress.on("fail", (error) => {
+  console.error(
+    "[Cypress failure diagnostics]",
+    JSON.stringify({
+      error: error.message,
+      pageState: getPageState(),
+      diagnostics: pageDiagnostics,
+    }),
+  );
+
+  throw error;
+});

--- a/cypress/cypress/support/step_definitions/steps/common.steps.ts
+++ b/cypress/cypress/support/step_definitions/steps/common.steps.ts
@@ -1,34 +1,29 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
 
-Given('I visit {string}', (url: string) => {
-  // The app is a Vite SPA: page content renders only after @tanstack/react-query fetches
-  // resolve. We deliberately do NOT guess/intercept specific API paths here (they drift and
-  // cause spurious waits). Instead the content assertions in text.steps (`I can read`) poll for
-  // the rendered text with a 30s ceiling — they resolve the instant the data appears, so the
-  // wait is content-driven and fast, not a blind fixed delay.
-  cy.visit(url).then(() => {
-    cy.window().then((win) => {
-      return new Cypress.Promise((resolve) => {
-        if (win.document.readyState === 'complete') {
-          resolve();
-        } else {
-          win.addEventListener('load', resolve);
-        }
-      });
-    });
-  });
+Given("I visit {string}", (url: string) => {
+  // Content assertions remain responsible for waiting on React Query rendering. Cypress
+  // already waits for the document load event, so adding a second load listener here cannot
+  // help when the document itself fails to load.
+  cy.visit(url);
 });
 
-Given('the reporting unit API for {string} returns no grade', (reportingUnitId: string) => {
-  cy.intercept('GET', `**/api/reporting-units/${reportingUnitId}`, (request) => {
-    request.continue((response) => {
-      if (typeof response.body !== 'object' || response.body === null) {
-        return;
-      }
+Given(
+  "the reporting unit API for {string} returns no grade",
+  (reportingUnitId: string) => {
+    cy.intercept(
+      "GET",
+      `**/api/reporting-units/${reportingUnitId}`,
+      (request) => {
+        request.continue((response) => {
+          if (typeof response.body !== "object" || response.body === null) {
+            return;
+          }
 
-      const body = response.body as Record<string, unknown>;
-      body.grade = { code: null, description: null, areas: [] };
-      response.body = body;
-    });
-  });
-});
+          const body = response.body as Record<string, unknown>;
+          body.grade = { code: null, description: null, areas: [] };
+          response.body = body;
+        });
+      },
+    );
+  },
+);

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -73,8 +73,8 @@
     "brace-expansion@>=2.0.0 <2.1.4": "2.1.4"
   },
   "allowScripts": {
-    "cypress@15.18.0": true,
-    "esbuild@0.28.1": true,
+    "cypress@15.20.1": true,
+    "esbuild@0.28.2": true,
     "fsevents@2.3.3": true
   }
 }


### PR DESCRIPTION
## Summary

- use `npm ci` for deterministic Cypress dependencies
- wait for the deployed frontend root before starting Cypress
- capture browser, HTTP, DOM, and navigation diagnostics on failures
- remove redundant post-`cy.visit()` load handling

## Validation

- TypeScript check passed
- Cypress verification passed
- Prettier check passed
- actionlint passed
- local untagged root smoke test passed

Authenticated scenarios were not fully validated locally because the external IDP flow failed in the local environment. CI has the required credentials.

---

Thanks for the PR!

Deployments, as required, will be available below:
Any successful deployments (not always required) will be available [here](https://nr-waste-plus-8-frontend.apps.silver.devops.gov.bc.ca/)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-waste-plus/actions/workflows/merge.yml)